### PR TITLE
Added a config option to not store IP addresses in the Trackable module

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{devise}
-  s.version = "1.2.0"
+  s.version = "1.2.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jos\303\251 Valim", "Carlos Ant\303\264nio"]

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -196,6 +196,10 @@ module Devise
   @@warden_config = nil
   @@warden_config_block = nil
 
+  # Should the trackable module store ip addresses in the database?
+  mattr_accessor :trackable_stores_ip_addresses
+  @@trackable_stores_ip_addresses = true
+
   # Default way to setup Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -16,7 +16,11 @@ module Devise
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
+        old_current, new_current = if Devise.trackable_stores_ip_addresses
+          [ self.current_sign_in_ip, request.remote_ip ]
+        else
+          [ nil, nil ]
+        end
         self.last_sign_in_ip     = old_current || new_current
         self.current_sign_in_ip  = new_current
 

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -103,6 +103,10 @@ Devise.setup do |config|
   # Defines name of the authentication token params key
   # config.token_authentication_key = :auth_token
 
+  # ==> Configuration for :trackable
+  # Should the trackable module store ip addresses in the database?
+  # config.trackable_stores_ip_addresses = true
+
   # ==> Scopes configuration
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -25,6 +25,10 @@ class TrackableHooksTest < ActionController::IntegrationTest
     assert user.current_sign_in_at > user.last_sign_in_at
   end
 
+  test "trackable stores ip addresses by default" do
+    assert_equal true, Devise.trackable_stores_ip_addresses
+  end
+
   test "current and last sign in remote ip are updated on each sign in" do
     user = create_user
     assert_nil user.current_sign_in_ip
@@ -35,6 +39,18 @@ class TrackableHooksTest < ActionController::IntegrationTest
 
     assert_equal "127.0.0.1", user.current_sign_in_ip
     assert_equal "127.0.0.1", user.last_sign_in_ip
+  end
+
+  test "current and last sign in remote ip are zeros if trackable is configured to ignore ip addrs" do
+    Devise.trackable_stores_ip_addresses = false
+    user = create_user
+    sign_in_as_user
+    user.reload
+
+    assert_nil user.current_sign_in_ip
+    assert_nil user.last_sign_in_ip
+
+    Devise.trackable_stores_ip_addresses = true
   end
 
   test "increase sign in count" do


### PR DESCRIPTION
Hi there,

Today we added a configuration option so that Trackable module will not store IP addresses. Our client requested this specifically, because the product's privacy policy states that IP addresses will not be stored in the database. This legally makes privacy a bit safer ... because if we don't store IP addresses at all, then hackers can't steal them, nor can governments subpoena us for records that we don't have.

We'd love it if you could merge the small change back into Devise. 

Thanks,
Nate @ Pivotal Labs
Jack @ CreationMix
