### PR TITLE
Forgetable deletes cookie

### DIFF
--- a/lib/devise/hooks/forgetable.rb
+++ b/lib/devise/hooks/forgetable.rb
@@ -5,7 +5,7 @@
 Warden::Manager.before_logout do |record, warden, options|
   if record.respond_to?(:forget_me!)
     record.forget_me! unless record.frozen?
-    options = options.merge(record.cookie_domain? ? { :domain => record.cookie_domain } : {})
-    warden.cookies.delete("remember_#{options[:scope]}_token", options)
+    cookie_options = record.cookie_domain? ? { :domain => record.cookie_domain } : {}
+    warden.cookies.delete("remember_#{options[:scope]}_token", cookie_options)
   end
 end

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -131,6 +131,7 @@ class RememberMeTest < ActionController::IntegrationTest
     get destroy_user_session_path
     assert_not warden.authenticated?(:user)
     assert_nil user.reload.remember_token
+    assert_nil warden.cookies['remember_user_token']
   end
 
   test 'do not remember the user anymore after forget' do
@@ -140,5 +141,6 @@ class RememberMeTest < ActionController::IntegrationTest
     get destroy_user_session_path
     get users_path
     assert_not warden.authenticated?(:user)
+    assert_nil warden.cookies['remember_user_token']
   end
 end


### PR DESCRIPTION
I'm on rails 3.0.0 and devise 1.1.2

I tried using "rememerable" and wasn't able to get logout to work, similar to the comments over at http://groups.google.com/group/plataformatec-devise/browse_thread/thread/15ef86a140701a51/cc3b47132b6dbc0e?lnk=raot. I'm very new to the devise framework, but one of my traces led me to the forgetable hook. See the commit for details. I don't know how the remember_me cookie would ever get deleted with the current code. Let me know if this not the issue and I'll keep hunting, or if the fix should be made in a different manner and I can make the change on my end and issue another pull request. Thanks
