### PR TITLE
Change password view labels should be more descriptive

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,10 +4,10 @@
   <%= devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
 
-  <p><%= f.label :password %><br />
+  <p><%= f.label :password, "New password" %><br />
   <%= f.password_field :password %></p>
 
-  <p><%= f.label :password_confirmation %><br />
+  <p><%= f.label :password_confirmation, "Confirm new password" %><br />
   <%= f.password_field :password_confirmation %></p>
 
   <p><%= f.submit "Change my password" %></p>


### PR DESCRIPTION
Just had a friend who said it was silly that he needed to enter his password in order to be able to change it. I thought about it and then I added a better text description to the labels so users understand what they need to enter to reset their password.
