### PR TITLE
email_field helpers

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.submit "Resend confirmation instructions" %></p>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.submit "Send me reset password instructions" %></p>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
   <%= f.password_field :password %></p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.label :password %><br />
   <%= f.password_field :password %></p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f| %>
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.label :password %><br />
   <%= f.password_field :password %></p>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -4,7 +4,7 @@
   <%= devise_error_messages! %>
 
   <p><%= f.label :email %><br />
-  <%= f.text_field :email %></p>
+  <%= f.email_field :email %></p>
 
   <p><%= f.submit "Resend unlock instructions" %></p>
 <% end %>


### PR DESCRIPTION
Hi,

i changed to devise templates to use email_field helper instead of text_field helper for the email field.
since devise is targeted to rails 3 this is very helpful for applications running on ios devices.
