### PR TITLE
Mixing Timeoutable and Rememberable

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -22,9 +22,19 @@ module Devise
 
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
+        return false if remember_exists_and_not_expired?
+        
         last_access && last_access <= self.class.timeout_in.ago
       end
-
+      
+      private
+      
+      def remember_exists_and_not_expired?
+        return false unless respond_to?(:remember_expired?)
+        
+        remember_created_at && !remember_expired?
+      end
+      
       module ClassMethods
         Devise::Models.config(self, :timeout_in)
       end

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -76,5 +76,14 @@ class SessionTimeoutTest < ActionController::IntegrationTest
       assert_contain 'Session expired!'
     end
   end
-
+  
+  test 'time out not triggered if remembered' do
+    user = sign_in_as_user :remember_me => true
+    get expire_user_path(user)
+    assert_not_nil last_request_at
+    
+    get users_path
+    assert_response :success
+    assert warden.authenticated?(:user)
+  end
 end


### PR DESCRIPTION
Maybe this isn't how Devise _should_ work - but it's how I needed it to work, so perhaps this patch is useful. All it does is makes sure #timedout? returns false if the resource is being remembered (and within the remembered window).

Let me know if I'm going about this the wrong way :)
