### PR TITLE
Have rememberable set the time that it was used to authenticate the user

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -54,6 +54,7 @@ module Devise
       def remember_me!(extend_period=false)
         self.remember_token = self.class.remember_token if respond_to?(:remember_token) && generate_remember_token?
         self.remember_created_at = Time.now.utc if generate_remember_timestamp?(extend_period)
+        self.remembered_at = Time.now.utc
         save(:validate => false)
       end
 

--- a/lib/devise/schema.rb
+++ b/lib/devise/schema.rb
@@ -50,6 +50,7 @@ module Devise
       use_salt = options.fetch(:use_salt, Devise.use_salt_as_remember_token)
       apply_devise_schema :remember_token,      String unless use_salt
       apply_devise_schema :remember_created_at, DateTime
+      apply_devise_schema :remembered_at, DateTime
     end
 
     # Creates sign_in_count, current_sign_in_at, last_sign_in_at,


### PR DESCRIPTION
current_sign_in_at is only useful if the person goes through the sign in process and using the updated_at field won't work since the user model might be updated by some other process.

This patch adds remembered_at to the migration and sets the field when logging in via the cookie.

I've tried it on my application and it seems to be working as expected.
