### PR TITLE
Allow trackable to work without storing IP addrs in the database

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{devise}
-  s.version = "1.2.rc"
+  s.version = "1.2.rc.cm1"
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jos\303\251 Valim", "Carlos Ant\303\264nio"]

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -16,9 +16,11 @@ module Devise
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
-        self.last_sign_in_ip     = old_current || new_current
-        self.current_sign_in_ip  = new_current
+        if respond_to?(:current_sign_in_ip) && respond_to?(:last_sign_in_ip)
+          old_current, new_current = self.current_sign_in_ip, request.remote_ip
+          self.last_sign_in_ip     = old_current || new_current
+          self.current_sign_in_ip  = new_current
+        end
 
         self.sign_in_count ||= 0
         self.sign_in_count += 1


### PR DESCRIPTION
This is a silent change that allows trackable to work without storing any IP addresses in the database.

As per your rejection of the last pull request we now check for the presence of the fields before writing them.

There is no documentation or configuration option associated with this feature.
