### PR TITLE
signed in status for user

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,8 @@
+== 1.1.3.1
+
+* enhancements
+  * Added signed_in attribute for trackable user to be able to check if a specific user signed in or out
+
 * deprecations
   * cookie_domain is deprecated in favor of cookie_options
   * after_update_path_for can no longer be defined in ApplicationController

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -11,12 +11,14 @@ class Devise::SessionsController < ApplicationController
   # POST /resource/sign_in
   def create
     resource = warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")
+    current_user.update_attribute(:signed_in => true) if record.respond_to?(signed_in?)
     set_flash_message :notice, :signed_in
     sign_in_and_redirect(resource_name, resource)
   end
 
   # GET /resource/sign_out
   def destroy
+    current_user.update_attribute(:signed_in => false) if record.respond_to?(signed_in?)
     signed_in = signed_in?(resource_name)
     sign_out_and_redirect(resource_name)
     set_flash_message :notice, :signed_out if signed_in

--- a/lib/devise/schema.rb
+++ b/lib/devise/schema.rb
@@ -55,6 +55,7 @@ module Devise
     # Creates sign_in_count, current_sign_in_at, last_sign_in_at,
     # current_sign_in_ip, last_sign_in_ip.
     def trackable
+      apply_devise_schema :signed_in,          Boolean, :default => false
       apply_devise_schema :sign_in_count,      Integer, :default => 0
       apply_devise_schema :current_sign_in_at, DateTime
       apply_devise_schema :last_sign_in_at,    DateTime

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -2,6 +2,19 @@ require 'test_helper'
 
 class TrackableHooksTest < ActionController::IntegrationTest
 
+  test "signed_in status is updated after user signed in or signed out" do
+    user = create_user
+    assert_false user.signed_in
+
+    sign_in_as_user
+    user.reload
+    assert_true user.signed_in
+
+    visit destroy_user_session_path
+    user.reload
+    assert_false user.signed_in
+  end
+
   test "current and last sign in timestamps are updated on each sign in" do
     user = create_user
     assert_nil user.current_sign_in_at

--- a/test/rails_app/db/schema.rb
+++ b/test/rails_app/db/schema.rb
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(:version => 20100401102949) do
     t.datetime "confirmation_sent_at"
     t.string   "reset_password_token"
     t.datetime "remember_created_at"
+    t.boolean  "signed_in"                            :default => false
     t.integer  "sign_in_count",                       :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"


### PR DESCRIPTION
We had a need to check if a specific user is currently signed_in or not.
We find it would be convenient if a devise "trackable" user could provide this feature.
I hope this patch is done right.

Regards.
Nicolas
