### PR TITLE
Empty flash[] messages suppressed

### DIFF
--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -102,7 +102,8 @@ module Devise
         options[:scope] = "devise.#{controller_name}"
         options[:default] = Array(options[:default]).unshift(kind.to_sym)
         options[:resource_name] = resource_name
-        flash[key] = I18n.t("#{resource_name}.#{kind}", options)
+        message = I18n.t("#{resource_name}.#{kind}", options)
+        flash[key] = message.blank? ? nil : message
       end
 
       def clean_up_passwords(object) #:nodoc:

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -53,4 +53,20 @@ class HelpersTest < ActionController::TestCase
   test 'is a devise controller' do
     assert @controller.devise_controller?
   end
+  
+  test 'does not issue blank flash messages' do
+    MyController.send(:public, :set_flash_message)
+    I18n.stubs(:t).returns('   ')
+    @controller.set_flash_message :notice, :send_instructions
+    assert flash[:notice].nil?
+    MyController.send(:protected, :set_flash_message)
+  end
+  
+  test 'issues non-blank flash messages normally' do
+    MyController.send(:public, :set_flash_message)
+    I18n.stubs(:t).returns('non-blank')
+    @controller.set_flash_message :notice, :send_instructions
+    assert flash[:notice] == 'non-blank'
+    MyController.send(:protected, :set_flash_message)
+  end
 end


### PR DESCRIPTION
A user on SO was noting that flash messages were being issued no matter what. He was advised to customize the messages to an empty string in the YAML file, but then empty flash messages were issued. This fixes that so that if the message is customized to be empty (nil or spaces) flash[key] will be set to nil. Tests in place.
