### PR TITLE
#646 - change default configuration text for config_within

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -50,7 +50,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :confirmable
   # The time you want to give your user to confirm his account. During this time
-  # he will be able to access your application without confirming. Default is nil.
+  # he will be able to access your application without confirming. Default is 0.days
   # When confirm_within is zero, the user won't be able to sign in without confirming.
   # You can use this to let your user access some features of your application
   # without confirming the account, but blocking it after a certain period


### PR DESCRIPTION
Modify the configuration text that is output for confirm_within so that it matches the actual default value.  If you use nil as a value, it crashes trying to call nil.ago
