### PR TITLE
Fix for long tokens in HTTP Basic Auth

### DIFF
--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -97,7 +97,7 @@ module Devise
       # Helper to decode credentials from HTTP.
       def decode_credentials
         return [] unless request.authorization && request.authorization =~ /^Basic (.*)/
-        ActiveSupport::Base64.decode64($1).split(/:/, 2)
+        ActiveSupport::Base64.decode64(request.authorization.split(' ', 2).last).split(/:/, 2)
       end
 
       # Sets the authentication hash and the password from params_auth_hash or http_auth_hash.

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -47,6 +47,16 @@ class HttpAuthenticationTest < ActionController::IntegrationTest
     end
   end
 
+  test 'sign in should authenticate with really long token' do
+    token = "token_containing_so_many_characters_that_the_base64_encoding_will_wrap"
+    user = create_user
+    user.update_attribute :authentication_token, token
+    get users_path(:format => :xml), {}, "HTTP_AUTHORIZATION" => "Basic #{ActiveSupport::Base64.encode64("#{token}:x")}"
+    assert_response :success
+    assert_match "<email>user@test.com</email>", response.body
+    assert warden.authenticated?(:user)
+  end
+  
   private
 
     def sign_in_as_new_user_with_http(username="user@test.com", password="123456")


### PR DESCRIPTION
I noticed a bug when testing authentication using the generated authentication_token in an API call using HTTP Basic Auth (that is, passing the token as the username and 'x' as the password). I've added a test case that demonstrates the bug and also applied the fix to http_authenticatable.rb.
