### PR TITLE
Redirecting to the last visited page upon successful logging in

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -55,6 +55,10 @@ module Devise
 
         ActiveSupport.on_load(:action_controller) do
           helper_method "current_#{mapping}", "#{mapping}_signed_in?", "#{mapping}_session"
+
+          after_filter :unless => :devise_controller? do
+            session["#{mapping}_return_to"] = request.path
+          end
         end
       end
 
@@ -75,7 +79,7 @@ module Devise
       # Return true if the given scope is signed in session. If no scope given, return
       # true if any scope is signed in. Does not run authentication hooks.
       def signed_in?(scope=nil)
-        [ scope || Devise.mappings.keys ].flatten.any? do |scope| 
+        [ scope || Devise.mappings.keys ].flatten.any? do |scope|
           warden.authenticate?(:scope => scope)
         end
       end
@@ -100,7 +104,7 @@ module Devise
       #   sign_in @user                             # sign_in(resource)
       #   sign_in @user, :event => :authentication  # sign_in(resource, options)
       #   sign_in @user, :bypass => true            # sign_in(resource, options)
-      # 
+      #
       def sign_in(resource_or_scope, *args)
         options  = args.extract_options!
         scope    = Devise::Mapping.find_scope!(resource_or_scope)

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -168,7 +168,7 @@ class AuthenticationRedirectTest < ActionController::IntegrationTest
   test 'redirect to default url if no other was configured' do
     sign_in_as_user
     assert_template 'home/index'
-    assert_nil session[:"user_return_to"]
+    assert_equal root_path, session[:"user_return_to"]
   end
 
   test 'redirect to requested url after sign in' do
@@ -177,10 +177,11 @@ class AuthenticationRedirectTest < ActionController::IntegrationTest
     assert_equal users_path, session[:"user_return_to"]
 
     follow_redirect!
-    sign_in_as_user :visit => false
+    get root_path
+    sign_in_as_user
 
-    assert_current_url '/users'
-    assert_nil session[:"user_return_to"]
+    assert_current_url root_path
+    assert_equal root_path, session[:"user_return_to"]
   end
 
   test 'redirect to last requested url overwriting the stored return_to option' do
@@ -196,7 +197,7 @@ class AuthenticationRedirectTest < ActionController::IntegrationTest
     sign_in_as_user :visit => false
 
     assert_current_url '/users'
-    assert_nil session[:"user_return_to"]
+    assert_equal users_path, session[:"user_return_to"]
   end
 
   test 'xml http requests does not store urls for redirect' do


### PR DESCRIPTION
Hmm, I might be missing something here but Devise has never properly redirected me to the last visited page upon logging in.

Upon further inspection I noticed that the `#{scope}_return_to` session variable is only being used for FailureApp, therefore rendering `stored_location_for(scope)` useless.

This patch adds an after_filter to the action controller to capture request path to `#{scope}_return_to`.
