### PR TITLE
Add support for non-navigational format response to SessionsController

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -2,6 +2,8 @@ class Devise::SessionsController < ApplicationController
   prepend_before_filter :require_no_authentication, :only => [ :new, :create ]
   include Devise::Controllers::InternalHelpers
 
+  respond_to :html, :xml, :json
+
   # GET /resource/sign_in
   def new
     clean_up_passwords(build_resource)
@@ -11,8 +13,9 @@ class Devise::SessionsController < ApplicationController
   # POST /resource/sign_in
   def create
     resource = warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")
-    set_flash_message :notice, :signed_in
-    sign_in_and_redirect(resource_name, resource)
+    set_flash_message(:notice, :signed_in) if is_navigational_format?
+    sign_in(resource_name, resource)
+    respond_with resource, :location => redirect_location(resource_name, resource)
   end
 
   # GET /resource/sign_out

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -206,7 +206,11 @@ module Devise
       end
 
       def redirect_for_sign_in(scope, resource) #:nodoc:
-        redirect_to stored_location_for(scope) || after_sign_in_path_for(resource)
+        redirect_to redirect_location(scope, resource)
+      end
+
+      def redirect_location(scope, resource) #:nodoc:
+        stored_location_for(scope) || after_sign_in_path_for(resource)
       end
 
       # Sign out an user and tries to redirect to the url specified by

--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -60,6 +60,11 @@ module Devise
         unknown_action!("Could not find devise mapping for path #{request.fullpath.inspect}") unless devise_mapping
       end
 
+      # Check whether it's navigational format, such as :html or :iphone, or not.
+      def is_navigational_format?
+        Devise.navigational_formats.include?(request.format.to_sym)
+      end
+
       def unknown_action!(msg)
         logger.debug "[Devise] #{msg}" if logger
         raise ActionController::UnknownAction, msg

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -17,7 +17,7 @@ class ControllerAuthenticableTest < ActionController::TestCase
     @mock_warden.expects(:authenticate?).with(:scope => :my_scope)
     @controller.signed_in?(:my_scope)
   end
-  
+
   test 'proxy signed_in?(nil) to authenticate?' do
     Devise.mappings.keys.each do |scope| # :user, :admin, :manager
       @mock_warden.expects(:authenticate?).with(:scope => scope)
@@ -199,6 +199,17 @@ class ControllerAuthenticableTest < ActionController::TestCase
     @mock_warden.expects(:set_user).never
     @controller.expects(:redirect_to).with(admin_root_path)
     @controller.sign_in_and_redirect(admin)
+  end
+
+  test 'redirect_location returns the stored location if set' do
+    user = User.new
+    @controller.session[:"user_return_to"] = "/foo.bar"
+    assert_equal '/foo.bar', @controller.redirect_location('user', user)
+  end
+
+  test 'redirect_location returns the after sign in path by default' do
+    user = User.new
+    assert_equal @controller.after_sign_in_path_for(:user), @controller.redirect_location('user', user)
   end
 
   test 'sign out and redirect uses the configured after sign out path when signing out only the current scope' do

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -205,6 +205,13 @@ class AuthenticationRedirectTest < ActionController::IntegrationTest
     assert_nil session[:"user_return_to"]
   end
 
+  test 'sign in with xml format returns xml response' do
+    create_user
+    post user_session_path(:format => 'xml', :user => {:email => "user@test.com", :password => '123456'})
+    assert_response :success
+    assert_match /<\?xml version="1.0" encoding="UTF-8"\?>/, response.body
+  end
+
   test 'redirect to configured home path for a given scope after sign in' do
     sign_in_as_admin
     assert_equal "/admin_area/home", @request.path


### PR DESCRIPTION
Hi,

I've patched Devise to return the authenticated object in case of JSON/XML POST request to `Devise::Sessions` controller, as I would like to make Devise supports AJAX sign in. Please review my patch and give me the feed back for it.

Thank you
