### PR TITLE
Fixes bug with namespacing of devise with omni-auth

### DIFF
--- a/lib/devise/omniauth/url_helpers.rb
+++ b/lib/devise/omniauth/url_helpers.rb
@@ -7,7 +7,7 @@ module Devise
         class_eval <<-URL_HELPERS, __FILE__, __LINE__ + 1
           def #{mapping.name}_omniauth_authorize_path(provider, params = {})
             if Devise.omniauth_configs[provider.to_sym]
-              "/#{mapping.path}/auth/\#{provider}\#{'?'+params.to_param if params.present?}"
+              "#{mapping.fullpath}/auth/\#{provider}\#{'?'+params.to_param if params.present?}"
             else
               raise ArgumentError, "Could not find omniauth provider \#{provider.inspect}"
             end

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -264,7 +264,7 @@ module ActionDispatch::Routing
       end
 
       def devise_omniauth_callback(mapping, controllers) #:nodoc:
-        path_prefix = "/#{mapping.path}/auth"
+        path_prefix = "#{mapping.fullpath}/auth"
 
         if ::OmniAuth.config.path_prefix && ::OmniAuth.config.path_prefix != path_prefix
           warn "[DEVISE] You can only add :omniauthable behavior to one model."


### PR DESCRIPTION
When namespacing a devise with omni-auth the callback url would be pointed to the path without the path_prefix. This commit fixes it

I wanted to add some tests to prevent regression, but the omniauth was defined on the main devise_for which isn't namespaced, and I was afraid of breaking all tests.
