### PR TITLE
Allow users to change model attributes (except password) without inputting current password

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -55,6 +55,11 @@ module Devise
   mattr_accessor :cookie_options
   @@cookie_options = {}
 
+  # Is the user's current password required to change all attributes on the model,
+  # or just when changing the user's password?
+  mattr_accessor :require_current_password_for_all_changes
+  @@require_current_password_for_all_changes = true
+
   # The number of times to encrypt password.
   mattr_accessor :stretches
   @@stretches = 10

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -77,7 +77,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :authentication_keys, :request_keys, :case_insensitive_keys, :http_authenticatable, :params_authenticatable)
+        Devise::Models.config(self, :authentication_keys, :request_keys, :case_insensitive_keys, :http_authenticatable, :params_authenticatable, :require_current_password_for_all_changes)
 
         def params_authenticatable?(strategy)
           params_authenticatable.is_a?(Array) ?

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -54,6 +54,10 @@ module Devise
 
         result = if valid_password?(current_password)
           update_attributes(params)
+        elsif !self.class.require_current_password_for_all_changes && params[:password].blank?
+          params.delete(:password)
+          params.delete(:password_confirmation)
+          update_attributes(params)
         else
           self.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
           self.attributes = params

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -48,6 +48,11 @@ Devise.setup do |config|
   # The realm used in Http Basic Authentication. "Application" by default.
   # config.http_authentication_realm = "Application"
 
+  # If false, the signed-in user only needs to supply their current password when
+  # attempting to change their password, as opposed requiring it when changing other
+  # attributes on the model (the default).
+  # config.require_current_password_for_all_changes = false
+
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -43,6 +43,11 @@ Devise.setup do |config|
   # The realm used in Http Basic Authentication. "Application" by default.
   # config.http_authentication_realm = "Application"
 
+  # If false, the signed-in user only needs to supply their current password when
+  # attempting to change their password, as opposed requiring it when changing other
+  # attributes on the model (the default).
+  # config.require_current_password_for_all_changes = false
+
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.


### PR DESCRIPTION
Hey Jose,

I think this one is fairly self-explanatory. This is a change requested by some of my users, and I think it's a config option that is appropriate to be in core, and should (arguably) be the default. IMO, I shouldn't require my current password to change attributes other than my password.

If you don't agree, I'd love to hear any alternative implementations you might be able to suggest. Thanks for your time!
