### PR TITLE
Wrong signature for user_omniauth_authorize_path methods on test helper

### DIFF
--- a/lib/devise/omniauth/test_helpers.rb
+++ b/lib/devise/omniauth/test_helpers.rb
@@ -40,8 +40,8 @@ module Devise
           next unless m.omniauthable?
 
           module_eval <<-ALIASES, __FILE__, __LINE__ + 1
-            def #{m.name}_omniauth_authorize_path(provider)
-              #{m.name}_omniauth_callback_path(provider)
+            def #{m.name}_omniauth_authorize_path(provider, params = {})
+              #{m.name}_omniauth_callback_path(provider, params)
             end
           ALIASES
         end


### PR DESCRIPTION
Calling `Devise::OmniAuth.short_circuit_authorizers!` overrides the `user_omniauth_authorize_path` method (and similar methods like `admin_omniauth_authorize_path`). 

The problem is that it changes the number of expected parameters: Originally, the method is declared on `lib/devise/omniauth/url_helpers.rb` as
    def #{mapping.name}_omniauth_authorize_path(provider, params = {})

but the overridden version declares it as
    def #{m.name}_omniauth_authorize_path(provider)

This was leading to an exception being raised after calling `Devise::OmniAuth.short_circuit_authorizers!`:

```
ruby-1.9.2-p0 > controller.user_omniauth_authorize_path(:facebook, :return_to => "/")
 => "/usuarios/auth/facebook?return_to=%2F" 
ruby-1.9.2-p0 > Devise::OmniAuth.test_mode!
 => ActionView::Base 
ruby-1.9.2-p0 > Devise::OmniAuth.short_circuit_authorizers!
 => {:user=>#<Devise::Mapping:0x00000102883cb0 @scoped_path="users", @singular=:user, @class_name="User", @ref=#<ActiveSupport::Dependencies::Reference:0x0000010287d748 @name="User">, @path="usuarios", @path_prefix=nil, @controllers={:omniauth_callbacks=>"users/omniauth_callbacks", :sessions=>"devise/sessions", :passwords=>"devise/passwords", :registrations=>"devise/registrations"}, @path_names={:registration=>"registro", :new=>"new", :edit=>"edit", :sign_in=>"entrar", :sign_out=>"salir", :sign_up=>"crear", :cancel=>"cancelar", :password=>"password"}, @sign_out_via=:get, @modules=[:database_authenticatable, :rememberable, :omniauthable, :recoverable, :registerable, :validatable, :trackable], @routes=[:session, :omniauth_callback, :password, :registration], @strategies=[:rememberable, :database_authenticatable]>} 
ruby-1.9.2-p0 > controller.user_omniauth_authorize_path(:facebook, :return_to => "/")
ArgumentError: wrong number of arguments (2 for 1)
    from /Users/wack-a-mole/Rails/devise/lib/devise/omniauth/test_helpers.rb:43:in `user_omniauth_authorize_path'
    from (irb):4
    from /Users/wack-a-mole/.rvm/gems/ruby-1.9.2-p0/gems/railties-3.0.3/lib/rails/commands/console.rb:44:in `start'
    from /Users/wack-a-mole/.rvm/gems/ruby-1.9.2-p0/gems/railties-3.0.3/lib/rails/commands/console.rb:8:in `start'
    from /Users/wack-a-mole/.rvm/gems/ruby-1.9.2-p0/gems/railties-3.0.3/lib/rails/commands.rb:23:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```

This pull request fixes that. All Devise tests pass after applying this patch (except one which also fails before applying the patch).
