### PR TITLE
ajax login on firefox with confirmable/activable enabled

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -64,7 +64,12 @@ module Devise
     end
 
     def redirect_url
-      send(:"new_#{scope}_session_path")
+      request_format = request.format.to_sym
+      if request_format == :html
+        send(:"new_#{scope}_session_path")
+      else
+        send(:"new_#{scope}_session_path", :format => request_format)
+      end
     end
 
     # Choose whether we should respond in a http authentication fashion,

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -69,6 +69,13 @@ class FailureTest < ActiveSupport::TestCase
         assert_equal 302, @response.first
       end
     end
+    
+    test 'redirects the correct format if it is a non-html format request' do
+      swap Devise, :navigational_formats => [:js] do
+        call_failure('formats' => :js)
+        assert_equal 'http://test.host/users/sign_in.js', @response.second["Location"]
+      end
+    end
   end
 
   context 'For HTTP request' do
@@ -120,7 +127,7 @@ class FailureTest < ActiveSupport::TestCase
           swap Devise, :http_authenticatable_on_xhr => false do
             call_failure('formats' => :json, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest')
             assert_equal 302, @response.first
-            assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
+            assert_equal 'http://test.host/users/sign_in.json', @response.second["Location"]
           end
         end
       end


### PR DESCRIPTION
failure_app redirects to the correct format if it is a non-html request. This is to ensure that firefox redirects the correct format since firefox doesn't inherit accept info. also fix issue 675 that is resurrected by issue 754.

refers:
issue 754: https://github.com/plataformatec/devise/issues/issue/754 and issue 675: https://github.com/plataformatec/devise/issues/issue/675
