### PR TITLE
Bugfix for accessing registration edit page while not logged in

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -107,7 +107,7 @@ class Devise::RegistrationsController < ApplicationController
       send(:"authenticate_#{resource_name}!")
       current_resource_meth = :"current_#{resource_name}"
       respond_to?(current_resource_meth) ?
-        return self.resource = resource_class.to_adapter.get!(send(current_resource_meth)).to_key :
+        (self.resource = resource_class.to_adapter.get!(send(current_resource_meth)).to_key) :
         nil
     end
 end


### PR DESCRIPTION
Hi, I noticed that there was an error generated when accessing RegistrationsController#edit, basically it was trying to call a method that wasn't there. I included a check for the current_#{resource_name} method, and had it return nil if it doesn't exist.

Does this make sense?
