### PR TITLE
Support for non-standard omniauth strategy names like CAS or LDAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rails", "~> 3.0.0"
 gem "oa-oauth", :require => "omniauth/oauth"
 gem "oa-openid", :require => "omniauth/openid"
+gem "oa-enterprise", :require => "omniauth/enterprise"
 
 group :test do
   gem "webrat", "0.7.2", :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,11 +73,18 @@ GEM
       will_paginate (~> 3.0.pre)
     multi_json (0.0.5)
     multipart-post (1.0.1)
+    net-ldap (0.1.1)
     nokogiri (1.4.3.1)
     nokogiri (1.4.3.1-java)
       weakling (>= 0.0.3)
     oa-core (0.1.6)
       rack (~> 1.1)
+    oa-enterprise (0.1.6)
+      net-ldap (~> 0.1.1)
+      nokogiri (~> 1.4.2)
+      oa-core (= 0.1.6)
+      pyu-ruby-sasl (~> 0.0.3.1)
+      rubyntlm (~> 0.1.1)
     oa-oauth (0.1.6)
       multi_json (~> 0.0.2)
       nokogiri (~> 1.4.2)
@@ -94,6 +101,7 @@ GEM
       multi_json (~> 0.0.4)
     orm_adapter (0.0.3)
     polyglot (0.3.1)
+    pyu-ruby-sasl (0.0.3.2)
     rack (1.2.1)
     rack-mount (0.6.13)
       rack (>= 1.0.0)
@@ -124,6 +132,7 @@ GEM
     ruby-openid (2.1.8)
     ruby-openid-apps-discovery (1.2.0)
       ruby-openid (>= 2.1.7)
+    rubyntlm (0.1.1)
     sqlite3-ruby (1.3.2)
     thor (0.14.6)
     treetop (1.4.9)
@@ -150,6 +159,7 @@ DEPENDENCIES
   mocha
   mongo (= 1.1.2)
   mongoid (= 2.0.0.beta.20)
+  oa-enterprise
   oa-oauth
   oa-openid
   orm_adapter (~> 0.0.3)

--- a/lib/devise/omniauth/config.rb
+++ b/lib/devise/omniauth/config.rb
@@ -11,7 +11,10 @@ module Devise
       end
 
       def strategy_class
-        ::OmniAuth::Strategies.const_get("#{::OmniAuth::Utils.camelize(@provider.to_s)}")
+        name = ::OmniAuth::Utils.camelize(@provider.to_s)
+        ::OmniAuth::Strategies.const_get(name)
+      rescue NameError
+        ::OmniAuth::Strategies.const_get(name.upcase)
       end
 
       def check_if_allow_stubs!

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -159,6 +159,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   config.omniauth :facebook, 'APP_ID', 'APP_SECRET', :scope => 'email,offline_access'
   config.omniauth :open_id
+  config.omniauth :cas, :cas_server => "https://localhost:4443"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
Enterprise strategies like CAS and LDAP use upcased strategy names. Devise OmniAuth integration had problems using them. This patch fixes it.
