### PR TITLE
Fix redirects for javascript (ajax) requests on authentication failures.

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -47,7 +47,11 @@ module Devise
     def redirect
       store_location!
       flash[:alert] = i18n_message
-      redirect_to redirect_url
+      if (request.format.to_sym == :js)
+        self.response_body = "window.location='#{redirect_url}';"
+      else
+        redirect_to redirect_url
+      end
     end
 
   protected


### PR DESCRIPTION
As indicated in this thread:
http://groups.google.com/group/plataformatec-devise/browse_thread/thread/30553801dc60076a

When using  jquery + :remote => true links in combination with Devise and timeoutable the user can get a basic authentication request when clicking a remote link after the session has expired.

Fixable by setting:
  config.navigational_formats = [:html, :js]

and the above fix in the code.

While handling an unauthorized javascript request the user will be redirected via the window.location code.
