### PR TITLE
Miscellaneous improvements

### DIFF
--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -47,9 +47,9 @@ module Devise
     def devise(*modules)
       include Devise::Models::Authenticatable
       options = modules.extract_options!
-      self.devise_modules += modules.map(&:to_sym).uniq.sort do |s1, s2|
-        Devise::ALL.index(s1) <=> Devise::ALL.index(s2) # follow Devise::ALL order
-      end
+      self.devise_modules += modules.map(&:to_sym).uniq.sort_by { |s|
+        Devise::ALL.index(s) || -1  # follow Devise::ALL order
+      }
 
       devise_modules_hook! do
         devise_modules.each { |m| include Devise::Models.const_get(m.to_s.classify) }

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -49,7 +49,8 @@ class ActiveRecordTest < ActiveSupport::TestCase
 
   test 'raise error on invalid module' do
     assert_raise NameError do
-      Configurable.class_eval { devise :doesnotexist }
+      # Mix valid an invalid modules.
+      Configurable.class_eval { devise :database_authenticatable, :doesnotexit }
     end
   end
 


### PR DESCRIPTION
0a09a55 Do not silently ignore invalid modules passed to devise method in model.
9985930 Generate add_index for :authentication_token (used by :token_authenticatable).

I think the add_index line for :authentication_token makes sense, since we're using the authentication_token column to look up users, but please review to be sure.
