### PR TITLE
email_required? wraps all email validations

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -22,10 +22,12 @@ module Devise
         assert_validations_api!(base)
 
         base.class_eval do
-          validates_presence_of   :email, :if => :email_required?
-          validates_uniqueness_of :email, :scope => authentication_keys[1..-1],
-            :case_sensitive => case_insensitive_keys.exclude?(:email), :allow_blank => true
-          validates_format_of     :email, :with  => email_regexp, :allow_blank => true
+          with_options :if => :email_required? do |v|
+            v.validates_presence_of   :email
+            v.validates_uniqueness_of :email, :scope => authentication_keys[1..-1],
+              :case_sensitive => case_insensitive_keys.exclude?(:email), :allow_blank => true
+            v.validates_format_of     :email, :with  => email_regexp, :allow_blank => true
+          end
 
           with_options :if => :password_required? do |v|
             v.validates_presence_of     :password


### PR DESCRIPTION
It is really convenient to disable password validations from my User model by redefining password_required?.  However, this doesn't work for email validations.  validates_presence_of :email has a :if => :password_required?, but validates_uniqueness_of and validates_format_of don't, so they can still fail, even if email_required? has been redefined.

This change wraps all of the email validations in a with_options block just like the password validations.
