### PR TITLE
HTTP authenticatable needs authentication keys to be set.

### DIFF
--- a/lib/devise/models/http_authenticatable.rb
+++ b/lib/devise/models/http_authenticatable.rb
@@ -3,14 +3,16 @@ require 'devise/strategies/http_authenticatable'
 module Devise
   module Models
     # Adds HttpAuthenticatable behavior to your model. It expects that your
-    # model class responds to authenticate and authentication_keys methods
-    # (which for example are defined in authenticatable).
+    # model class responds to authenticate method
+    # (which for example is defined in authenticatable).
     module HttpAuthenticatable
       def self.included(base)
         base.extend ClassMethods
       end
 
       module ClassMethods
+        Devise::Models.config(self, :authentication_keys)
+
         # Authenticate an user using http.
         def authenticate_with_http(username, password)
           authenticate(authentication_keys.first => username, :password => password)


### PR DESCRIPTION
For branch 1.0.

In case you only need http authenticatable without database authenticatable you have to define an authentication_keys method in your model (as explained in documentation too).

Why not add it to config for this module?
