### PR TITLE
Use flash[:success] messages in some proper actions

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -24,7 +24,7 @@ class Devise::ConfirmationsController < ApplicationController
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
     if resource.errors.empty?
-      set_flash_message :notice, :confirmed
+      set_flash_message :success, :confirmed
       sign_in_and_redirect(resource_name, resource)
     else
       render_with_scope :new

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -32,7 +32,7 @@ class Devise::PasswordsController < ApplicationController
     self.resource = resource_class.reset_password_by_token(params[resource_name])
 
     if resource.errors.empty?
-      set_flash_message :notice, :updated
+      set_flash_message :success, :updated
       sign_in_and_redirect(resource_name, resource)
     else
       render_with_scope :edit

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -15,7 +15,7 @@ class Devise::RegistrationsController < ApplicationController
 
     if resource.save
       if resource.active?
-        set_flash_message :notice, :signed_up
+        set_flash_message :success, :signed_up
         sign_in_and_redirect(resource_name, resource)
       else
         set_flash_message :notice, :inactive_signed_up, :reason => resource.inactive_message.to_s
@@ -36,7 +36,7 @@ class Devise::RegistrationsController < ApplicationController
   # PUT /resource
   def update
     if resource.update_with_password(params[resource_name])
-      set_flash_message :notice, :updated
+      set_flash_message :success, :updated
       sign_in resource_name, resource, :bypass => true
       redirect_to after_update_path_for(resource)
     else

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -11,7 +11,7 @@ class Devise::SessionsController < ApplicationController
   # POST /resource/sign_in
   def create
     resource = warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")
-    set_flash_message(:notice, :signed_in) if is_navigational_format?
+    set_flash_message(:success, :signed_in) if is_navigational_format?
     sign_in(resource_name, resource)
     respond_with resource, :location => redirect_location(resource_name, resource)
   end
@@ -20,6 +20,6 @@ class Devise::SessionsController < ApplicationController
   def destroy
     signed_in = signed_in?(resource_name)
     sign_out_and_redirect(resource_name)
-    set_flash_message :notice, :signed_out if signed_in
+    set_flash_message :success, :signed_out if signed_in
   end
 end

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -25,7 +25,7 @@ class Devise::UnlocksController < ApplicationController
     self.resource = resource_class.unlock_access_by_token(params[:unlock_token])
 
     if resource.errors.empty?
-      set_flash_message :notice, :unlocked
+      set_flash_message :success, :unlocked
       sign_in_and_redirect(resource_name, resource)
     else
       render_with_scope :new


### PR DESCRIPTION
I there, I start using devise now, it's great, congrats.

But one minimal thing I noticed is that you dont use :success flash messages, only :notice. I think that using the success messages in some proper actions(account verified, successful login and logout and changed account informations with success).

It's not a bug, but a little bit more "candy" with green color, it becomes a little more intuitive for users. 
