### PR TITLE
Allow confirmation email to be resent with key specified in config

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -116,6 +116,10 @@ module Devise
   # Time interval you can access your account before confirming your account.
   mattr_accessor :confirm_within
   @@confirm_within = 0.days
+  
+  # Defines which key will be used when confirming an account
+  mattr_accessor :confirmation_keys
+  @@confirmation_keys = [ :email ]
 
   # Time interval to timeout the user session without activity.
   mattr_accessor :timeout_in

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -133,7 +133,7 @@ module Devise
         # with an email not found error.
         # Options must contain the user email
         def send_confirmation_instructions(attributes={})
-          confirmable = find_or_initialize_with_error_by(:email, attributes[:email], :not_found)
+          confirmable = find_or_initialize_with_errors(confirmation_keys, attributes, :not_found)
           confirmable.resend_confirmation_token if confirmable.persisted?
           confirmable
         end
@@ -153,7 +153,7 @@ module Devise
           generate_token(:confirmation_token)
         end
 
-        Devise::Models.config(self, :confirm_within)
+        Devise::Models.config(self, :confirm_within, :confirmation_keys)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -65,6 +65,9 @@ Devise.setup do |config|
   # (ie 2 days).
   # config.confirm_within = 2.days
 
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+  
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
   # config.remember_for = 2.weeks

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -218,4 +218,21 @@ class ConfirmableTest < ActiveSupport::TestCase
     user.save
     assert user.reload.active?
   end
+  
+  test 'should find a user to send email instructions for the user confirm it\'s email by authentication_keys' do
+    swap Devise, :authentication_keys => [:username, :email] do
+      user = create_user
+      confirm_user = User.send_confirmation_instructions(:email => user.email, :username => user.username)
+      assert_equal confirm_user, user
+    end
+  end
+  
+  test 'should require all confirmation_keys' do
+      swap Devise, :confirmation_keys => [:username, :email] do
+          user = create_user
+          confirm_user = User.send_confirmation_instructions(:email => user.email)
+          assert_not confirm_user.persisted?
+          assert_equal "can't be blank", confirm_user.errors[:username].join
+      end
+  end
 end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -62,6 +62,9 @@ Devise.setup do |config|
   # (ie 2 days).
   # config.confirm_within = 2.days
 
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [ :email ]
+  
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
   # config.remember_for = 2.weeks


### PR DESCRIPTION
I need to be able to allow user to have multiple accounts with the same email address and login with username. 1.2rc allows password resets and account unlock requests by username. I need to resend confirmation emails by username also. I raised this as issue 813.
