### PR TITLE
Friendly_token length

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -370,7 +370,7 @@ module Devise
 
   # Generate a friendly string randomically to be used as token.
   def self.friendly_token
-    ActiveSupport::SecureRandom.base64(44).tr('+/=', 'xyz')
+    ActiveSupport::SecureRandom.base64(15).tr('+/=', 'xyz')
   end
 end
 

--- a/test/models/encryptable_test.rb
+++ b/test/models/encryptable_test.rb
@@ -31,7 +31,7 @@ class EncryptableTest < ActiveSupport::TestCase
 
   test 'should generate a base64 hash using SecureRandom for password salt' do
     swap_with_encryptor Admin, :sha1 do
-      ActiveSupport::SecureRandom.expects(:base64).with(44).returns('friendly_token')
+      ActiveSupport::SecureRandom.expects(:base64).with(15).returns('friendly_token')
       assert_equal 'friendly_token', create_admin.password_salt
     end
   end


### PR DESCRIPTION
Make Devise::friendly_token 20 characters long.

This makes the tokens better suited for URLs in plain-text emails, and
is still secure for all practical purposes.

As proposed in http://groups.google.com/group/plataformatec-devise/browse_thread/thread/6eb3d04cd40c38e1 .
