### PR TITLE
Preventing timeoutable from interfering with stateless token auth

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -6,7 +6,7 @@
 Warden::Manager.after_set_user do |record, warden, options|
   scope = options[:scope]
 
-  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope)
+  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false
     last_request_at = warden.session(scope)['last_request_at']
 
     if record.timedout?(last_request_at)


### PR DESCRIPTION
Related to [this issue](https://github.com/plataformatec/devise/issues#issue/851).

Note: test needs to be cleaned up with proper user expiration.

Thanks!
