### PR TITLE
http_auth? returns true for html requests

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -129,7 +129,7 @@ module Devise
     end
 
     def request_format
-      @request_format ||= request.format.respond_to?(:ref) ? request.format.ref : request.format
+      @request_format ||= request.format.respond_to?(:symbol) ? request.format.symbol : request.format
     end
   end
 end


### PR DESCRIPTION
Found a typo in newly refactored Devise::FailureApp#request_format method. Seems like the MIME class returned by request.format uses symbol for a friendly symbol representation. Caused test failures and tested in application we are using. YMMV.

Regards,
Jack
