### PR TITLE
Custom failure app testability

### DIFF
--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -46,7 +46,7 @@ module Devise
           env["warden.options"] = result
           Warden::Manager._run_callbacks(:before_failure, env, result)
 
-          status, headers, body = Devise::FailureApp.call(env).to_a
+          status, headers, body = Devise.warden_config[:failure_app].call(env).to_a
           @controller.send :render, :status => status, :text => body,
             :content_type => headers["Content-Type"], :location => headers["Location"]
 

--- a/test/test_helpers_test.rb
+++ b/test/test_helpers_test.rb
@@ -4,6 +4,12 @@ class TestHelpersTest < ActionController::TestCase
   tests UsersController
   include Devise::TestHelpers
 
+  class CustomFailureApp < Devise::FailureApp
+    def redirect
+      self.status = 306
+    end
+  end
+  
   test "redirects if attempting to access a page unauthenticated" do
     get :index
     assert_redirected_to new_user_session_path
@@ -51,6 +57,16 @@ class TestHelpersTest < ActionController::TestCase
     sign_out user
     get :index
     assert_redirected_to new_user_session_path
+  end
+  
+  test "respects custom failure app" do
+    begin
+      Devise.warden_config.failure_app = CustomFailureApp
+      get :index
+      assert_response 306
+    ensure
+      Devise.warden_config.failure_app = Devise::FailureApp
+    end
   end
 
   test "defined Warden after_authentication callback should not be called when sign_in is called" do


### PR DESCRIPTION
I noticed that some basic behaviors implemented in my custom FailureApp were not applied in test mode. This patch causes tests to employ the custom app (if configured).
