### PR TITLE
Allow configurable validation scopes

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -98,6 +98,10 @@ module Devise
   mattr_accessor :password_length
   @@password_length = 6..20
 
+  # Scopes for validations
+	mattr_accessor :validation_scopes
+	@@validation_scopes = nil
+	
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for
   @@remember_for = 2.weeks

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -23,7 +23,7 @@ module Devise
 
         base.class_eval do
           validates_presence_of   :email, :if => :email_required?
-          validates_uniqueness_of :email, :scope => authentication_keys[1..-1],
+          validates_uniqueness_of :email, :scope => validation_scopes || authentication_keys[1..-1],
             :case_sensitive => case_insensitive_keys.exclude?(:email), :allow_blank => true
           validates_format_of     :email, :with  => email_regexp, :allow_blank => true
 
@@ -58,7 +58,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(self, :email_regexp, :password_length, :validation_scopes)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -88,6 +88,9 @@ Devise.setup do |config|
 
   # Regex to use to validate the email address
   # config.email_regexp = /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
+  
+  # Validation scopes if they are different from authentication_keys[1..-1]
+  # config.validation_scopes = [:account_id] 
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -12,9 +12,10 @@ end
 
 class DeviseTest < ActiveSupport::TestCase
   test 'model options can be configured through Devise' do
-    swap Devise, :confirm_within => 113, :pepper => "foo" do
+    swap Devise, :confirm_within => 113, :pepper => "foo", :validation_scopes => [:account_id] do
       assert_equal 113, Devise.confirm_within
       assert_equal "foo", Devise.pepper
+      assert_equal [:account_id], Devise.validation_scopes
     end
   end
 

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -20,6 +20,16 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_match(/taken/, user.errors[:email].join)
   end
 
+  test "should honor validation_scopes when checking uniqueness of email" do
+    existing_user = create_user(:some_number => 15)
+    assert_equal 15, existing_user.some_number
+    user = new_user(:email => existing_user.email, :some_number => 16)
+    assert_equal 16, user.some_number
+    assert user.valid?
+    user.some_number = 15
+    assert user.invalid?
+  end
+
   test 'should require correct email format, allowing blank' do
     user = new_user(:email => '')
     assert user.invalid?
@@ -91,7 +101,7 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_not (user.errors[:password].join =~ /is too long/)
   end
 
-  test 'shuold not be included in objects with invalid API' do
+  test 'should not be included in objects with invalid API' do
     assert_raise RuntimeError do
       Class.new.send :include, Devise::Models::Validatable
     end

--- a/test/rails_app/app/active_record/user.rb
+++ b/test/rails_app/app/active_record/user.rb
@@ -4,5 +4,5 @@ class User < ActiveRecord::Base
   include Shim
   include SharedUser
 
-  attr_accessible :username, :email, :password, :password_confirmation, :remember_me
+  attr_accessible :username, :email, :password, :password_confirmation, :remember_me, :some_number
 end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -85,6 +85,9 @@ Devise.setup do |config|
 
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+  
+  # Validation scopes if they are different from authentication_keys[1..-1]
+  config.validation_scopes = [:some_number]
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -3,6 +3,7 @@ class CreateTables < ActiveRecord::Migration
     create_table :users do |t|
       t.string :username
       t.string :facebook_token
+      t.integer :some_number
 
       t.database_authenticatable :null => false
       t.confirmable


### PR DESCRIPTION
Rather than relying on authentication_keys[1..-1] as validatable.rb is currently doing,  this pull request allows validation_scopes to be configured so email validation can be scoped, for instance, by account_id, even if account_id is not in the authentication_keys.  

I needed this functionality recently in an app I was working on.  Authentication_keys used :subdomain,  but emails needed to be scoped by account_id so I could not use :validatable module.

I have defaulted @@validation_scopes to nil so existing functionality is not altered.
