### PR TITLE
Rails 3 1

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -243,7 +243,9 @@ module Devise
 
   # Set the mailer reference object to access the mailer.
   def self.mailer=(class_name)
-    @@mailer_ref = ActiveSupport::Dependencies.reference(class_name)
+    @@mailer_ref = ActiveSupport::Dependencies.respond_to?(:reference)
+                    ? ActiveSupport::Dependencies.reference(class_name)
+                    : ActiveSupport::Dependencies.ref(class_name)
   end
   self.mailer = "Devise::Mailer"
 


### PR DESCRIPTION
When running on rails 3.1.beta I noticed the deprecation warning for ref moving to reference. Not sure how you usually handle commits like this that won't be needed/valid for a bit, but thought I'd throw it out there if even for a reminder for later. 
