### PR TITLE
New cache api compatible

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -227,9 +227,11 @@ module Devise
   end
 
   def self.ref(arg)
-    dependencies = ActiveSupport::Dependencies
-    dependencies.respond_to?(:reference) ?
-      dependencies.reference(arg) : dependencies.ref(arg)
+    if defined?(ActiveSupport::Dependencies::ClassCache)
+      ActiveSupport::Dependencies::Reference.store(arg)
+    else
+      ActiveSupport::Dependencies.ref(arg)
+    end
   end
 
   def self.omniauth_providers
@@ -244,7 +246,11 @@ module Devise
 
   # Get the mailer class from the mailer reference object.
   def self.mailer
-    @@mailer_ref.get
+    if defined?(ActiveSupport::Dependencies::ClassCache)
+      @@mailer_ref.get "Devise::Mailer"
+    else
+      @@mailer_ref.get
+    end
   end
 
   # Set the mailer reference object to access the mailer.

--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -73,7 +73,11 @@ module Devise
 
     # Gives the class the mapping points to.
     def to
-      @ref.get
+      if defined?(ActiveSupport::Dependencies::ClassCache)
+        @ref.get @class_name
+      else
+        @ref.get
+      end
     end
 
     def strategies


### PR DESCRIPTION
It looks like the new ClassCache api is more different than I previously thought. After testing things in a real 3.1 app I found a couple cases where devise will need to pass the desired key into the new get call. 

Currently the ActiveSupport::Dependencies::ClassCache::Getter class exists to handle old get calls which don't expect needing to pass in the key. As far as I can tell the new api will always require you to pass in the key. These methods help demonstrate some of the changes:
# in rails/activesupport/lib/active_support/dependencies.rb

```
Reference = ClassCache.new

def ref(name)
  Reference.new(name)
end
deprecate :ref

# Store a reference to a class +klass+.
def reference(klass)
  Reference.store klass
end

# Get the reference for class named +name+.
def constantize(name)
  Reference.get(name)
end
```

Devise was getting the deprecation warnings given it's use of @ref.get in the to method defined in mapping. The current issue is that with the last patches from myself and then José the new call to reference is incorrect and a rails 3.1 app on master will not work correctly. It's not enough to simply change ref to reference as I had thought. The correct way it appears is to use the store method:

   def self.ref(arg)
-    dependencies = ActiveSupport::Dependencies
-    dependencies.respond_to?(:reference) ?
-      dependencies.reference(arg) : dependencies.ref(arg)
-    if defined?(ActiveSupport::Dependencies::ClassCache)
-      ActiveSupport::Dependencies::Reference.store(arg)
-    else
-      ActiveSupport::Dependencies.ref(arg)
-    end

Supporting the new and old api's seems easy enough, though a bit ugly. The current patch has several calls that look for ClassCache to be defined. Whether we wrap that in a simple new_api? method seems less interesting than if we want to shoot for compatibility on both fronts. 

If I had realized the full extent of the differences I probably wouldn't have send in the request to change ref to reference, but now that we're down this path we might as well consider the possibilities. Devise tests do pass, and the new 3.1 app seems good with these changes. 

Hopefully this makes a bit more sense. Took me a sec to trace through things and realize what had changed and how. Happy to comment more/update things as I can. Given I opened this can of worms I want to be sure it's closed correctly. 

Thoughts?
