### PR TITLE
Slow running Devise unit tests

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -51,7 +51,7 @@ Devise.setup do |config|
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.
-  config.stretches = 10
+  config.stretches = (Rails.env == "test") ? 1 : 10
 
   # Setup a pepper to generate the encrypted password.
   # config.pepper = <%= ActiveSupport::SecureRandom.hex(64).inspect %>


### PR DESCRIPTION
Found that devise was running slowly through unit tests due to bcrypt stretches. Bernard Schaefer purposed a less than ideal solution (http://oinopa.com/2011/02/05/want-a-faster-test-suite.html) and I found that modifying  streches in the config was sufficient to reduce test cost (http://www.thepursuitofquality.com/post/66/speeding-up-devise-tests.html).

I'm still fairly new to ruby/rails so excuse an error in my solution - as well my quick scan didn't find any unit tests for this case, but I'd gladly write them if someone pointed me to the file required.

Cheers,
Gavin Miller 
