### PR TITLE
Downcase Omniauth callbacks; fixes up omniauth LDAP callback

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -272,7 +272,7 @@ module ActionDispatch::Routing
           ::OmniAuth.config.path_prefix = path_prefix
         end
 
-        match "#{path_prefix}/:action/callback", :action => Regexp.union(mapping.to.omniauth_providers.map(&:to_s)),
+        match "#{path_prefix}/:action/callback", :action => Regexp.union(mapping.to.omniauth_providers.map{|p| p.to_s.downcase}),
           :to => controllers[:omniauth_callbacks], :as => :omniauth_callback
       ensure
         @scope[:path] = path


### PR DESCRIPTION
When using oa-enterprise's LDAP, the strategy must be configured as :LDAP since the camelize inflectors can't understand "ldap" -> "LDAP" and instead "ldap" becomes "Ldap" (hence resulting in an inability to fetch the LDAP strategy).

However, with the strategy configured as :LDAP, the callback route becomes LDAP/callback rather than  ldap/callback which is actually hit.

This fixes the issue by downcasing all omniauth callback routes; which passes existing tests and seems to work, but is admittedly a wide-spectrum fix for a specific issue (and depends on the seemingly random fact that all other omniauth providers seem to hit downcased callbacks as well).

There are a few (potentially) better ways to fix this:
- Modifying omniauth/oa-enterprise to hit LDAP/callback rather than ldap/callback (consistency with pre-callback routing, which uses capitalized LDAP)
- Modifying Devise to handle configuring LDAP as :ldap (consistency with all other omniauth providers)
- Modifying inflectors to understand "ldap" -> "LDAP" (essentially provides previous option in a more universal way, but is also somewhat wrong)

But this "downcase everything; nuke" strategy is easiest and seemed to pass tests for me.
