### PR TITLE
Increases the default password maximum length to 128 characters

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -96,7 +96,7 @@ module Devise
 
   # Range validation for password length
   mattr_accessor :password_length
-  @@password_length = 6..20
+  @@password_length = 6..128
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -10,7 +10,7 @@ module Devise
     # Validatable adds the following options to devise_for:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
-    #   * +password_length+: a range expressing password length. Defaults to 6..20.
+    #   * +password_length+: a range expressing password length. Defaults to 6..128.
     #
     module Validatable
       # All validations used by this module.

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -87,8 +87,8 @@ Devise.setup do |config|
   # config.cookie_options = {}
 
   # ==> Configuration for :validatable
-  # Range for password length. Default is 6..20.
-  # config.password_length = 6..20
+  # Range for password length. Default is 6..128.
+  # config.password_length = 6..128
 
   # Regex to use to validate the email address
   # config.email_regexp = /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -75,10 +75,10 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too short (minimum is 6 characters)', user.errors[:password].join
   end
 
-  test 'should require a password with maximum of 20 characters long' do
-    user = new_user(:password => 'x'*21, :password_confirmation => 'x'*21)
+  test 'should require a password with maximum of 128 characters long' do
+    user = new_user(:password => 'x'*129, :password_confirmation => 'x'*129)
     assert user.invalid?
-    assert_equal 'is too long (maximum is 20 characters)', user.errors[:password].join
+    assert_equal 'is too long (maximum is 128 characters)', user.errors[:password].join
   end
 
   test 'should not require password length when it\'s not changed' do

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -80,8 +80,8 @@ Devise.setup do |config|
   config.use_salt_as_remember_token = true
 
   # ==> Configuration for :validatable
-  # Range for password length. Default is 6..20.
-  # config.password_length = 6..20
+  # Range for password length. Default is 6..128.
+  # config.password_length = 6..128
 
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i


### PR DESCRIPTION
The current default limit of 20 characters is terribly short.
