### PR TITLE
Make flash messages HTML safe

### DIFF
--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -137,7 +137,7 @@ MESSAGE
         options[:default] = Array(options[:default]).unshift(kind.to_sym)
         options[:resource_name] = resource_name
         message = I18n.t("#{resource_name}.#{kind}", options)
-        flash[key] = message if message.present?
+        flash[key] = message.html_safe if message.present?
       end
 
       def clean_up_passwords(object) #:nodoc:


### PR DESCRIPTION
Sometimes content writers want simple HTML in their flash messages. I think it's OK to assume our language .yml files are HTML-safe. Please let me know if there is a more appropriate way to do this, but this is what I have monkey-patched for now.
