### PR TITLE
Allow to override the path after resending confirmation instructions

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -13,7 +13,7 @@ class Devise::ConfirmationsController < ApplicationController
 
     if resource.errors.empty?
       set_flash_message(:notice, :send_instructions) if is_navigational_format?
-      respond_with resource, :location => new_session_path(resource_name)
+      respond_with resource, :location => after_resending_confirmation_instructions_path_for(resource_name)
     else
       respond_with_navigational(resource){ render_with_scope :new }
     end
@@ -31,4 +31,11 @@ class Devise::ConfirmationsController < ApplicationController
       respond_with_navigational(resource.errors, :status => :unprocessable_entity){ render_with_scope :new }
     end
   end
+
+  protected
+
+    # The path used after resending confirmation instructions.
+    def after_resending_confirmation_instructions_path_for(resource_name)
+      new_session_path(resource_name)
+    end
 end


### PR DESCRIPTION
the redirection destination of Devise::ConfirmationsController#create is (kind of) hard coded as new_session_path, while Devise::RegistrationsController has nice after_inactive_sign_up_path_for hook.

the attached patch introduces ConfirmationsController's counterpart.

(but the name of the hook may be too long.. I'm open for alternatives, thanks.)
