### PR TITLE
devise_for :only option

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -173,6 +173,9 @@ module ActionDispatch::Routing
         end
 
         routes  = mapping.routes
+        if options.has_key?(:only)
+          routes  = Array(options.delete(:only)).map { |s| s.to_s.singularize.to_sym } & mapping.routes
+        end
         routes -= Array(options.delete(:skip)).map { |s| s.to_s.singularize.to_sym }
 
         devise_scope mapping.name do

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   end
 
   # Other routes for routing_test.rb
+  devise_for :reader, :class_name => "User", :only => :passwords
+
   namespace :publisher, :path_names => { :sign_in => "i_dont_care", :sign_out => "get_out" } do
     devise_for :accounts, :class_name => "Admin", :path_names => { :sign_in => "get_in" }
   end

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -123,6 +123,13 @@ class CustomizedRoutingTest < ActionController::TestCase
     end
   end
 
+  test 'does only map reader password' do
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/sessions', :action => 'new'}, 'reader/sessions/new')
+    end
+    assert_recognizes({:controller => 'devise/passwords', :action => 'new'}, 'reader/password/new')
+  end
+
   test 'map account with custom path name for session sign in' do
     assert_recognizes({:controller => 'devise/sessions', :action => 'new', :locale => 'en'}, '/en/accounts/login')
   end


### PR DESCRIPTION
this commit provides a :only option for the devise_for method, analogous to the :skip option
