### PR TITLE
Devise raises BCrypt::Errors::InvalidHash on empty encrypted_password

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -33,9 +33,13 @@ module Devise
 
       # Verifies whether an password (ie from sign in) is the user password.
       def valid_password?(password)
-        bcrypt   = ::BCrypt::Password.new(self.encrypted_password)
-        password = ::BCrypt::Engine.hash_secret("#{password}#{self.class.pepper}", bcrypt.salt)
-        Devise.secure_compare(password, self.encrypted_password)
+        begin
+          bcrypt   = ::BCrypt::Password.new(self.encrypted_password)
+          password = ::BCrypt::Engine.hash_secret("#{password}#{self.class.pepper}", bcrypt.salt)
+          Devise.secure_compare(password, self.encrypted_password)
+        rescue BCrypt::Errors::InvalidHash
+          return false
+        end
       end
 
       # Set password and password confirmation to nil

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -6,12 +6,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     # case_insensitive_keys is set to :email by default.
     email = 'Foo@Bar.com'
     user = new_user(:email => email)
-    
+
     assert_equal email, user.email
     user.save!
     assert_equal email.downcase, user.email
   end
-  
+
   test 'should respond to password and password confirmation' do
     user = new_user
     assert user.respond_to?(:password)
@@ -45,6 +45,18 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   test 'should test for a valid password' do
     user = create_user
     assert user.valid_password?('123456')
+    assert_not user.valid_password?('654321')
+  end
+
+  test 'should not raise error with an empty password' do
+    user = create_user
+    user.encrypted_password = ''
+    assert_nothing_raised { user.valid_password?('123456') }
+  end
+
+  test 'should be an invalid password if the user has an empty password' do
+    user = create_user
+    user.encrypted_password = ''
     assert_not user.valid_password?('654321')
   end
 


### PR DESCRIPTION
Hi there José,

This test and patch fixes an edge case where someone who was using oauth authentication on prior devise would have an empty encrypted_password.  This then was causing Devise to bomb out with an InvalidHash error from BCrypt.

Simple fix to catch that exception and return false, which should send the user back to the login screen instead of blowing up.

Mikel
