### PR TITLE
README should use notice/alert instead of success/failure in I18n section.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -259,7 +259,7 @@ Feel free to choose the one you prefer!
 
 === I18n
 
-Devise uses flash messages with I18n with the flash keys :success and :failure. To customize your app, you can set up your locale file:
+Devise uses flash messages with I18n with the flash keys :notice and :alert. To customize your app, you can set up your locale file:
 
   en:
     devise:


### PR DESCRIPTION
Due to changes introduced by 6d80418fd138d2c89b843a762891f13d46a7af08, README file should be changed in its I18n section.
