### PR TITLE
Change the XML error tag from <hash> to <errors>

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -96,7 +96,13 @@ module Devise
     def http_auth_body
       return i18n_message unless request_format
       method = "to_#{request_format}"
-      {}.respond_to?(method) ? { :error => i18n_message }.send(method) : i18n_message
+      if method == "to_xml"
+        { :error => i18n_message }.to_xml(:root => "errors")
+      elsif {}.respond_to?(method)
+        { :error => i18n_message }.send(method)
+      else
+        i18n_message
+      end
     end
 
     def recall_app(app)


### PR DESCRIPTION
This has the practical upshot of making way more sense when you look at or process the error:

```
<errors>
  <error>Some error message from the i18n file</error>
</errors>
```

Also more consistent with an ActiveRecord model that failed to save, which reports its errors in an <errors> tag as well.
