### PR TITLE
Recoverable functionality broken when reset_password_sent_at missing

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -73,6 +73,7 @@ module Devise
         def generate_reset_password_token
           self.reset_password_token = self.class.reset_password_token
           self.reset_password_sent_at = Time.now.utc if respond_to?(:reset_password_sent_at=)
+          self.reset_password_token
         end
 
         # Resets the reset password token with and save the record without

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -196,4 +196,12 @@ class RecoverableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should save the model when the reset_password_sent_at doesnt exist' do
+    user = create_user
+    user.stubs(:respond_to?).with(:reset_password_sent_at=).returns(false)
+    user.stubs(:respond_to?).with(:headers_for).returns(false)
+    user.send_reset_password_instructions
+    user.reload
+    assert_not_nil user.reset_password_token
+  end
 end


### PR DESCRIPTION
Fix bug when the reset_password_sent_at field doesn't exist generate_password_token returns nil causing the token not to be saved.
