### PR TITLE
clarify readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -231,6 +231,8 @@ If the customization at the views level is not enough, you can customize each co
 
     devise_for :admins, :controllers => { :sessions => "admins/sessions" }
 
+Be sure to use strings, not symbols, for controller route overrides (for example: "admins/sessions" as above) otherwise login functionality may break.
+
 3) And since we changed the controller, it won't use the "devise/sessions" views, so remember to copy "devise/sessions" to "admin/sessions".
 
 Remember that Devise uses flash messages to let users know if sign in was successful or failed. Devise expects your application to call "flash[:notice]" and "flash[:alert]" as appropriate.


### PR DESCRIPTION
Edited README to clarify using strings for controller route overrides. Issue #816

https://github.com/plataformatec/devise/issues/816

For people like me that accidentally used symbols instead and spent hours wondering what was going on.
