### PR TITLE
respect do not track headers in trackable

### DIFF
--- a/lib/devise/hooks/trackable.rb
+++ b/lib/devise/hooks/trackable.rb
@@ -3,7 +3,7 @@
 # and on authentication. Retrieving the user from session (:fetch) does
 # not trigger it.
 Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
-  if record.respond_to?(:update_tracked_fields!) && warden.authenticated?(options[:scope]) && warden.request.headers['X-Do-Not-Track'].to_s != '1' && warden.request.headers['DNT'].to_s != '1'
+  if record.respond_to?(:update_tracked_fields!) && warden.authenticated?(options[:scope]) && !warden.request.env['devise.skip_trackable']
     record.update_tracked_fields!(warden.request)
   end
 end

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -62,29 +62,20 @@ class TrackableHooksTest < ActionController::IntegrationTest
     end
   end
   
-  test "respect X-Do-Not-Track and DNT headers" do
+  test "do not track if devise.skip_trackable is set" do
     user = create_user
     sign_in_as_user do
-      header "X-Do-Not-Track" , "1"
-      header "DNT" , "0"
+      header 'devise.skip_trackable', '1'
     end
     user.reload
     assert_equal 0, user.sign_in_count
     visit destroy_user_session_path
     
     sign_in_as_user do
-      header "X-Do-Not-Track" , "0"
-      header "DNT" , "1"
-    end
-    user.reload
-    assert_equal 0, user.sign_in_count
-    visit destroy_user_session_path
-    
-    sign_in_as_user do
-      header "X-Do-Not-Track" , "0"
-      header "DNT" , "0"
+      header 'devise.skip_trackable', false
     end
     user.reload
     assert_equal 1, user.sign_in_count
   end
+
 end


### PR DESCRIPTION
I added support for the X-Do-Not-Track and the DNT headers to trackable. Look here for further information:
http://blog.sidstamm.com/2011/01/try-out-do-not-track-http-header.html

I guess Devise should support this header. I'm not sure if there should be a configuration option to turn the support of this header off.
