### PR TITLE
Remove :anybody_signed_in? from the controller helpers

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -5,7 +5,7 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        helper_method :warden, :signed_in?, :devise_controller?, :anybody_signed_in?
+        helper_method :warden, :signed_in?, :devise_controller?
       end
 
       # Define authentication filters and accessor helpers based on mappings.


### PR DESCRIPTION
:anybody_signed_in? helper was deprecated in https://github.com/plataformatec/devise/commit/73669e09c82ddd14b560c7b45df1c95c9ebafe33 and removed in https://github.com/plataformatec/devise/commit/fe5ef25614fc77178205055070552e46923e467b but not removed from the #helper_method call.
