### PR TITLE
Don't validate email format and uniqueness unless it's changed

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -23,8 +23,8 @@ module Devise
 
         base.class_eval do
           validates_presence_of   :email, :if => :email_required?
-          validates_uniqueness_of :email, :case_sensitive => (case_insensitive_keys != false), :allow_blank => true
-          validates_format_of     :email, :with  => email_regexp, :allow_blank => true
+          validates_uniqueness_of :email, :case_sensitive => (case_insensitive_keys != false), :allow_blank => true, :if => :email_changed?
+          validates_format_of     :email, :with  => email_regexp, :allow_blank => true, :if => :email_changed?
 
           validates_presence_of     :password, :if => :password_required?
           validates_confirmation_of :password, :if => :password_required?

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -8,7 +8,7 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'can\'t be blank', user.errors[:email].join
   end
 
-  test 'should require uniqueness of email, allowing blank' do
+  test 'should require uniqueness of email if email has changed, allowing blank' do
     existing_user = create_user
 
     user = new_user(:email => '')
@@ -18,9 +18,12 @@ class ValidatableTest < ActiveSupport::TestCase
     user.email = existing_user.email
     assert user.invalid?
     assert_match(/taken/, user.errors[:email].join)
+
+    user.save(:validate => false)
+    assert user.valid?
   end
 
-  test 'should require correct email format, allowing blank' do
+  test 'should require correct email format if email has changed, allowing blank' do
     user = new_user(:email => '')
     assert user.invalid?
     assert_not_equal 'is invalid', user.errors[:email].join
@@ -30,6 +33,9 @@ class ValidatableTest < ActiveSupport::TestCase
       assert user.invalid?, 'should be invalid with email ' << email
       assert_equal 'is invalid', user.errors[:email].join
     end
+
+    user.save(:validate => false)
+    assert user.valid?
   end
 
   test 'should accept valid emails' do


### PR DESCRIPTION
to avoid hitting the database (uniqueness validation) every time a user record is validated.
