### PR TITLE
Don't load 'recoverable' resource if it was loaded before 

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -90,12 +90,13 @@ module Devise
         end
 
       module ClassMethods
-        # Attempt to find a user by it's email. If a record is found, send new
-        # password instructions to it. If not user is found, returns a new user
-        # with an email not found error.
-        # Attributes must contain the user email
+        # Attempt to find a user by it's email or any key from 'reset_password_keys' array.
+        # If a record is found, send new password instructions to it. If not user is found,
+        # returns a new user with an email not found error.
+        # Attributes must contain the user email or any key from 'reset_password_keys' array.
         def send_reset_password_instructions(attributes={})
-          recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+          recoverable = self.class.to_s == 'Class' ? find_or_initialize_with_errors(
+              reset_password_keys, attributes, :not_found) : self
           recoverable.send_reset_password_instructions if recoverable.persisted?
           recoverable
         end


### PR DESCRIPTION
Hello!

It does not break your tests. Now let me explain why I need this.
You are loading the resource and sending the email in one function, but I need to slip this in two steps, and add some verification between. So I will load the resource myself and your function will skip loading the resource again.
