### PR TITLE
dup the conditions hash before calling filter_auth_params, this fixes an 

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -113,7 +113,7 @@ module Devise
         #   end
         #
         def find_for_authentication(conditions)
-          filter_auth_params(conditions)
+          conditions = filter_auth_params(conditions.dup)
           (case_insensitive_keys || []).each { |k| conditions[k].try(:downcase!) }
           to_adapter.find_first(conditions)
         end
@@ -126,14 +126,14 @@ module Devise
         # Find an initialize a group of attributes based on a list of required attributes.
         def find_or_initialize_with_errors(required_attributes, attributes, error=:invalid) #:nodoc:
           (case_insensitive_keys || []).each { |k| attributes[k].try(:downcase!) }
-          
+
           attributes = attributes.slice(*required_attributes)
           attributes.delete_if { |key, value| value.blank? }
 
           if attributes.size == required_attributes.size
             record = to_adapter.find_first(filter_auth_params(attributes))
           end
-          
+
           unless record
             record = new
 

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -12,6 +12,23 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_equal email.downcase, user.email
   end
 
+  test 'find_for_authentication and filter_auth_params should not modify the conditions hash' do
+    FilterAuthUser = Class.new(User) do
+      def self.filter_auth_params(conditions)
+        if conditions.is_a?(Hash) && login = conditions.delete('login')
+          key = login.include?('@') ? :email : :username
+          conditions[key] = login
+        end
+        super(conditions)
+      end
+    end
+
+    conditions = { 'login' => 'foo@bar.com' }
+    FilterAuthUser.find_for_authentication(conditions)
+
+    assert_equal({ 'login' => 'foo@bar.com' }, conditions)
+  end
+
   test 'should respond to password and password confirmation' do
     user = new_user
     assert user.respond_to?(:password)


### PR DESCRIPTION
Hey Guys,

This patch dups the conditions hash before calling `filter_auth_params`, this fixes an issue with reseting your password when using a custom auth field like login.

Enjoy,

Josh
