### PR TITLE
Rails has removed SecureRandom from ActiveSupport in Rails 3.2, deprecated

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/numeric/time'
 require 'active_support/dependencies'
 require 'orm_adapter'
 require 'set'
+require 'securerandom'
 
 module Devise
   autoload :FailureApp, 'devise/failure_app'
@@ -402,11 +403,7 @@ module Devise
 
   # Generate a friendly string randomically to be used as token.
   def self.friendly_token
-    if defined? ::SecureRandom
-      ::SecureRandom.base64(15).tr('+/=', 'xyz')
-    else
-      ActiveSupport::SecureRandom.base64(15).tr('+/=', 'xyz')
-    end
+    SecureRandom.base64(15).tr('+/=', 'xyz')
   end
 
   # constant-time comparison algorithm to prevent timing attacks


### PR DESCRIPTION
Rails has remove SecureRandom from ActiveSupport in Rails 3.2, deprecated in 3.1

Since it has been deprecated, this patch favors SecureRandom on ActiveSupport::SecureRandom

Source: [Commit on the rails repository](https://github.com/rails/rails/commit/1170cceaaec8c0c8aef173913405be1456e4b2be#activesupport/lib/active_support)
