### PR TITLE
Changing references to SecureRandom in generators and encryptable_test

### DIFF
--- a/lib/generators/devise/install_generator.rb
+++ b/lib/generators/devise/install_generator.rb
@@ -1,4 +1,4 @@
-require 'active_support/secure_random'
+require 'securerandom'
 
 module Devise
   module Generators

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -54,7 +54,7 @@ Devise.setup do |config|
   config.stretches = 10
 
   # Setup a pepper to generate the encrypted password.
-  # config.pepper = <%= ActiveSupport::SecureRandom.hex(64).inspect %>
+  # config.pepper = <%= SecureRandom.hex(64).inspect %>
 
   # ==> Configuration for :confirmable
   # The time you want to give your user to confirm his account. During this time

--- a/test/models/encryptable_test.rb
+++ b/test/models/encryptable_test.rb
@@ -31,7 +31,7 @@ class EncryptableTest < ActiveSupport::TestCase
 
   test 'should generate a base64 hash using SecureRandom for password salt' do
     swap_with_encryptor Admin, :sha1 do
-      ActiveSupport::SecureRandom.expects(:base64).with(15).returns('friendly_token')
+      SecureRandom.expects(:base64).with(15).returns('friendly_token')
       assert_equal 'friendly_token', create_admin.password_salt
     end
   end


### PR DESCRIPTION
'rails generate devise:install' was failing due to referencing ActiveSupport::SecureRandom

Previous commit to switch 'active_support/securerandom' to 'securerandom' missed a couple of spots.
