### PR TITLE
the script section in the travis yml isn't needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-script: "rake test"
 rvm:
   - 1.8.7
   - 1.9.2


### PR DESCRIPTION
The script section in the travis yml isn't needed as this is the default behavior, this should also fix the tests.
