### PR TITLE
Override serializable_hash rather than to_json/to_xml to protect authentication-related fields.

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -209,6 +209,13 @@ module Devise
   mattr_accessor :navigational_formats
   @@navigational_formats = [:"*/*", "*/*", :html]
 
+  # Which attributes are excluded by default when calling serializable_hash.
+  # serializable_hash is used by to_json, to_xml etc. You can always override this setting by
+  # passing :except or :only as options. By default, we exclude password-related fields and tokens.
+  mattr_accessor :attributes_excluded_from_serializable_hash
+  @@attributes_excluded_from_serializable_hash = [ :encrypted_password, :authentication_token,
+    :confirmation_token, :reset_password_token, :remember_token, :unlock_token, :password_salt ]
+
   # When set to true, signing out a user signs out all other scopes.
   mattr_accessor :sign_out_all_scopes
   @@sign_out_all_scopes = true

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -76,17 +76,12 @@ module Devise
       def authenticatable_salt
       end
 
-      %w(to_xml to_json).each do |method|
-        class_eval <<-RUBY, __FILE__, __LINE__
-          def #{method}(options={})
-            if self.class.respond_to?(:accessible_attributes)
-              options = { :only => self.class.accessible_attributes.to_a }.merge(options || {})
-              super(options)
-            else
-              super
-            end
-          end
-        RUBY
+      # Override serializable_hash to protect critical devise fields.
+      # The crypted_password as well as salts and tokens are considered critical so they should not
+      # be included in representations such as JSON or XML.
+      def serializable_hash(options = nil)
+        options = { :except => Devise.attributes_excluded_from_serializable_hash }.merge(options || {})
+        super(options)
       end
 
       module ClassMethods

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -58,6 +58,12 @@ Devise.setup do |config|
   # Does not affect registerable.
   # config.paranoid = true
 
+  # Configure which attributes are, by default, excluded from hash representations (e.g. to_json).
+  # You can override this on a case by case basis by passing the :except/:only options,
+  #   e.g. user.to_json(:only => :authentication_token)
+  # config.attributes_excluded_from_serializable_hash = [ :encrypted_password, :authentication_token,
+  #   :confirmation_token, :reset_password_token, :remember_token, :unlock_token, :password_salt ]
+
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.

--- a/test/models/authenticatable_test.rb
+++ b/test/models/authenticatable_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class AuthenticatableTest < ActiveSupport::TestCase
+  test 'should not include critical Devise fields in its serializable_hash' do
+    user = new_user
+    hash = user.serializable_hash
+
+    Devise.attributes_excluded_from_serializable_hash.each { |field| assert !hash.key?(field) }
+  end
+
+  test 'should include critical Devise fields in its serializable_hash if explicitly asked for with :only' do
+    user = new_user
+    hash = user.serializable_hash(:only => :encrypted_password)
+
+    assert_not_nil hash['encrypted_password']
+  end
+
+  test 'should include critical Devise fields in its serializable_hash if :except is overridden' do
+    user = new_user
+    hash = user.serializable_hash(:except => :id)
+
+    assert_not_nil hash['encrypted_password']
+  end
+end


### PR DESCRIPTION
As discussed via Twitter, here's my suggestion for a better implementation of the to_json/to_xml behavior provided by Devise.

This commit introduces a couple of benefits over the current behavior:
- serializable_hash is, to the best of my knowledge, the suggested way to configure the hash representation of ressources. to_json/to_xml use it internally as well, however, the to_format methods are concerned with the actual conversion (e.g. converting a hash to JSON) rather than the representation of the resource.
- Another benefit of serializable_hash is that other hash-like formats could pick it up as well without Devise having to override another to_format method.
- I've changed the behavior to not include/exclude fields based on the attr_accessible/attr_protected settings. The rationale behind this is that – again, to the best of my knowledge – ActiveModel and ActiveRecord don't do this by default (see http://apidock.com/rails/ActiveModel/Serialization/serializable_hash). If a user were to migrate to Devise from another authentication solution and they have JSON/XML APIs, Devise would change the behavior which would potentially confuse users. The better solution, IMO, is to blacklist Devise's "dangerous" fields (password-related and tokens) by default and also make this configurable. The case-by-case overriding is still possible.

Let me know if you need other adjustments or if you find the slight change in behavior troublesome.
- Clemens
