### PR TITLE
More transparent implementation of :format => false

### DIFF
--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -22,7 +22,7 @@ module Devise
   #   # is the modules included in the class
   #
   class Mapping #:nodoc:
-    attr_reader :singular, :scoped_path, :path, :controllers, :path_names, :class_name, :sign_out_via
+    attr_reader :singular, :scoped_path, :path, :controllers, :path_names, :class_name, :sign_out_via, :format
     alias :name :singular
 
     # Receives an object and find a scope for it. If a scope cannot be found,
@@ -71,6 +71,7 @@ module Devise
       @defaults.merge!(options[:defaults] || {})
 
       @sign_out_via = options[:sign_out_via] || Devise.sign_out_via
+      @format = options[:format]
     end
 
     # Return modules for the mapping.

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -103,6 +103,10 @@ module ActionDispatch::Routing
     #
     #      devise_for :users, :only => :sessions
     #
+    #  * :format => include "(.:format)" in the generated routes? true by default, set to false to disable:
+    #
+    #      devise_for :users, :format => false
+    #
     #
     # ==== Scoping
     #
@@ -161,6 +165,8 @@ module ActionDispatch::Routing
       options[:path_names]    = (@scope[:path_names] || {}).merge(options[:path_names] || {})
       options[:constraints]   = (@scope[:constraints] || {}).merge(options[:constraints] || {})
       options[:defaults]      = (@scope[:defaults] || {}).merge(options[:defaults] || {})
+
+      @scope[:options]        = (@scope[:options] || {}).merge({:format => false}) if options[:format] == false
 
       resources.map!(&:to_sym)
 

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -47,6 +47,10 @@ Rails.application.routes.draw do
     devise_for :homebase_admin, :class_name => "Admin", :path => "homebase"
   end
   
+  # Routes for format=false testing
+  devise_for :htmlonly_admin, :class_name => "Admin", :skip => [:confirmations, :unlocks], :path => "htmlonly_admin", :format => false
+  devise_for :htmlonly_users, :class_name => "User", :only => [:confirmations, :unlocks], :path => "htmlonly_users", :format => false
+  
   # Other routes for routing_test.rb
   devise_for :reader, :class_name => "User", :only => :passwords
 

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -190,6 +190,41 @@ class CustomizedRoutingTest < ActionController::TestCase
       assert_recognizes({:controller => 'devise/registrations', :action => 'new'}, {:path => 'http://10.0.0.100//homebase/sign_up', :method => :get})
     end
   end
+  
+  test 'map with format false for sessions' do
+    assert_recognizes({:controller => 'devise/sessions', :action => 'new'}, {:path => '/htmlonly_admin/sign_in', :method => :get})
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/sessions', :action => 'new'}, {:path => '/htmlonly_admin/sign_in.xml', :method => :get})
+    end
+  end
+  
+  test 'map with format false for passwords' do
+    assert_recognizes({:controller => 'devise/passwords', :action => 'create'}, {:path => '/htmlonly_admin/password', :method => :post})
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/passwords', :action => 'create'}, {:path => '/htmlonly_admin/password.xml', :method => :post})
+    end
+  end
+  
+  test 'map with format false for registrations' do
+    assert_recognizes({:controller => 'devise/registrations', :action => 'new'}, {:path => '/htmlonly_admin/sign_up', :method => :get})
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/registrations', :action => 'new'}, {:path => '/htmlonly_admin/sign_up.xml', :method => :get})
+    end
+  end
+  
+  test 'map with format false for confirmations' do
+    assert_recognizes({:controller => 'devise/confirmations', :action => 'show'}, {:path => '/htmlonly_users/confirmation', :method => :get})
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/confirmations', :action => 'show'}, {:path => '/htmlonly_users/confirmation.xml', :method => :get})
+    end
+  end
+  
+  test 'map with format false for unlocks' do
+    assert_recognizes({:controller => 'devise/unlocks', :action => 'show'}, {:path => '/htmlonly_users/unlock', :method => :get})
+    assert_raise ActionController::RoutingError do
+      assert_recognizes({:controller => 'devise/unlocks', :action => 'show'}, {:path => '/htmlonly_users/unlock.xml', :method => :get})
+    end
+  end
 end
 
 class ScopedRoutingTest < ActionController::TestCase


### PR DESCRIPTION
Here is the more transparent implementation of :format => false, which uses @scope[:options] to avoid changing all the devise_*() methods individually.

There is also a separate commit which adds support for options[:defaults] similar to options[:constraints] which josevalim said would be welcome.
