### PR TITLE
I don't know why jose didn't do this from the start.

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -202,3 +202,14 @@ Devise.setup do |config|
   #   manager.default_strategies(:scope => :user).unshift :some_external_strategy
   # end
 end
+
+
+
+if Rails.env.test?
+  class ActionController::TestCase
+    include Devise::TestHelpers
+  end
+end
+
+
+


### PR DESCRIPTION
so we can remove this from the wiki: https://github.com/plataformatec/devise/wiki/How-To:-Controllers-and-Views-tests-with-Rails-3-(and-rspec)
