### PR TITLE
Make all controllers inherit from a single DeviseController

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -1,4 +1,4 @@
-class Devise::ConfirmationsController < ApplicationController
+class Devise::ConfirmationsController < DeviseController
   include Devise::Controllers::InternalHelpers
 
   # GET /resource/confirmation/new

--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -1,4 +1,4 @@
-class Devise::OmniauthCallbacksController < ApplicationController
+class Devise::OmniauthCallbacksController < DeviseController
   include Devise::Controllers::InternalHelpers
 
   def failure

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -1,4 +1,4 @@
-class Devise::PasswordsController < ApplicationController
+class Devise::PasswordsController < DeviseController
   prepend_before_filter :require_no_authentication
   include Devise::Controllers::InternalHelpers
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -1,4 +1,4 @@
-class Devise::RegistrationsController < ApplicationController
+class Devise::RegistrationsController < DeviseController
   prepend_before_filter :require_no_authentication, :only => [ :new, :create, :cancel ]
   prepend_before_filter :authenticate_scope!, :only => [:edit, :update, :destroy]
   include Devise::Controllers::InternalHelpers

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,4 +1,4 @@
-class Devise::SessionsController < ApplicationController
+class Devise::SessionsController < DeviseController
   prepend_before_filter :require_no_authentication, :only => [ :new, :create ]
   include Devise::Controllers::InternalHelpers
 

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -1,4 +1,4 @@
-class Devise::UnlocksController < ApplicationController
+class Devise::UnlocksController < DeviseController
   prepend_before_filter :require_no_authentication
   include Devise::Controllers::InternalHelpers
 

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -1,0 +1,3 @@
+# All Devise controllers are inherited from here.
+class DeviseController < ApplicationController
+end


### PR DESCRIPTION
Just a simple change introducing an empty controller between devise controllers and ApplicationController. This means you can use template inheritence in rails 3.1 (a la [template-inheritence](https://github.com/sj26/devise/commits/template-inheritence), but it's rails 3.1 only then).

It also means you can move some of the shared stuff into the devise controller. (a la [controller-inheritence-experimental](https://github.com/sj26/devise/commits/controller-inheritence-experimental))

Additionally, using Rails 3.1 you can easily add an extra template scope lookup, so it searches "app/views/<scope>", "app/views/devise", then "app/views/application". I'm working on this in a [template-inheritence-experimental](https://github.com/sj26/devise/commits/template-inheritence-experimental).

(Have been meaning to send this for a while...)
