### PR TITLE
Do not redirect on require_no_authentication on non-navigational formats

### DIFF
--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -91,6 +91,8 @@ MESSAGE
       # Example:
       #   before_filter :require_no_authentication, :only => :new
       def require_no_authentication
+        return unless is_navigational_format?
+
         no_input = devise_mapping.no_input_strategies
         args = no_input.dup.push :scope => resource_name
         if no_input.present? && warden.authenticate?(*args)

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -245,6 +245,14 @@ class RegistrationTest < ActionController::IntegrationTest
     assert response.body.include? %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<errors>)
   end
 
+  test 'a user sign up with duplicate information in XML format should return invalid response' do
+    user = sign_in_as_user
+
+    post user_registration_path(:format => 'xml'), :user => user.attributes
+    assert_response :unprocessable_entity
+    assert response.body.include? %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<errors>)
+  end
+
   test 'a user update information with valid data in XML format should return valid response' do
     user = sign_in_as_user
     put user_registration_path(:format => 'xml'), :user => { :current_password => '123456', :email => 'user.new@test.com' }


### PR DESCRIPTION
Without this commit, I would receive a 302 redirect instead of a 422 when creating a duplicate account with the JSON format. Of course, I do not know if this is the best way to solve this problem, but it was the most direct way for me.

```
  attrs = { agent: { email: 'johnsmith@example.com', password: 'password', password_confirmation: 'password' }, format: 'json' }
  post '/agents', attrs
  puts response.code
  puts response.body

  post '/agents', attrs
  puts response.code
  puts response.body
```

before:

```
201
{"agent":{"email":"johnsmith@example.com"}}
302
<html><body>You are being <a href="http://www.example.com/">redirected</a>.</body></html>
```

after:

```
201
{"agent":{"email":"johnsmith@example.com"}}
422
{"email":["has already been taken"]}
```
