### PR TITLE
Make it easier to override & extend the require_no_authentication behavior by splitting it out into 2 helpers, only one of them internal

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -218,6 +218,14 @@ module Devise
         session.keys.grep(/^devise\./).each { |k| session.delete(k) }
       end
 
+      # Helper for use in before_filters where no authentication is required.
+      #
+      # Example:
+      #   before_filter :require_no_authentication, :only => :new
+      def require_no_authentication
+        redirect_if_already_authenticated
+      end
+
       # Overwrite Rails' handle unverified request to sign out all scopes,
       # clear run strategies and remove cached variables.
       def handle_unverified_request

--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -86,11 +86,12 @@ MESSAGE
         self.resource = resource_class.new(hash)
       end
 
-      # Helper for use in before_filters where no authentication is required.
+      # The default behavior used by require_no_authentication
+      # Redirects if an authentication is active
       #
-      # Example:
-      #   before_filter :require_no_authentication, :only => :new
-      def require_no_authentication
+      # See also:
+      #   Devise::Helpers#require_no_authentication
+      def redirect_if_already_authenticated
         no_input = devise_mapping.no_input_strategies
         args = no_input.dup.push :scope => resource_name
         if no_input.present? && warden.authenticate?(*args)

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -38,25 +38,25 @@ class HelpersTest < ActionController::TestCase
     assert @controller.class.action_methods.empty?
   end
 
-  test 'require no authentication tests current mapping' do
+  test 'redirect if already authenticated tests current mapping' do
     @mock_warden.expects(:authenticate?).with(:rememberable, :token_authenticatable, :scope => :user).returns(true)
     @mock_warden.expects(:user).with(:user).returns(User.new)
     @controller.expects(:redirect_to).with(root_path)
-    @controller.send :require_no_authentication
+    @controller.send :redirect_if_already_authenticated
   end
 
-  test 'require no authentication skips if no inputs are available' do
+  test 'redirect if already authenticated skips if no inputs are available' do
     Devise.mappings[:user].expects(:no_input_strategies).returns([])
     @mock_warden.expects(:authenticate?).never
     @controller.expects(:redirect_to).never
-    @controller.send :require_no_authentication
+    @controller.send :redirect_if_already_authenticated
   end
 
-  test 'require no authentication sets a flash message' do
+  test 'redirect if already authenticated sets a flash message' do
     @mock_warden.expects(:authenticate?).with(:rememberable, :token_authenticatable, :scope => :user).returns(true)
     @mock_warden.expects(:user).with(:user).returns(User.new)
     @controller.expects(:redirect_to).with(root_path)
-    @controller.send :require_no_authentication
+    @controller.send :redirect_if_already_authenticated
     assert flash[:alert] == I18n.t("devise.failure.already_authenticated")
   end
 


### PR DESCRIPTION
I was having a hell of a time overriding the require_no_authentication behavior to allow an error response when the request was a partial-page ajax request, in order to avoid the redirection causing the full site to be loaded in a sub-section of the page.

I was ultimately able to do it, but only after defining require_no_authentication in the Helpers, as you see here.

Curious to hear thoughts on this, or possible alternatives.
