### PR TITLE
Change :except to :only for registration routes

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -319,7 +319,7 @@ module ActionDispatch::Routing
           :cancel => mapping.path_names[:cancel]
         }
 
-        resource :registration, :only => [:new, :create, :edit, :update, :destroy, :path], => mapping.path_names[:registration],
+        resource :registration, :only => [:new, :create, :edit, :update, :destroy], :path => mapping.path_names[:registration],
                  :path_names => path_names, :controller => controllers[:registrations] do
           get :cancel
         end


### PR DESCRIPTION
This pull will change the route definition so that :except option is replace by :only, giving more fine tuned control to devise over the generated routes. Basic problem is that when the router's resource(s) methods are overridden to provide more routes out of the box, the registration routes have those extra routes, but they are not relevant to devise. This implementation is more in-line with all the other route generating methods.
