### PR TITLE
sign_in should return true and assert that. fixes #1232

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -106,6 +106,7 @@ module Devise
           warden.session_serializer.store(resource, scope)
         elsif warden.user(scope) == resource && !options.delete(:force)
           # Do nothing. User already signed in and we are not forcing it.
+          true
         else
           warden.set_user(resource, options.merge!(:scope => scope))
         end

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -106,7 +106,7 @@ class ControllerAuthenticatableTest < ActionController::TestCase
     user = User.new
     @mock_warden.expects(:user).returns(user)
     @mock_warden.expects(:set_user).never
-    @controller.sign_in(user)
+    assert @controller.sign_in(user)
   end
 
   test 'sign in again when the user is already in only if force is given' do


### PR DESCRIPTION
sign_in should return true in case user is already signed in and assert that. fixes #1232
