### PR TITLE
friendly_token should be friendlier

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -417,7 +417,7 @@ module Devise
 
   # Generate a friendly string randomically to be used as token.
   def self.friendly_token
-    SecureRandom.base64(15).tr('+/=', 'xyz')
+    SecureRandom.base64(15).tr('+/=lIO0', 'pqrsxyz')
   end
 
   # constant-time comparison algorithm to prevent timing attacks

--- a/test/models/encryptable_test.rb
+++ b/test/models/encryptable_test.rb
@@ -31,8 +31,10 @@ class EncryptableTest < ActiveSupport::TestCase
 
   test 'should generate a base64 hash using SecureRandom for password salt' do
     swap_with_encryptor Admin, :sha1 do
-      SecureRandom.expects(:base64).with(15).returns('friendly_token')
-      assert_equal 'friendly_token', create_admin.password_salt
+      SecureRandom.expects(:base64).with(15).returns('01lI')
+      salt = create_admin.password_salt
+      assert_not_equal '01lI', salt
+      assert_equal 4, salt.size
     end
   end
 


### PR DESCRIPTION
I got a password generated by friendly_token by email today and it contained an I ... or was it an l?  I certainly can't tell the difference in many fonts.  This patch should fix that.
