### PR TITLE
Speed up tests by defaulting to 1 stretch in test env

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -61,6 +61,8 @@ Devise.setup do |config|
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.
+  # Limiting the stretches to just one in test env will increase the performance of
+  # your tests dramatically if you create a lot of users.
   config.stretches = Rails.env.test? ? 1 : 10
 
   # Setup a pepper to generate the encrypted password.


### PR DESCRIPTION
As proposed here, limiting the stretches in test env to just one should be a default as it drastically increases the speed for acceptance test that involve devise: 
https://github.com/plataformatec/devise/wiki/Speed-up-your-unit-tests
