### PR TITLE
Tests that should no longer exclude Mongoid

### DIFF
--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -219,14 +219,14 @@ class RegistrationTest < ActionController::IntegrationTest
     get new_user_registration_path(:format => 'xml')
     assert_response :success
     assert_match %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<user>), response.body
-    assert_no_match(/<confirmation-token/, response.body) if DEVISE_ORM == :active_record
+    assert_no_match(/<confirmation-token/, response.body)
   end
 
   test 'a user with JSON sign up stub' do
     get new_user_registration_path(:format => 'json')
     assert_response :success
     assert_match %({"user":), response.body
-    assert_no_match(/"confirmation_token"/, response.body) if DEVISE_ORM == :active_record
+    assert_no_match(/"confirmation_token"/, response.body)
   end
 
   test 'an admin sign up with valid information in XML format should return valid response' do

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -42,18 +42,16 @@ class ActiveRecordTest < ActiveSupport::TestCase
     assert_include_modules Admin, :database_authenticatable, :registerable, :timeoutable, :recoverable, :lockable, :rememberable, :encryptable
   end
 
-  if DEVISE_ORM == :active_record
-    test 'validations options are not applied to late' do
-      validators = WithValidation.validators_on :password
-      length = validators.find { |v| v.kind == :length }
-      assert_equal 2, length.options[:minimum]
-      assert_equal 6, length.options[:maximum]
-    end
+  test 'validations options are not applied too late' do
+    validators = WithValidation.validators_on :password
+    length = validators.find { |v| v.kind == :length }
+    assert_equal 2, length.options[:minimum]
+    assert_equal 6, length.options[:maximum]
+  end
 
-    test 'validations are applied just once' do
-      validators = Several.validators_on :password
-      assert_equal 1, validators.select{ |v| v.kind == :length }.length
-    end
+  test 'validations are applied just once' do
+    validators = Several.validators_on :password
+    assert_equal 1, validators.select{ |v| v.kind == :length }.length
   end
 
   test 'chosen modules are inheritable' do


### PR DESCRIPTION
Following up on the Mongoid test fixes, just found these that should not be conditionally excluded any longer -- they pass.
