### PR TITLE
Fix optional enforcement of particular authentication keys

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -38,8 +38,10 @@ class Devise::SessionsController < ApplicationController
   protected
 
   def stub_options(resource)
-    array = resource_class.authentication_keys.dup
-    array << :password if resource.respond_to?(:password)
-    { :methods => array, :only => [:password] }
+    methods = resource_class.authentication_keys.dup
+    methods = methods.keys if methods.is_a?(Hash)
+    methods << :password if resource.respond_to?(:password)
+    { :methods => methods, :only => [:password] }
   end
 end
+

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -454,6 +454,23 @@ class AuthenticationOthersTest < ActionController::IntegrationTest
   end
 end
 
+class AuthenticationKeysTest < ActionController::IntegrationTest
+  test 'missing authentication keys cause authentication to abort' do
+    swap Devise, :authentication_keys => [:subdomain] do
+      sign_in_as_user
+      assert_contain "Invalid email or password."
+      assert_not warden.authenticated?(:user)
+    end
+  end
+
+  test 'missing authentication keys cause authentication to abort unless marked as not required' do
+    swap Devise, :authentication_keys => { :email => true, :subdomain => false } do
+      sign_in_as_user
+      assert warden.authenticated?(:user)
+    end
+  end
+end
+
 class AuthenticationRequestKeysTest < ActionController::IntegrationTest
   test 'request keys are used on authentication' do
     host! 'foo.bar.baz'


### PR DESCRIPTION
Documentation states that authentication_keys should accept a hash with
values indicating whether or not each key is required. This was added in
b2066cc2 but tests only covered request_keys, and 29afe2d2 later broke
it with a << array operator.
