### PR TITLE
Re-add JRuby to the build matrix 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ rvm:
   - ree
   - rbx
   - rbx-2.0
+  - jruby


### PR DESCRIPTION
We hopefully resolved our JRuby woes on travis-ci.org.
