### PR TITLE
Don't require explicit scope in authenticate router extension

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -205,11 +205,15 @@ module ActionDispatch::Routing
 
     # Allow you to add authentication request from the router:
     #
-    #   authenticate(:user) do
+    #   authenticate do
     #     resources :post
     #   end
     #
-    def authenticate(scope)
+    #   authenticate(:admin) do
+    #     resources :users
+    #   end
+    #
+    def authenticate(scope=nil)
       constraint = lambda do |request|
         request.env["warden"].authenticate!(:scope => scope)
       end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     get :expire, :on => :member
     get :accept, :on => :member
 
-    authenticate :user do
+    authenticate do
       post :exhibit, :on => :member
     end
   end


### PR DESCRIPTION
Just like other extensions do.
