### PR TITLE
Fix usage of “its” / “it’s” in documentation

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -1,7 +1,7 @@
 # Each time a record is set we check whether its session has already timed out
 # or not, based on last request time. If so, the record is logged out and
 # redirected to the sign in page. Also, each time the request comes and the
-# record is set, we set the last request time inside it's scoped session to
+# record is set, we set the last request time inside its scoped session to
 # verify timeout in the following request.
 Warden::Manager.after_set_user do |record, warden, options|
   scope = options[:scope]

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -29,7 +29,7 @@ module Devise
         after_create  :send_confirmation_instructions, :if => :confirmation_required?
       end
 
-      # Confirm a user by setting it's confirmed_at to actual time. If the user
+      # Confirm a user by setting its confirmed_at to actual time. If the user
       # is already confirmed, add en error to email field
       def confirm!
         unless_confirmed do
@@ -133,7 +133,7 @@ module Devise
         end
 
       module ClassMethods
-        # Attempt to find a user by it's email. If a record is found, send new
+        # Attempt to find a user by its email. If a record is found, send new
         # confirmation instructions to it. If not user is found, returns a new user
         # with an email not found error.
         # Options must contain the user email
@@ -143,7 +143,7 @@ module Devise
           confirmable
         end
 
-        # Find a user by it's confirmation token and try to confirm it.
+        # Find a user by its confirmation token and try to confirm it.
         # If no user is found, returns a new user with an error.
         # If the user is already confirmed, create an error for the user
         # Options must have the confirmation_token

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -3,7 +3,7 @@ module Devise
     # Handles blocking a user access after a certain number of attempts.
     # Lockable accepts two different strategies to unlock a user after it's
     # blocked: email and time. The former will send an email to the user when
-    # the lock happens, containing a link to unlock it's account. The second
+    # the lock happens, containing a link to unlock its account. The second
     # will unlock the user automatically after some configured time (ie 2.hours).
     # It's also possible to setup lockable to use both email and time strategies.
     #
@@ -22,7 +22,7 @@ module Devise
 
       delegate :lock_strategy_enabled?, :unlock_strategy_enabled?, :to => "self.class"
 
-      # Lock a user setting it's locked_at to actual time.
+      # Lock a user setting its locked_at to actual time.
       def lock_access!
         self.locked_at = Time.now
 
@@ -132,7 +132,7 @@ module Devise
         end
 
       module ClassMethods
-        # Attempt to find a user by it's email. If a record is found, send new
+        # Attempt to find a user by its email. If a record is found, send new
         # unlock instructions to it. If not user is found, returns a new user
         # with an email not found error.
         # Options must contain the user email
@@ -142,7 +142,7 @@ module Devise
          lockable
         end
 
-        # Find a user by it's unlock token and try to unlock it.
+        # Find a user by its unlock token and try to unlock it.
         # If no user is found, returns a new user with an error.
         # If the user is not locked, creates an error for the user
         # Options must have the unlock_token

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -97,7 +97,7 @@ module Devise
         end
 
       module ClassMethods
-        # Attempt to find a user by it's email. If a record is found, send new
+        # Attempt to find a user by its email. If a record is found, send new
         # password instructions to it. If not user is found, returns a new user
         # with an email not found error.
         # Attributes must contain the user email
@@ -112,7 +112,7 @@ module Devise
           generate_token(:reset_password_token)
         end
 
-        # Attempt to find a user by it's reset_password_token to reset its
+        # Attempt to find a user by its reset_password_token to reset its
         # password. If a user is found and token is still valid, reset its password and automatically
         # try saving the record. If not user is found, returns a new user
         # containing an error in reset_password_token attribute.

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -2,7 +2,7 @@ module Devise
   module Models
     # Validatable creates all needed validations for a user email and password.
     # It's optional, given you may want to create the validations by yourself.
-    # Automatically validate if the email is present, unique and it's format is
+    # Automatically validate if the email is present, unique and its format is
     # valid. Also tests presence of password, confirmation and length.
     #
     # == Options

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -73,7 +73,7 @@ class LockTest < ActionController::IntegrationTest
     assert_not user.reload.access_locked?
   end
 
-  test "sign in user automatically after unlocking it's account" do
+  test "sign in user automatically after unlocking its account" do
     user = create_user(:locked => true)
     visit_user_unlock_with_token(user.unlock_token)
     assert warden.authenticated?(:user)

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -174,7 +174,7 @@ class PasswordTest < ActionController::IntegrationTest
     assert warden.authenticated?(:user)
   end
 
-  test 'does not sign in user automatically after changing its password if its locked' do
+  test 'does not sign in user automatically after changing its password if it\'s locked' do
     user = create_user(:locked => true)
     request_forgot_password
     reset_password :reset_password_token => user.reload.reset_password_token
@@ -183,7 +183,7 @@ class PasswordTest < ActionController::IntegrationTest
     assert !warden.authenticated?(:user)
   end
 
-  test 'sign in user automatically and confirm after changing its password if its not confirmed' do
+  test 'sign in user automatically and confirm after changing its password if it\'s not confirmed' do
     user = create_user(:confirm => false)
     request_forgot_password
     reset_password :reset_password_token => user.reload.reset_password_token

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -87,7 +87,7 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too long (maximum is 128 characters)', user.errors[:password].join
   end
 
-  test 'should not require password length when its not changed' do
+  test 'should not require password length when it\'s not changed' do
     user = create_user.reload
     user.password = user.password_confirmation = nil
     assert user.valid?


### PR DESCRIPTION
Both “its” and “it’s” was being used erroneously in the documentation and the test case titles. Read more here: http://theoatmeal.com/comics/apostrophe
