### PR TITLE
Allow to set default 'from' header of Devise mails in custom mailer class

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -50,7 +50,9 @@ module Devise
       end
 
       def mailer_sender(mapping)
-        if Devise.mailer_sender.is_a?(Proc)
+        if default_params[:from].present?
+          default_params[:from]
+        elsif Devise.mailer_sender.is_a?(Proc)
           Devise.mailer_sender.call(mapping.name)
         else
           Devise.mailer_sender

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -2,7 +2,8 @@
 # four configuration values can also be set straight in your models.
 Devise.setup do |config|
   # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in DeviseMailer.
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -4,6 +4,7 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
 
   def setup
     setup_mailer
+    Devise.mailer = 'Devise::Mailer'
     Devise.mailer_sender = 'test@example.com'
   end
 
@@ -33,6 +34,11 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
 
   test 'setup sender from configuration' do
     assert_equal ['test@example.com'], mail.from
+  end
+
+  test 'setup sender from custom mailer defaults' do
+    Devise.mailer = 'Users::Mailer'
+    assert_equal ['custom@example.com'], mail.from
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -4,6 +4,7 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
 
   def setup
     setup_mailer
+    Devise.mailer = 'Devise::Mailer'
     Devise.mailer_sender = 'test@example.com'
   end
 
@@ -36,6 +37,11 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
 
   test 'setup sender from configuration' do
     assert_equal ['test@example.com'], mail.from
+  end
+
+  test 'setup sender from custom mailer defaults' do
+    Devise.mailer = 'Users::Mailer'
+    assert_equal ['custom@example.com'], mail.from
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -4,6 +4,7 @@ class UnlockInstructionsTest < ActionMailer::TestCase
 
   def setup
     setup_mailer
+    Devise.mailer = 'Devise::Mailer'
     Devise.mailer_sender = 'test@example.com'
   end
 
@@ -36,6 +37,11 @@ class UnlockInstructionsTest < ActionMailer::TestCase
 
   test 'setup sender from configuration' do
     assert_equal ['test@example.com'], mail.from
+  end
+
+  test 'setup sender from custom mailer defaults' do
+    Devise.mailer = 'Users::Mailer'
+    assert_equal ['custom@example.com'], mail.from
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/rails_app/app/mailers/users/mailer.rb
+++ b/test/rails_app/app/mailers/users/mailer.rb
@@ -1,0 +1,3 @@
+class Users::Mailer < Devise::Mailer
+  default :from => 'custom@example.com'
+end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -2,7 +2,8 @@
 # four configuration values can also be set straight in your models.
 Devise.setup do |config|
   # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in DeviseMailer.
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = "please-change-me@config-initializers-devise.com"
 
   # Configure the class responsible to send e-mails.


### PR DESCRIPTION
In my app I have my custom mailer class, which inherits Devise::Mailer class:

```
 class Users::Mailer < Devise::Mailer
  default from: 'custom@email.com'
  def some_additional_mail
    ...
  end
end
```

And I noticed that Devise, for its mails, overwrites my default "from" header by email address from Devise initializer config. I think that more sensible approach is to allow to set default headers, such as from, by custom mailer class, if somebody is using such.

So I've changed it in Devise, that if there is defined default "from" header, then use it, otherwise use mailer_sender from Devise initializer config.
