### PR TITLE
Implement #1306.

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -32,7 +32,8 @@ class Devise::PasswordsController < ApplicationController
     self.resource = resource_class.reset_password_by_token(params[resource_name])
 
     if resource.errors.empty?
-      set_flash_message(:notice, :updated) if is_navigational_format?
+      flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
+      set_flash_message(:notice, flash_message) if is_navigational_format?
       sign_in(resource_name, resource)
       respond_with resource, :location => redirect_location(resource_name, resource)
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
     passwords:
       send_instructions: 'You will receive an email with instructions about how to reset your password in a few minutes.'
       updated: 'Your password was changed successfully. You are now signed in.'
+      updated_not_active: 'Your password was changed successfully.'
       send_paranoid_instructions: "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
     confirmations:
       send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -147,7 +147,7 @@ class PasswordTest < ActionController::IntegrationTest
     reset_password :reset_password_token => user.reload.reset_password_token
 
     assert_current_url '/'
-    assert_contain 'Your password was changed successfully.'
+    assert_contain 'Your password was changed successfully. You are now signed in.'
     assert user.reload.valid_password?('987654321')
   end
 
@@ -179,6 +179,8 @@ class PasswordTest < ActionController::IntegrationTest
     request_forgot_password
     reset_password :reset_password_token => user.reload.reset_password_token
 
+    assert_contain 'Your password was changed successfully.'
+    assert_not_contain 'You are now signed in.'
     assert_equal new_user_session_path, @request.path
     assert !warden.authenticated?(:user)
   end


### PR DESCRIPTION
[Implement #1306]. After a password reset, don't show "You are now signed in." if the user can't be signed-in anyway.

The problem with this is that there will be a notice and an alert message displayed at the same time (it's a problem for us since our design is made for displaying only one message at a time). 
