### PR TITLE
Added in JSON and XML Idempotent Sign In

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Devise::SessionsController < ApplicationController
-  prepend_before_filter :require_no_authentication, :only => [ :new, :create ]
+  prepend_before_filter :require_no_authentication, :only => [ :new, :create ], :if => :deauth?
   include Devise::Controllers::InternalHelpers
 
   # GET /resource/sign_in
@@ -43,5 +43,10 @@ class Devise::SessionsController < ApplicationController
     methods << :password if resource.respond_to?(:password)
     { :methods => methods, :only => [:password] }
   end
+  
+  def deauth?
+    request.format.html?
+  end
+  
 end
 


### PR DESCRIPTION
Added in de-authenticate method that will check by default if a request is an html format and updated the filters to only de-authenticate a user if by default in that case. This will allow for JSON and XML requests to be idempotent. To try running from the terminal the following command multiple times:

``` bash
curl -b cookie -c cookie -v -H 'Accept: application/json' -H 'Content-Type: application/json' -X POST -d '{"user":{"email":"kevin@ksylvest.com","password":"password"}}' http://localhost:3000/users/sign_in.json
```
