### PR TITLE
DatabaseAuthenticatable#clean_up_passwords should set accessors to nil

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -45,7 +45,7 @@ module Devise
 
       # Set password and password confirmation to nil
       def clean_up_passwords
-        self.password = self.password_confirmation = ""
+        self.password = self.password_confirmation = nil
       end
 
       # Update record attributes when :current_password matches, otherwise returns

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -401,14 +401,14 @@ class AuthenticationOthersTest < ActionController::IntegrationTest
 
   test 'sign in stub in xml format' do
     get new_user_session_path(:format => 'xml')
-    assert_equal "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<user>\n  <email></email>\n  <password></password>\n</user>\n", response.body
+    assert_equal "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<user>\n  <email></email>\n  <password nil=\"true\"></password>\n</user>\n", response.body
   end
 
   test 'sign in stub in json format' do
     get new_user_session_path(:format => 'json')
     assert_match '{"user":{', response.body
     assert_match '"email":""', response.body
-    assert_match '"password":""', response.body
+    assert_match '"password":null', response.body
   end
 
   test 'sign in stub in json with non attribute key' do
@@ -416,7 +416,7 @@ class AuthenticationOthersTest < ActionController::IntegrationTest
       get new_user_session_path(:format => 'json')
       assert_match '{"user":{', response.body
       assert_match '"other_key":null', response.body
-      assert_match '"password":""', response.body
+      assert_match '"password":null', response.body
     end
   end
 


### PR DESCRIPTION
clean_up_passwords is setting password/password_confirmation to an empty string (despite what the comment says).

In my app, this causes update_with_password to fail on a second attempt with the validation error "password can't be blank"

e.g.

```
u = User.first
u.update_with_password(:current_password => "password", :first_name => "Bob")
 => true

u.update_with_password(:current_password => "password", :first_name => "Bob")
=> false
u.errors
=> {:password=>["can't be blank"]}
```
