### PR TITLE
cache generated url_helpers fixes #1317

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -399,8 +399,11 @@ module Devise
 
   # Regenerates url helpers considering Devise.mapping
   def self.regenerate_helpers!
-    Devise::Controllers::UrlHelpers.remove_helpers!
-    Devise::Controllers::UrlHelpers.generate_helpers!
+    @@helpers_generated ||= begin
+      Devise::Controllers::UrlHelpers.remove_helpers!
+      Devise::Controllers::UrlHelpers.generate_helpers!
+      true
+    end
   end
 
   # A method used internally to setup warden manager from the Rails initialize


### PR DESCRIPTION
This commit stops Devise.regenerate_helpers! from being called on every url_for. 
It undoes a 60% slowdown we had when upgrading to 1.4.4
