### PR TITLE
Ability to disable user ip tracking

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -220,6 +220,10 @@ module Devise
   mattr_accessor :sign_out_via
   @@sign_out_via = :get
 
+  # When set to true, user last and current IP addresses will be stored
+  mattr_accessor :track_ip
+  @@track_ip = true
+
   # PRIVATE CONFIGURATION
 
   # Store scopes mappings.

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -11,19 +11,27 @@ module Devise
     # * last_sign_in_ip    - Holds the remote ip of the previous sign in
     #
     module Trackable
+      extend ActiveSupport::Concern
+
       def update_tracked_fields!(request)
         old_current, new_current = self.current_sign_in_at, Time.now
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
-        self.last_sign_in_ip     = old_current || new_current
-        self.current_sign_in_ip  = new_current
+        if self.class.track_ip
+          old_current, new_current = self.current_sign_in_ip, request.remote_ip
+          self.last_sign_in_ip     = old_current || new_current
+          self.current_sign_in_ip  = new_current
+        end
 
         self.sign_in_count ||= 0
         self.sign_in_count += 1
 
         save(:validate => false)
+      end
+
+      module ClassMethods
+        Devise::Models.config(self, :track_ip)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -194,6 +194,9 @@ Devise.setup do |config|
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
 
+  # Whether you want to track user IP addresses
+  # config.track_ip = true
+
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -77,5 +77,16 @@ class TrackableHooksTest < ActionController::IntegrationTest
     user.reload
     assert_equal 1, user.sign_in_count
   end
+  
+  test "do not store user ip address if track_ip is false" do
+    swap Devise, :track_ip => false do
+      user = create_user
+      sign_in_as_user
+      
+      user.reload
+      assert_nil user.current_sign_in_ip
+      assert_nil user.last_sign_in_ip
+    end
+  end
 
 end


### PR DESCRIPTION
Added an option to configuration that allows to disable user ip tracking but keeps the sign in counter and timestamp fields. Sometimes there's a need to skip user ip tracking.

Disabled fields:
- last_sign_in_ip
- current_sign_in_ip
