### PR TITLE
Proposed change for paranoid mode implementation (Issue #1375)

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -12,8 +12,7 @@ class Devise::PasswordsController < ApplicationController
   def create
     self.resource = resource_class.send_reset_password_instructions(params[resource_name])
 
-    if successful_and_sane?(resource)
-      set_flash_message(:notice, :send_instructions) if is_navigational_format?
+    if successfully_sent?(resource)
       respond_with({}, :location => after_sending_reset_password_instructions_path_for(resource_name))
     else
       respond_with_navigational(resource){ render_with_scope :new }

--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -112,6 +112,20 @@ MESSAGE
           resource.errors.empty?
         end
       end
+      
+      # Helper for use after calling send_*_instructions methods on a resource. If we are in paranoid mode, we always
+      # act as if the resource was valid and instructions were sent.
+      def successfully_sent?(resource)
+        notice = if Devise.paranoid
+          :send_paranoid_instructions
+        elsif  resource.errors.empty?
+          :send_instructions
+        end
+        
+        notice.present?.tap do |success| 
+          set_flash_message :notice, notice if success && is_navigational_format?
+        end
+      end
 
       # Sets the flash message with :key, using I18n. By default you are able
       # to setup your messages using specific resource scope, and if no one is

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class PasswordsControllerTest < ActionController::TestCase
+  tests Devise::PasswordsController
+  include Devise::TestHelpers
+
+  setup :setup_for_user
+
+  test "#create" do    
+    user = User.create!(:email => 'user@example.com', :password => 'password')
+
+    post :create, :user => { :email => "user@example.com" }
+
+    assert_equal I18n.t('devise.passwords.send_instructions'), flash[:notice]
+    assert_successful_create_redirect
+    assert ActionMailer::Base.deliveries.present?
+  end
+
+  test "#create fails when no such user" do    
+    post :create, :user => { :email => "nosuchuser@example.com" }
+
+    assert_response :success
+    assert_template "devise/passwords/new"
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  test "#create when paranoid and no such user" do
+    swap Devise, :paranoid => true do
+      post :create, :user => { :email => "nosuchuser@example.com" }
+
+      assert_equal I18n.t('devise.passwords.send_paranoid_instructions'), flash[:notice]
+      assert_successful_create_redirect
+      assert ActionMailer::Base.deliveries.empty?
+    end
+  end
+
+  test "#create when paranoid and user exists" do
+    swap Devise, :paranoid => true do
+      user = User.create!(:email => 'user@example.com', :password => 'password')
+
+      post :create, :user => { :email => "user@example.com" }
+
+      assert_equal I18n.t('devise.passwords.send_paranoid_instructions'), flash[:notice]
+      assert_successful_create_redirect
+      assert ActionMailer::Base.deliveries.present?
+    end
+  end
+  
+  protected
+
+  def setup_for_user
+    ActionMailer::Base.deliveries = []
+    request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+  
+  def assert_successful_create_redirect
+    assert_redirected_to @controller.send(:after_sending_reset_password_instructions_path_for, :user)
+  end
+
+end

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -208,6 +208,15 @@ class PasswordTest < ActionController::IntegrationTest
     assert response.body.include? %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<errors>)
   end
 
+  test 'reset password request with invalid E-Mail in XML format should return empty and valid response' do
+    swap Devise, :paranoid => true do
+      create_user
+      post user_password_path(:format => 'xml'), :user => {:email => "invalid@test.com"}
+      assert_response :success
+      assert_equal response.body, { }.to_xml
+    end
+  end
+
   test 'change password with valid parameters in XML format should return valid response' do
     user = create_user
     request_forgot_password
@@ -250,7 +259,7 @@ class PasswordTest < ActionController::IntegrationTest
       assert_not_contain "1 error prohibited this user from being saved:"
       assert_not_contain "Email not found"
       assert_contain "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
-      assert_current_url "/users/password"
+      assert_current_url "/users/sign_in"
     end
   end
 
@@ -262,7 +271,7 @@ class PasswordTest < ActionController::IntegrationTest
       click_button 'Send me reset password instructions'
 
       assert_contain "If your e-mail exists on our database, you will receive a password recovery link on your e-mail"
-      assert_current_url "/users/password"
+      assert_current_url "/users/sign_in"
     end
   end
 end


### PR DESCRIPTION
Hi Jose and Devise team,

I've implemented some proposed changes in the PasswordsController only.  If the approach looks got to you guys, I can additionally commit the following changes:
- Make the same change in UnlocksController and ConfirmationsController (only other places this logic appears)
- Remove successful_and_sane? from internal_helpers (replaced by successfully_sent?)
- Update the appropriate integration tests

Before I realized that integration/recoverable_test.rb was testing this logic, I created a PasswordsControllerTest to develop against.  I will remove that in a subsequent commit.

Thanks,
Jim 
