### PR TITLE
OmniAuth 1.0.0 stable support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,14 @@ source "http://rubygems.org"
 gemspec
 
 gem "rails", "~> 3.1.0"
-gem "oa-oauth", '~> 0.2.0', :require => "omniauth/oauth"
-gem "oa-openid", '~> 0.2.0', :require => "omniauth/openid"
-
+gem 'omniauth', '~> 1.0.0'
+gem 'omniauth-oauth2', '~> 1.0.0'
 gem "rdoc"
 
 group :test do
   gem "webrat", "0.7.2", :require => false
   gem "mocha", :require => false
+  gem 'omniauth-facebook' #, '~> 1.0.0'
 end
 
 platforms :jruby do

--- a/lib/devise/omniauth.rb
+++ b/lib/devise/omniauth.rb
@@ -1,12 +1,14 @@
 begin
-  require "omniauth/core"
+  require "omniauth"
+  require "omniauth/version"
 rescue LoadError => e
-  warn "Could not load 'omniauth/core'. Please ensure you have the oa-core gem installed and listed in your Gemfile."
+  warn "Could not load 'omniauth'. Please ensure you have the omniauth gem >= 1.0.0 installed and listed in your Gemfile."
   raise
 end
 
-unless OmniAuth.config.respond_to? :test_mode
-  raise "You are using an old OmniAuth version, please ensure you have 0.2.0.beta version or later installed."
+
+unless OmniAuth::VERSION =~ /^1\./
+  raise "You are using an old OmniAuth version, please ensure you have 1.0.0 version or later installed."
 end
 
 # Clean up the default path_prefix. It will be automatically set by Devise.

--- a/lib/devise/omniauth/config.rb
+++ b/lib/devise/omniauth/config.rb
@@ -2,22 +2,44 @@ module Devise
   module OmniAuth
     class Config
       attr_accessor :strategy
-      attr_reader :args
+      attr_reader :args, :options, :provider
 
       def initialize(provider, args)
         @provider = provider
         @args     = args
         @strategy = nil
+        @options = @args.last.is_a?(Hash) ? @args.last : {}
       end
 
       # open_id strategy can have configurable name
       def strategy_name
-        options = @args.last.is_a?(Hash) && @args.last
-        options && options[:name] ? options[:name] : @provider
+        options[:name] || @provider
       end
 
       def strategy_class
-        ::OmniAuth::Strategies.const_get("#{::OmniAuth::Utils.camelize(@provider.to_s)}")
+        find_strategy || require_strategy
+      end
+
+      def find_strategy
+        ::OmniAuth.strategies.find do |strategy_class|
+          strategy_class.to_s =~ /#{::OmniAuth::Utils.camelize(strategy_name)}$/ ||
+            strategy_class.default_options[:name] == strategy_name
+        end
+      end
+
+      def require_strategy
+        if [:facebook, :github, :twitter].include?(provider.to_sym)
+          require "omniauth/strategies/#{provider}"
+        elsif options[:require]
+          require options[:require]
+        else
+          require "omniauth-#{provider}"
+        end
+        find_strategy || autoload_strategy
+      end
+
+      def autoload_strategy
+        ::OmniAuth::Strategies.const_get(::OmniAuth::Utils.camelize(provider.to_s))
       end
     end
   end

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -12,14 +12,6 @@ class OmniauthableIntegrationTest < ActionController::IntegrationTest
 
   setup do
     OmniAuth.config.test_mode = true
-    stub_facebook!
-  end
-
-  teardown do
-    OmniAuth.config.test_mode = false
-  end
-
-  def stub_facebook!
     OmniAuth.config.mock_auth[:facebook] = {
       "uid" => '12345',
       "provider" => 'facebook',
@@ -27,6 +19,10 @@ class OmniauthableIntegrationTest < ActionController::IntegrationTest
       "credentials" => {"token" => 'plataformatec'},
       "extra" => {"user_hash" => FACEBOOK_INFO}
     }
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
   end
 
   def stub_action!(name)
@@ -128,7 +124,7 @@ class OmniauthableIntegrationTest < ActionController::IntegrationTest
     OmniAuth.config.mock_auth[:facebook] = :invalid_credentials
 
     visit "/users/sign_in"
-    click_link "Sign in with facebook"
+    click_link "Sign in with Facebook"
 
     assert_current_url "/users/sign_in"
     assert_contain 'Could not authorize you from Facebook because "Invalid credentials".'

--- a/test/omniauth/config_test.rb
+++ b/test/omniauth/config_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class OmniAuthConfigTest < ActiveSupport::TestCase
+  def self.context(name, &block)
+    instance_eval(&block)
+  end
+
+  setup do
+    $: << File.dirname(__FILE__)
+  end
+
+  context 'Devise::OmniAuth::Config#strategy_name' do
+    test 'returns provider if no options given' do
+      config = Devise::OmniAuth::Config.new :facebook, [{}]
+      assert_equal :facebook, config.strategy_name
+    end
+    test 'returns provider if no name option given' do
+      config = Devise::OmniAuth::Config.new :facebook, [{ :other => :option }]
+      assert_equal :facebook, config.strategy_name
+    end
+    test 'returns name option' do
+      config = Devise::OmniAuth::Config.new :facebook, [{ :name => :github }]
+      assert_equal :github, config.strategy_name
+    end
+  end
+
+  context 'Devise::OmniAuth::Config#strategy_class' do
+    test "finds contrib strategies" do
+      config = Devise::OmniAuth::Config.new :facebook, [{}]
+      assert_equal OmniAuth::Strategies::Facebook, config.strategy_class
+    end
+    test "finds the strategy in OmniAuth's list by name" do
+      NamedTestStrategy = Class.new
+      NamedTestStrategy.send :include, OmniAuth::Strategy
+      NamedTestStrategy.option :name, :the_one
+
+      config = Devise::OmniAuth::Config.new :the_one, [{}]
+      assert_equal NamedTestStrategy, config.strategy_class
+    end
+    test "finds the strategy in OmniAuth's list by class name" do
+      UnNamedTestStrategy = Class.new
+      UnNamedTestStrategy.send :include, OmniAuth::Strategy
+
+      config = Devise::OmniAuth::Config.new :un_named_test_strategy, [{}]
+      assert_equal UnNamedTestStrategy, config.strategy_class
+    end
+    test 'attempts to load an as-yet not loaded plugin' do
+      config = Devise::OmniAuth::Config.new :my_strategy, [{}]
+      config_class = config.strategy_class
+      assert_equal MyStrategy, config_class
+    end
+    test 'allows the user to define a custom require path' do
+      config = Devise::OmniAuth::Config.new :my_other_strategy, [{:require => 'my_other_strategy'}]
+      config_class = config.strategy_class
+      assert_equal MyOtherStrategy, config_class
+    end
+  end
+end

--- a/test/omniauth/my_other_strategy.rb
+++ b/test/omniauth/my_other_strategy.rb
@@ -1,0 +1,5 @@
+require 'omniauth'
+
+class MyOtherStrategy
+  include OmniAuth::Strategy
+end

--- a/test/omniauth/omniauth-my_strategy.rb
+++ b/test/omniauth/omniauth-my_strategy.rb
@@ -1,0 +1,5 @@
+require 'omniauth'
+
+class MyStrategy
+  include OmniAuth::Strategy
+end

--- a/test/omniauth/url_helpers_test.rb
+++ b/test/omniauth/url_helpers_test.rb
@@ -28,25 +28,25 @@ class OmniAuthRoutesTest < ActionController::TestCase
   end
 
   test 'should generate authorization path' do
-    assert_match "/users/auth/facebook", @controller.omniauth_authorize_path(:user, :facebook)
+    assert_match '/users/auth/facebook', @controller.send(:omniauth_authorize_path, :user, :facebook)
 
     assert_raise ArgumentError do
       @controller.omniauth_authorize_path(:user, :github)
     end
   end
 
-  test 'should generate authorization path for named open_id omniauth' do
-    assert_match "/users/auth/google", @controller.omniauth_authorize_path(:user, :google)
+  test 'should generate authorization path for named omniauth' do
+    assert_match "/users/auth/other_facebook", @controller.send(:omniauth_authorize_path, :user, :other_facebook)
   end
 
   test 'should generate authorization path with params' do
-    assert_match "/users/auth/open_id?openid_url=http%3A%2F%2Fyahoo.com",
-                  @controller.omniauth_authorize_path(:user, :open_id, :openid_url => "http://yahoo.com")
+    assert_match "/users/auth/other_facebook?openid_url=http%3A%2F%2Fyahoo.com",
+                  @controller.send(:omniauth_authorize_path, :user, :other_facebook, :openid_url => "http://yahoo.com")
   end
 
   test 'should not add a "?" if no param was sent' do
-    assert_equal "/users/auth/open_id",
-                  @controller.omniauth_authorize_path(:user, :open_id)
+    assert_equal "/users/auth/other_facebook",
+                  @controller.send(:omniauth_authorize_path, :user, :other_facebook)
   end
 
   test 'should set script name in the path if present' do

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -176,9 +176,8 @@ Devise.setup do |config|
   # config.sign_out_via = :get
 
   # ==> OmniAuth
-  config.omniauth :facebook, 'APP_ID', 'APP_SECRET', :scope => 'email,offline_access'
-  config.omniauth :open_id
-  config.omniauth :open_id, :name => 'google', :identifier => 'https://www.google.com/accounts/o8/id'
+  config.omniauth :facebook, 'APP_ID', 'APP_SECRET'
+  config.omniauth :facebook, 'APP_ID', 'APP_SECRET', :name => 'other_facebook'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -96,10 +96,10 @@ class DefaultRoutingTest < ActionController::TestCase
     assert_recognizes({:controller => 'users/omniauth_callbacks', :action => 'facebook'}, {:path => 'users/auth/facebook/callback', :method => :post})
     assert_named_route "/users/auth/facebook/callback", :user_omniauth_callback_path, :facebook
 
-    # named open_id
-    assert_recognizes({:controller => 'users/omniauth_callbacks', :action => 'google'}, {:path => 'users/auth/google/callback', :method => :get})
-    assert_recognizes({:controller => 'users/omniauth_callbacks', :action => 'google'}, {:path => 'users/auth/google/callback', :method => :post})
-    assert_named_route "/users/auth/google/callback", :user_omniauth_callback_path, :google
+    # named strategy
+    assert_recognizes({:controller => 'users/omniauth_callbacks', :action => 'other_facebook'}, {:path => 'users/auth/other_facebook/callback', :method => :get})
+    assert_recognizes({:controller => 'users/omniauth_callbacks', :action => 'other_facebook'}, {:path => 'users/auth/other_facebook/callback', :method => :post})
+    assert_named_route "/users/auth/other_facebook/callback", :user_omniauth_callback_path, :other_facebook
 
     assert_raise ActionController::RoutingError do
       assert_recognizes({:controller => 'ysers/omniauth_callbacks', :action => 'twitter'}, {:path => 'users/auth/twitter/callback', :method => :get})


### PR DESCRIPTION
I'm newbie at Github and don't sure that i do right.
I don't found any way update an existing pool rquest for OmniAuth 1.0.0 support. Please review my new pool request please.

rake test results of devise gem
636 tests, 1568 assertions, 0 failures, 0 errors, 0 skips
