### PR TITLE
Allow specifying a resource_return_to for sign out

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -21,13 +21,14 @@ class Devise::SessionsController < ApplicationController
   # DELETE /resource/sign_out
   def destroy
     signed_in = signed_in?(resource_name)
+    redirect_path = after_sign_out_path_for(resource_name)
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message :notice, :signed_out if signed_in
 
     # We actually need to hardcode this, as Rails default responder doesn't
     # support returning empty response on GET request
     respond_to do |format|
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to redirect_path }
       format.all do
         method = "to_#{request_format}"
         text = {}.respond_to?(method) ? {}.send(method) : ""

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -207,9 +207,10 @@ module Devise
       # scope. Notice that differently from +after_sign_in_path_for+ this method
       # receives a symbol with the scope, and not the resource.
       #
-      # By default is the root_path.
+      # By default, it first tries to find a valid resource_return_to key in the
+      # session, then it fallbacks to root_path.
       def after_sign_out_path_for(resource_or_scope)
-        root_path
+        stored_location_for(resource_or_scope) || root_path
       end
 
       # Sign in a user and tries to redirect first to the stored location and
@@ -236,8 +237,9 @@ module Devise
       # after_sign_out_path_for.
       def sign_out_and_redirect(resource_or_scope)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
+        redirect_path = after_sign_out_path_for(scope)
         Devise.sign_out_all_scopes ? sign_out : sign_out(scope)
-        redirect_to after_sign_out_path_for(scope)
+        redirect_to redirect_path
       end
 
       # Overwrite Rails' handle unverified request to sign out all scopes,

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -248,6 +248,16 @@ class ControllerAuthenticatableTest < ActionController::TestCase
     end
   end
 
+  test 'sign out and redirect uses the stored location when signing out' do
+    swap Devise, :sign_out_all_scopes => true do
+      @mock_warden.expects(:user).times(Devise.mappings.size)
+      @mock_warden.expects(:logout).with().returns(true)
+      @controller.expects(:redirect_to).with("/foo.bar")
+      @controller.session[:"admin_return_to"] = "/foo.bar"
+      @controller.sign_out_and_redirect(:admin)
+    end
+  end
+
   test 'is not a devise controller' do
     assert_not @controller.devise_controller?
   end


### PR DESCRIPTION
It was impossible to accomplish this by providing a
custom #after_sign_out_path_for in ApplicationController because the
session gets destroyed before it is called. Furthermore,
resource_return_to is now used by default if it exists, so users won't
have to provide a custom #after_sign_out_path_for in that case.

Note: I couldn't quite figure out how to add a test for this in test/integration/authenticatable_test.rb.
