### PR TITLE
fixed require for google_oauth2 strategy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rdoc"
 group :test do
   gem 'omniauth-facebook'
   gem 'omniauth-openid', '~> 1.0.1'
+  gem "omniauth-google-oauth2", '~> 0.1.4'
   gem "webrat", "0.7.2", :require => false
   gem "mocha", :require => false
 end

--- a/lib/devise/omniauth/config.rb
+++ b/lib/devise/omniauth/config.rb
@@ -28,7 +28,7 @@ module Devise
       end
 
       def require_strategy
-        if [:facebook, :github, :twitter].include?(provider.to_sym)
+        if [:facebook, :github, :twitter, :google_oauth2].include?(provider.to_sym)
           require "omniauth/strategies/#{provider}"
         elsif options[:require]
           require options[:require]

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -179,7 +179,7 @@ Devise.setup do |config|
   config.omniauth :facebook, 'APP_ID', 'APP_SECRET', :scope => 'email,offline_access'
   config.omniauth :openid
   config.omniauth :openid, :name => 'google', :identifier => 'https://www.google.com/accounts/o8/id'
-
+  config.omniauth :google_oauth2, 'APP_ID', 'APP_SECRET', :scope => 'https://www.googleapis.com/auth/userinfo.email'
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.


### PR DESCRIPTION
When including google_oauth2 strategy i ran into the error that the strategy could not be found. 

Fixed that. 
