### PR TITLE
Update devise.gemspec

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = "contact@plataformatec.com.br"
   s.homepage    = "http://github.com/plataformatec/devise"
   s.description = "Flexible authentication solution for Rails with Warden"
-  s.authors     = ['José Valim', 'Carlos Antônio']
+  s.authors     = ['Jose Valim', 'Carlos Antonio'] # accented name causes "ArgumentError: invalid byte sequence in US-ASCII"
 
   s.rubyforge_project = "devise"
 


### PR DESCRIPTION
Accented characters cause error "ArgumentError: invalid byte sequence in US-ASCII"
They definitely are the correct way of writing names with all dignity but I believe "large scale acceptance" of the solution here should have higher priority, if I may.
