### PR TITLE
Adding reminder to restart server in the installation guide

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -88,7 +88,7 @@ The generator will install an initializer which describes ALL Devise's configura
 
   rails generate devise MODEL
 
-Replace MODEL by the class name used for the applications users, it's frequently 'User' but could also be 'Admin'. This will create a model (if one does not exist) and configure it with default Devise modules. Next, you'll usually run db:migrate as the generator will have created a migration file (if your ORM supports them). This generator also configures your config/routes.rb file, continue reading this file to understand exactly what the generator produces and how to use it.
+Replace MODEL by the class name used for the applications users, it's frequently 'User' but could also be 'Admin'. This will create a model (if one does not exist) and configure it with default Devise modules. Next, you'll usually run db:migrate as the generator will have created a migration file (if your ORM supports them). This generator also configures your config/routes.rb file, continue reading this file to understand exactly what the generator produces and how to use it. Finally, if your server was already running, then restart it as Rails doesn't automatically load methods from a new gem.
 
 Support for Rails 2.3.x can be found by installing Devise 1.0.x from the v1.0 branch.
 


### PR DESCRIPTION
I ran into a small problem after installing devise, an error saying "undefined method `devise_for'..." - turns out I simply needed to restart the server as Rails does not load new methods from a gem automatically.
