### PR TITLE
Added support for rails 3.1 new mass assignment conventions

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -51,7 +51,8 @@ module Devise
       # Update record attributes when :current_password matches, otherwise returns
       # error on :current_password. It also automatically rejects :password and
       # :password_confirmation if they are blank.
-      def update_with_password(params={})
+      def update_with_password(params, *options)
+        as = options.first[:as] rescue nil
         current_password = params.delete(:current_password)
 
         if params[:password].blank?
@@ -60,7 +61,7 @@ module Devise
         end
 
         result = if valid_password?(current_password)
-          update_attributes(params)
+          update_attributes(params, :as => as)
         else
           self.attributes = params
           self.valid?
@@ -84,11 +85,13 @@ module Devise
       #     super(params)
       #   end
       #
-      def update_without_password(params={})
+      def update_without_password(params, *options)
+        as = options.first[:as] rescue nil
+        
         params.delete(:password)
         params.delete(:password_confirmation)
 
-        result = update_attributes(params)
+        result = update_attributes(params, :as => as)
         clean_up_passwords
         result
       end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -87,6 +87,13 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert user.reload.valid_password?('pass321')
   end
   
+  test 'should update password with valid current password and :as option' do
+    user = create_user
+    assert user.update_with_password(:current_password => '123456',
+      :password => 'pass321', :password_confirmation => 'pass321', :as => :admin)
+    assert user.reload.valid_password?('pass321')
+  end
+  
   test 'should add an error to current password when it is invalid' do
     user = create_user
     assert_not user.update_with_password(:current_password => 'other',
@@ -136,6 +143,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   test 'should update the user without password' do
     user = create_user
     user.update_without_password(:email => 'new@example.com')
+    assert_equal 'new@example.com', user.email
+  end
+  
+  test 'should update the user without password with :as option' do
+    user = create_user
+    user.update_without_password(:email => 'new@example.com', :as => :admin)
     assert_equal 'new@example.com', user.email
   end
 


### PR DESCRIPTION
With this pull request you are able to call `update_without_password` and `update_with_password` methods with `:as` option. This new feature of Rails 3.1 is described [here](http://www.enlightsolutions.com/articles/whats-new-in-edge-scoped-mass-assignment-in-rails-3-1/)
