### PR TITLE
remember_me breaks if you are using a non-default scope name for a model

### DIFF
--- a/lib/devise/controllers/rememberable.rb
+++ b/lib/devise/controllers/rememberable.rb
@@ -20,8 +20,8 @@ module Devise
       end
 
       # Remembers the given resource by setting up a cookie
-      def remember_me(resource)
-        scope = Devise::Mapping.find_scope!(resource)
+      def remember_me(resource, options = {})
+        scope = options[:scope] || Devise::Mapping.find_scope!(resource)
         resource.remember_me!(resource.extend_remember_period)
         cookies.signed["remember_#{scope}_token"] = remember_cookie_values(resource)
       end

--- a/lib/devise/hooks/rememberable.rb
+++ b/lib/devise/hooks/rememberable.rb
@@ -1,6 +1,6 @@
 Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
   scope = options[:scope]
   if record.respond_to?(:remember_me) && record.remember_me && warden.authenticated?(scope)
-    Devise::Controllers::Rememberable::Proxy.new(warden).remember_me(record)
+    Devise::Controllers::Rememberable::Proxy.new(warden).remember_me(record, :scope => scope)
   end
 end


### PR DESCRIPTION
the remember_me functionality would break because the remember_X_token
would not be named properly

for instance, if you are authenticating a User, but using the scope 'mobile_user',
the remember token would (incorrectly) be set to remember_user_token, meaning
that the cookie would not be used and breaking the remember me functionality
