### PR TITLE
Don't pass on non-hash parameters.

### DIFF
--- a/lib/devise/controllers/internal_helpers.rb
+++ b/lib/devise/controllers/internal_helpers.rb
@@ -83,6 +83,7 @@ MESSAGE
       # Build a devise resource.
       def build_resource(hash=nil)
         hash ||= params[resource_name] || {}
+        hash = {} unless hash.is_a?(Hash)
         self.resource = resource_class.new(hash)
       end
 


### PR DESCRIPTION
A user or attacker attempts, for example:

```
curl -G -d 'user=a_string' http://localhost:3000/users/sign_in
```

Currently an exception will be thrown, because you can't call `stringify_keys` on a `String` type. Patch checks that `param[:user]` is a `Hash`, or falls back to an empty hash.
