### PR TITLE
Allow users to update non-password account attributes without their current password

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -40,7 +40,12 @@ class Devise::RegistrationsController < ApplicationController
   def update
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
 
-    if resource.update_with_password(params[resource_name])
+    any_passwords = %w(password password_confirmation current_password).any? do |field|
+      params[resource_name][field].present?
+    end
+    update_method = any_passwords ? :update_with_password : :update_without_password
+
+    if resource.send(update_method, params[resource_name])
       set_flash_message :notice, :updated if is_navigational_format?
       sign_in resource_name, resource, :bypass => true
       respond_with resource, :location => after_update_path_for(resource)

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -144,7 +144,6 @@ class RegistrationTest < ActionController::IntegrationTest
     get edit_user_registration_path
 
     fill_in 'email', :with => 'user.new@example.com'
-    fill_in 'current password', :with => '123456'
     click_button 'Update'
 
     assert_current_url '/'


### PR DESCRIPTION
A user should be able to update non-password account attributes (such as username or any other developer-added attributes to their Devise user model) without using their current password.

This is a standard practice on plenty of websites, and I believe this is a common enough use case that Devise should support it out-of-the-box.
