### PR TITLE
Fix taking associated failure app from the scope in the given env.

### DIFF
--- a/lib/devise/delegator.rb
+++ b/lib/devise/delegator.rb
@@ -8,7 +8,7 @@ module Devise
     def failure_app(env)
       app = env["warden.options"] &&
         (scope = env["warden.options"][:scope]) &&
-        Devise.mappings[scope].failure_app
+        Devise.mappings[scope.to_sym].failure_app
 
       app || Devise::FailureApp
     end

--- a/test/delegator_test.rb
+++ b/test/delegator_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class DelegatorTest < ActiveSupport::TestCase
+  def delegator
+    Devise::Delegator.new
+  end
+
+  test 'failure_app returns default failure app if no warden options in env' do
+    assert_equal Devise::FailureApp, delegator.failure_app({})
+  end
+
+  test 'failure_app returns default failure app if no scope in warden options' do
+    assert_equal Devise::FailureApp, delegator.failure_app({"warden.options" => {}})
+  end
+
+  test 'failure_app returns associated failure app by scope in the given environment' do
+    assert_kind_of Proc, delegator.failure_app({"warden.options" => {:scope => "manager"}})
+  end
+end


### PR DESCRIPTION
There is a delegator to get failure app, introduced in 4629bee and tuned in 24b26026. The latter commit introduced a bit of logic, however, no tests are included into commit. Needless to say this resulted in a
broken code.

The point is that `env["warden.options"][:scope]` returns a string. However, `Devise.mappings` is a hash with symbol keys.

Adding tests and converting scope to symbol here.

I couldn't find the way to create and push the scope to use in the last test, so injecting a local variable here. @josevalim, please, help me with the last test.

This bug for me is a blocker to use Devise >= 1.5.
