### PR TITLE
Add dependency status to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 == Devise
 
-{<img src="https://secure.travis-ci.org/plataformatec/devise.png" />}[http://travis-ci.org/plataformatec/devise]
+{<img src="https://secure.travis-ci.org/plataformatec/devise.png" />}[http://travis-ci.org/plataformatec/devise] {<img src="https://gemnasium.com/plataformatec/devise.png?travis" />}[https://gemnasium.com/plataformatec/devise.png]
 
 Devise is a flexible authentication solution for Rails based on Warden. It:
 


### PR DESCRIPTION
This is a good way to keep up on your gem dependencies' versions. These status images are popping up on gems like rails, twitter, omniauth, etc.
