### PR TITLE
Move "include Devise::Models::Authenticatable" inside devise_modules_hook! call

### DIFF
--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -48,7 +48,6 @@ module Devise
     # for a complete description on those values.
     #
     def devise(*modules)
-      include Devise::Models::Authenticatable
       options = modules.extract_options!.dup
 
       selected_modules = modules.map(&:to_sym).uniq.sort_by do |s|
@@ -56,6 +55,7 @@ module Devise
       end
 
       devise_modules_hook! do
+        include Devise::Models::Authenticatable
         selected_modules.each do |m|
           mod = Devise::Models.const_get(m.to_s.classify)
 


### PR DESCRIPTION
Allow alternate ORMs to run compatibility setup code before Authenticatable is included.

The particular issue for dm-devise is that DataMapper does not have a before_validation method, which is called when Authenticatable is included (as of plataformatec/devise@bd27bf76). dm-devise adds before_validation in it's devise_modules_hook!

I don't see any obvious reason that this would break anything. ActiveRecord and DataMapper tests pass (I haven't tried with mongoid)
