### PR TITLE
Fix for a bug: Incorrect message for locked account

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -79,7 +79,7 @@ module Devise
         # if the user can login or not (wrong password, etc)
         unlock_access! if lock_expired?
 
-        if super
+        if super && !access_locked?
           self.failed_attempts = 0
           save(:validate => false)
           true

--- a/test/models/lockable_test.rb
+++ b/test/models/lockable_test.rb
@@ -23,6 +23,19 @@ class LockableTest < ActiveSupport::TestCase
     assert_equal 0, user.reload.failed_attempts
   end
 
+  test "should increment failed_attempts on successfull validation if the user is already locked" do
+    user = create_user
+    user.confirm!
+
+    swap Devise, :maximum_attempts => 2 do
+      3.times { user.valid_for_authentication?{ false } }
+      assert user.reload.access_locked?
+    end
+
+    user.valid_for_authentication?{ true }
+    assert_equal 4, user.reload.failed_attempts
+  end
+
   test "should not touch failed_attempts if lock_strategy is none" do
     user = create_user
     user.confirm!


### PR DESCRIPTION
Thanks for the wonderful plugin. I encountered this issue that I could replicate in the latest code. 

If a user has already been locked and he/she tries to login with correct password again, the 'failed_attempts' count is reset to zero. Any further attempts to login with incorrect password increments the 'failed_attempts' and gives out the "Invalid username or email' message instead of the expected 'Your account has been locked' until the count exceeds the maximum attempts allowed. 
It could be so because Devise resets the 'failed_attempts' based on mainly the password validity and doesn't check for locked state. I've tried to fix the same.
