### PR TITLE
update_with_password_unchecked

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -69,6 +69,22 @@ module Devise
         clean_up_passwords
         result
       end
+      
+      # Update record attributes without checking for a :current_password match.
+      # It automatically rejects :password and :password_confirmation if they are blank.
+      # Recommended only for backend use, for example an admin can manually set a 
+      # password when creating a new user, or manually reset a password without
+      # needing to know a user's :current_password.
+      def update_with_password_unchecked(params, *options)
+        if params[:password].blank?
+          params.delete(:password)
+          params.delete(:password_confirmation) if params[:password_confirmation].blank?
+        end
+
+        result = update_attributes(params, *options)
+        clean_up_passwords
+        result
+      end
 
       # Updates record attributes without asking for the current password.
       # Never allows to change the current password. If you are using this


### PR DESCRIPTION
Hi,

I have been using Active Admin which uses Devise and to my knowledge there is no current way for an admin to set passwords for a user through the backend, as the existing method would require the admin to be aware of that user's current_password. A scenario that this does not fit is when an admin needs to create/update a client account in a CMS (whether Active Admin or another).

I have added a new method "update_with_password_unchecked" to database_authenticable.rb to address this. It is in the same style as "update_with_password" and "update_without_password". The latter is different in that it will not update the password attribute. There is a note in my method to confirm it is only recommended for backend/admin-only use.

If there is already an alternative way to do this in Devise please let me know.

Kind regards

Ben
