### PR TITLE
Bring .travis.yml up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ script: "bundle exec rake test"
 rvm:
   - 1.8.7
   - 1.9.2
+  - 1.9.3
   - ree
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br


### PR DESCRIPTION
- rbx and rbx-2.0 have both been aliases for rbx-18mode (master in 1.8 mode) for a few months now
- test against 1.9.3, too
