### PR TITLE
Allow regex to avoid string conversion for parameter filtering

### DIFF
--- a/lib/devise/param_filter.rb
+++ b/lib/devise/param_filter.rb
@@ -35,7 +35,7 @@ module Devise
 
     # Determine which values should be transformed to string or passed as-is to the query builder underneath
     def param_requires_string_conversion?(value)
-      true unless value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(Fixnum)
+      [Fixnum, TrueClass, FalseClass, Regexp].none? {|clz| value.is_a? clz }
     end
   end
 end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -28,6 +28,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_equal( { 'login' => 'foo@bar.com', "bool1" => true, "bool2" => false, "fixnum" => 123, "will_be_converted" => "1..10" }, conditions)
   end
 
+  test "param filter should not convert regular expressions to strings" do
+    conditions = { "regexp" => /expression/ }
+    conditions = Devise::ParamFilter.new([], []).filter(conditions)
+    assert_equal( { "regexp" => /expression/ }, conditions)
+  end
+
   test 'should respond to password and password confirmation' do
     user = new_user
     assert user.respond_to?(:password)


### PR DESCRIPTION
We've run into a problem where we want to do a case-insensitive username lookup. We cannot use the built-in case-insensitivity capabilities, because they do not preserve case on the username, which our customer requires.

This commit simply lets us pass a Regexp as a param filter, allowing us to implement the feature we require.
