### PR TITLE
More helpful sign-up message for Confirmable

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -18,7 +18,7 @@ class Devise::RegistrationsController < DeviseController
         sign_in(resource_name, resource)
         respond_with resource, :location => after_sign_up_path_for(resource)
       else
-        set_flash_message :notice, :inactive_signed_up, :reason => inactive_reason(resource) if is_navigational_format?
+        set_flash_message :notice, :"signed_up_but_#{inactive_reason(resource)}" if is_navigational_format?
         expire_session_data_after_sign_in!
         respond_with resource, :location => after_inactive_sign_up_path_for(resource)
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,7 +35,9 @@ en:
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
       signed_up: 'Welcome! You have signed up successfully.'
-      inactive_signed_up: 'You have signed up successfully. However, we could not sign you in because your account is %{reason}.'
+      signed_up_but_unconfirmed: 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
+      signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
+      signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'
       updated: 'You updated your account successfully.'
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -50,7 +50,7 @@ class RegistrationTest < ActionController::IntegrationTest
   test 'a guest user should be able to sign up successfully and be blocked by confirmation' do
     user_sign_up
 
-    assert_contain 'You have signed up successfully. However, we could not sign you in because your account is unconfirmed.'
+    assert_contain 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
     assert_not_contain 'You have to confirm your account before continuing'
     assert_current_url "/"
 


### PR DESCRIPTION
This is also better for translations, because we can translate paragraph-wise.

signed_up_but_inactive and signed_up_but_locked are likely not needed,
but I wasn't sure how to best remove them.

---

Can we change the locale file like this, or should we be worried about breaking compatibility?
