### PR TITLE
fix unlock message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
         locked: 'locked'
     unlocks:
       send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
-      unlocked: 'Your account was successfully unlocked. You are now signed in.'
+      unlocked: 'Your account has been unlocked successfully. Please sign in to continue.'
       send_paranoid_instructions: 'If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.'
     omniauth_callbacks:
       success: 'Successfully authorized from %{kind} account.'

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -81,7 +81,7 @@ class LockTest < ActionController::IntegrationTest
     visit_user_unlock_with_token(user.unlock_token)
 
     assert_current_url "/users/sign_in"
-    assert_contain 'Your account was successfully unlocked.'
+    assert_contain 'Your account has been unlocked successfully. Please sign in to continue.'
 
     assert_not user.reload.access_locked?
   end


### PR DESCRIPTION
As 2.0.0rc, user redirect to sign in page after unlock. So relevant message need to update also.
