### PR TITLE
Send confirmation email after_commit to avoid background jobs from trying to send email before record is created

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -31,9 +31,9 @@ module Devise
 
       included do
         before_create :generate_confirmation_token, :if => :confirmation_required?
-        after_create  :send_confirmation_instructions, :if => :confirmation_required?
         before_update :postpone_email_change_until_confirmation, :if => :postpone_email_change?
         after_update :send_confirmation_instructions, :if => :reconfirmation_required?
+        after_commit  :send_confirmation_instructions, :if => :confirmation_required?
       end
 
       # Confirm a user by setting it's confirmed_at to actual time. If the user


### PR DESCRIPTION
When delegating DeviseMailer to something like Resque, sometimes the email tries to get sent before the record has fully been created. So, changing after_create to after_commit which fixes this problem.
