### PR TITLE
Fix test behaviour for rspec subject requests

### DIFF
--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -15,9 +15,8 @@ module Devise
 
     # Override process to consider warden.
     def process(*)
-      result = nil
-      _catch_warden { result = super }
-      result
+      # Make sure we always return @response, a la ActionController::TestCase::Behaviour#process, even if warden interrupts
+      _catch_warden { super } || @response
     end
 
     # We need to setup the environment variables and the response in the controller.
@@ -66,6 +65,8 @@ module Devise
 
     protected
 
+    # Catch warden continuations and handle like the middleware would.
+    # Returns nil when interrupted, otherwise the normal result of the block.
     def _catch_warden(&block)
       result = catch(:warden, &block)
 


### PR DESCRIPTION
Consider the following rspec test, which is fairly standard:

``` ruby
class ThingsController < ActionController::Base
  before_filter :authenticate_user!
  def show; end
end

describe ThingsController, "#show" do
  subject { get :show }
  context "when not logged in" do
    it { should redirect_to new_user_session_path }
  end
end
```

This fails because when warden throws on failure, `get :show` returns `nil`. `get`/`post`/etc. return the result of `ActionController::Base#process` which is normally guaranteed to be a `Response`, but the [devise test helpers override this](https://github.com/plataformatec/devise/blob/master/lib/devise/test_helpers.rb#L17) to return `nil` on a warden failure.

This patch ensures `#process` will always return a `Response`.

Perhaps it should go further and make `#_catch_warden` return the rendered response instead of nil in the failure case?
