### PR TITLE
Fixed apply_schema warning showing when Mongoid is used

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -65,7 +65,7 @@ module Devise
             "insensitivity)\n"
         end
 
-        if Devise.apply_schema && defined?(Mongoid)
+        if Devise.apply_schema && !defined?(Mongoid)
           warn "\n[DEVISE] Devise.apply_schema is true. This means Devise was " \
             "automatically configuring your DB. This no longer happens. You should " \
             "set Devise.apply_schema to false and manually set the fields used by Devise as shown here: " \


### PR DESCRIPTION
Given https://github.com/plataformatec/devise/blob/master/lib/devise/orm/active_record.rb has the deprecation warning but Mongoid doesn't, and MongoDB doesn't have a schema to manage, shouldn't this be !defined?(Mongoid)?
