### PR TITLE
fix for when using :host in routes

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -196,7 +196,8 @@ module ActionDispatch::Routing
       options[:path_names]    = (@scope[:path_names] || {}).merge(options[:path_names] || {})
       options[:constraints]   = (@scope[:constraints] || {}).merge(options[:constraints] || {})
       options[:defaults]      = (@scope[:defaults] || {}).merge(options[:defaults] || {})
-      options[:options]       = (@scope[:options] || {}).merge({:format => false}) if options[:format] == false
+      options[:options]       = @scope[:options] || {}
+      options[:options][:format] = false if options[:format] == false
 
       resources.map!(&:to_sym)
 

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -58,6 +58,10 @@ Rails.application.routes.draw do
   # Other routes for routing_test.rb
   devise_for :reader, :class_name => "User", :only => :passwords
 
+  scope :host => "sub.example.com" do
+    devise_for :sub_admin, :class_name => "Admin"
+  end
+
   namespace :publisher, :path_names => { :sign_in => "i_dont_care", :sign_out => "get_out" } do
     devise_for :accounts, :class_name => "Admin", :path_names => { :sign_in => "get_in" }
   end

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -128,6 +128,10 @@ class CustomizedRoutingTest < ActionController::TestCase
     end
   end
 
+  test 'subdomain admin' do
+    assert_recognizes({"host"=>"sub.example.com", :controller => 'devise/sessions', :action => 'new'}, {:host => "sub.example.com", :path => '/sub_admin/sign_in', :method => :get})
+  end
+
   test 'does only map reader password' do
     assert_raise ActionController::RoutingError do
       assert_recognizes({:controller => 'devise/sessions', :action => 'new'}, 'reader/sessions/new')


### PR DESCRIPTION
fix for :host getting overwritten in scope[:options] and thus not generating URLs with correct hostnames
