### PR TITLE
updating CHANGELOG to reflect rubygems releases

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,10 +1,14 @@
-== 2.0.3
+== 2.0.4
 
 * bug fix
   * Ensure warning is not shown by mistake on apps with mounted engines
   * Fixes related to remember_token and rememberable_options
   * Ensure serializable_hash does not depend on accessible attributes
   * Ensure that timeout callback does not run on sign out action
+
+== 2.0.3
+
+* skipped
 
 == 2.0.2
 


### PR DESCRIPTION
Since we skipped 2.0.3, update CHANGELOG to reflect that. 

"Could not find devise-2.0.3 in any of the sources"
