### PR TITLE
Sketch for less intrusive use of omniauth

### DIFF
--- a/app/controllers/devise/omniauth_authorize_controller.rb
+++ b/app/controllers/devise/omniauth_authorize_controller.rb
@@ -1,0 +1,6 @@
+class Devise::OmniauthAuthorizeController < DeviseController
+  def show
+    session[:omni_devise_mapping] = resource_name
+    redirect_to "#{::OmniAuth.config.path_prefix}/#{params[:provider]}"
+  end
+end

--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Devise::OmniauthCallbacksController < DeviseController
+  after_filter :clean_session
+
   def failure
     set_flash_message :alert, :failure, :kind => failed_strategy.name.to_s.humanize, :reason => failure_message
     redirect_to after_omniauth_failure_path_for(resource_name)
@@ -20,5 +22,9 @@ class Devise::OmniauthCallbacksController < DeviseController
 
   def after_omniauth_failure_path_for(scope)
     new_session_path(scope)
+  end
+
+  def clean_session
+    session.delete(:omni_devise_mapping)
   end
 end

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -413,7 +413,6 @@ module Devise
   #   config.omniauth :github, APP_ID, APP_SECRET
   #
   def self.omniauth(provider, *args)
-    @@helpers << Devise::OmniAuth::UrlHelpers
     config = Devise::OmniAuth::Config.new(provider, args)
     @@omniauth_configs[config.strategy_name.to_sym] = config
   end

--- a/lib/devise/omniauth/url_helpers.rb
+++ b/lib/devise/omniauth/url_helpers.rb
@@ -1,24 +1,6 @@
 module Devise
   module OmniAuth
     module UrlHelpers
-      def self.define_helpers(mapping)
-        return unless mapping.omniauthable?
-
-        class_eval <<-URL_HELPERS, __FILE__, __LINE__ + 1
-          def #{mapping.name}_omniauth_authorize_path(provider, params = {})
-            if Devise.omniauth_configs[provider.to_sym]
-              script_name = request.env["SCRIPT_NAME"]
-
-              path = "\#{script_name}/#{mapping.path}/auth/\#{provider}\".squeeze("/")
-              path << '?' + params.to_param if params.present?
-              path
-            else
-              raise ArgumentError, "Could not find omniauth provider \#{provider.inspect}"
-            end
-          end
-        URL_HELPERS
-      end
-
       def omniauth_authorize_path(resource_or_scope, *args)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
         send("#{scope}_omniauth_authorize_path", *args)

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -116,7 +116,8 @@ class OmniauthableIntegrationTest < ActionController::IntegrationTest
 
   test "handles callback error parameter according to the specification" do
     OmniAuth.config.mock_auth[:facebook] = :access_denied
-    visit "/users/auth/facebook/callback?error=access_denied"
+    visit "/users/sign_in"
+    click_link "Sign in with Facebook"
     assert_current_url "/users/sign_in"
     assert_contain 'Could not authorize you from Facebook because "Access denied".'
   end

--- a/test/omniauth/url_helpers_test.rb
+++ b/test/omniauth/url_helpers_test.rb
@@ -30,7 +30,7 @@ class OmniAuthRoutesTest < ActionController::TestCase
   test 'should generate authorization path' do
     assert_match "/users/auth/facebook", @controller.omniauth_authorize_path(:user, :facebook)
 
-    assert_raise ArgumentError do
+    assert_raise ActionController::RoutingError do
       @controller.omniauth_authorize_path(:user, :github)
     end
   end
@@ -47,12 +47,5 @@ class OmniAuthRoutesTest < ActionController::TestCase
   test 'should not add a "?" if no param was sent' do
     assert_equal "/users/auth/openid",
                   @controller.omniauth_authorize_path(:user, :openid)
-  end
-
-  test 'should set script name in the path if present' do
-    @request.env['SCRIPT_NAME'] = '/q'
-
-    assert_equal "/q/users/auth/facebook",
-                 @controller.omniauth_authorize_path(:user, :facebook)
   end
 end


### PR DESCRIPTION
This is more a sketch for now, and I'd like to get some feedback on it. My goals where to have devise use omniauth in a less intrusive way so that omniauth can still be used independently of devise. This also achieves omniauth support for multiple models.

How it works:
- keep omniauth as is, don't force specific path
- use extra controller (Devise::OmniauthAuthorizeController) to prepare request to omniauth, i.e. store resource name in session, then redirect to omniauth
- use routing constraints to route the callback to the correct omniauth callback controller

So for developers implementing the callbacks nothing really changes, just testing the callback controller in isolation becomes a bit more tricky because you'll need to set the resource name in the session.

Notes:
- would like to remove the extra redirect to omniauth, but I couldn't figure out a good way.
- need to find a better way to remove the resource name from the session to avoid potential issues when using omniauth without devise.
