### PR TITLE
Use rememberable_options instead of deprecated cookie_options in initializer

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -24,7 +24,7 @@ module Devise
     #   * +extend_remember_period+: if true, extends the user's remember period
     #     when remembered via cookie. False by default.
     #
-    #   * +cookie_options+: configuration options passed to the created cookie.
+    #   * +rememberable_options+: configuration options passed to the created cookie.
     #
     # == Examples
     #

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -117,7 +117,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # :secure => true in order to force SSL only cookies.
-  # config.cookie_options = {}
+  # config.rememberable_options = {}
 
   # ==> Configuration for :validatable
   # Range for password length. Default is 6..128.


### PR DESCRIPTION
Updated initializer template to use rememberable_options instead of deprecated cookie_options. Also fix in comments for same.
