### PR TITLE
Devise.mailer_sender proc can be passed resource

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -48,7 +48,12 @@ module Devise
         if default_params[:from].present?
           default_params[:from]
         elsif Devise.mailer_sender.is_a?(Proc)
-          Devise.mailer_sender.call(mapping.name, @resource)
+          case Devise.mailer_sender.arity
+          when 2  
+            Devise.mailer_sender.call(mapping.name, @resource)
+          else
+            Devise.mailer_sender.call(mapping.name)
+          end
         else
           Devise.mailer_sender
         end

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -92,4 +92,22 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
       assert_equal ['another@example.com'], mail.from
     end
   end
+  
+  test 'mailer sender accepts a proc with mapping_name' do
+    p = Proc.new {|mapping_name|
+      mapping_name && "another@example.com"
+    }
+    swap Devise, :mailer_sender => p do
+      assert_equal ['another@example.com'], mail.from
+    end
+  end
+  
+  test 'mailer sender accepts a proc with mapping_name and resource' do
+    p = Proc.new {|mapping_name, resource|
+      mapping_name && resource && "another@example.com"
+    }
+    swap Devise, :mailer_sender => p do
+      assert_equal ['another@example.com'], mail.from
+    end
+  end
 end


### PR DESCRIPTION
This adds the following functionality when configuring a mailer_sender proc:

```
Devise.setup do |config|
  config.mailer_sender = Proc.new { |devise_mapping_name, resource|
     # do some stuff here with the devise_mapping_name and the resource
    }
end
```

The use case us so that the mailer sender can be selected based on the resource and not just the mapping_name. It's also backwards compatible, so the proc can still be called as in the past

```
Devise.setup do |config|
  config.mailer_sender = Proc.new { |devise_mapping_name|
     # do some stuff here with the devise_mapping_name
    }
end
```

Thanks
