### PR TITLE
Fix redirect when authenticating mounted apps

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -88,6 +88,7 @@ module Devise
       opts  = {}
       route = :"new_#{scope}_session_path"
       opts[:format] = request_format unless skip_format?
+      opts[:script_name] = nil
 
       context = send(Devise.available_router_name)
 


### PR DESCRIPTION
The patch fixes [this really annoying issue](https://github.com/plataformatec/devise/issues/1592).

If you really want to get to the bottom of it, the answer lies somewhere between `Devise::FailureApp` and `ActionDispatch::Routing::RoutesProxy`.

I didn't quite succeed in translating my sophisticated eyeball QA to a failing test but all existing tests pass, which should make everyone quite happy.
