### PR TITLE
Token regeneration on session timeout.

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -139,6 +139,10 @@ module Devise
   mattr_accessor :timeout_in
   @@timeout_in = 30.minutes
 
+  # Authentication token expiration on timeout
+  mattr_accessor :expire_auth_token_on_timeout
+  @@expire_auth_token_on_timeout = false
+
   # Used to encrypt password. Please generate one with rake secret.
   mattr_accessor :pepper
   @@pepper = nil

--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -11,6 +11,7 @@ Warden::Manager.after_set_user do |record, warden, options|
 
     if record.timedout?(last_request_at)
       warden.logout(scope)
+      record.reset_authentication_token! if record.respond_to?(:reset_authentication_token!) && record.expire_auth_token_on_timeout
       throw :warden, :scope => scope, :message => :timeout
     end
 

--- a/lib/devise/models/token_authenticatable.rb
+++ b/lib/devise/models/token_authenticatable.rb
@@ -56,6 +56,9 @@ module Devise
       def after_token_authentication
       end
 
+      def expire_auth_token_on_timeout
+        self.class.expire_auth_token_on_timeout
+      end
 
       module ClassMethods
         def find_for_token_authentication(conditions)
@@ -67,7 +70,7 @@ module Devise
           generate_token(:authentication_token)
         end
 
-        ::Devise::Models.config(self, :token_authentication_key)
+        ::Devise::Models.config(self, :token_authentication_key, :expire_auth_token_on_timeout)
       end
     end
   end

--- a/test/integration/token_authenticatable_test.rb
+++ b/test/integration/token_authenticatable_test.rb
@@ -100,6 +100,19 @@ class TokenAuthenticationTest < ActionController::IntegrationTest
     end
   end
 
+  test 'should not authenticated and reset token when expire_auth_token_on_timeout is set to true, timeoutable is enabled and we have a timed out session' do
+    swap Devise, :token_authentication_key => :secret_token, :expire_auth_token_on_timeout => true, :timeout_in => (-1).minute do
+      user = sign_in_as_new_user_with_token
+      assert warden.authenticated?(:user)
+      token = user.authentication_token
+
+      get_users_path_as_existing_user(user)
+      assert_not warden.authenticated?(:user)
+      user.reload
+      assert_not_equal token, user.authentication_token
+    end
+  end
+
   test 'should not be subject to injection' do
     swap Devise, :token_authentication_key => :secret_token do
       user1 = create_user_with_authentication_token()


### PR DESCRIPTION
When token acts like a session it should expire on session timeout. 
