### PR TITLE
Added ability to override redirect_to path after sending reset password ...

### DIFF
--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -32,12 +32,6 @@ class PasswordTest < ActionController::IntegrationTest
     click_button 'Change my password'
   end
 
-  def redefine_after_reset_password_path
-    PasswordsController.send :define_method, :after_sending_reset_password_instructions_path_for do |r_name|
-      '/any_url_you_wish'
-    end
-  end
-
   test 'authenticated user should not be able to visit forgot password page' do
     sign_in_as_user
     assert warden.authenticated?(:user)
@@ -54,15 +48,6 @@ class PasswordTest < ActionController::IntegrationTest
 
     assert_template 'sessions/new'
     assert_contain 'You will receive an email with instructions about how to reset your password in a few minutes.'
-  end
-
-  test 'programmers should be able to redefine redirect path after user resets password' do
-    create_user
-    redefine_after_reset_password_path
-    request_forgot_password
-
-    assert_response :success
-    assert_template 'home/index'
   end
 
   test 'not authenticated user with invalid email should receive an error message' do

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -20,7 +20,6 @@ ActionController::Routing::Routes.draw do |map|
   map.admin_root '/admin_area/home', :controller => "admins", :action => "index"
 
   map.connect '/sign_in', :controller => "sessions", :action => "new"
-  map.connect '/any_url_you_wish', :controller => 'home', :action => 'index'
   map.connect ':controller/:action/:id'
   map.connect ':controller/:action/:id.:format'
 end


### PR DESCRIPTION
The main purpose of this pull request is to enable behaviour like https://github.com/plataformatec/devise/pull/1067 for Rails 2.x

I am not very familiar with TestUnit, so please let me know about any problem with tests.
