### PR TITLE
Verify AR constant is defined in test suite.

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,21 +13,23 @@ class SessionsControllerTest < ActionController::TestCase
     assert_equal 200, @response.status
     assert_template "devise/sessions/new"
   end
-  
-  if ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
-    test "#new doesn't raise mass-assignment exception even if sign-in key is attr_protected" do
-      request.env["devise.mapping"] = Devise.mappings[:user] 
+ 
+  if defined?(ActiveRecord) 
+    if ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
+      test "#new doesn't raise mass-assignment exception even if sign-in key is attr_protected" do
+        request.env["devise.mapping"] = Devise.mappings[:user] 
 
-      ActiveRecord::Base.mass_assignment_sanitizer = :strict
-      User.class_eval { attr_protected :email }
-    
-      begin
-        assert_nothing_raised ActiveModel::MassAssignmentSecurity::Error do
-          get :new, :user => { :email => "allez viens!" }
+        ActiveRecord::Base.mass_assignment_sanitizer = :strict
+        User.class_eval { attr_protected :email }
+      
+        begin
+          assert_nothing_raised ActiveModel::MassAssignmentSecurity::Error do
+            get :new, :user => { :email => "allez viens!" }
+          end
+        ensure
+          ActiveRecord::Base.mass_assignment_sanitizer = :logger
+          User.class_eval { attr_accessible :email }
         end
-      ensure
-        ActiveRecord::Base.mass_assignment_sanitizer = :logger
-        User.class_eval { attr_accessible :email }
       end
     end
   end


### PR DESCRIPTION
Ensure ActiveRecord is defined, which is not true when running Mongoid tests.
