### PR TITLE
Clean up global namespaces

### DIFF
--- a/lib/devise/models/encryptable.rb
+++ b/lib/devise/models/encryptable.rb
@@ -67,7 +67,7 @@ module Devise
             when nil
               raise "You need to give an :encryptor as option in order to use :encryptable"
             else
-              ::Devise::Encryptors.const_get(encryptor.to_s.classify)
+              Devise::Encryptors.const_get(encryptor.to_s.classify)
           end
         end
 

--- a/lib/devise/models/token_authenticatable.rb
+++ b/lib/devise/models/token_authenticatable.rb
@@ -70,7 +70,7 @@ module Devise
           generate_token(:authentication_token)
         end
 
-        ::Devise::Models.config(self, :token_authentication_key, :expire_auth_token_on_timeout)
+        Devise::Models.config(self, :token_authentication_key, :expire_auth_token_on_timeout)
       end
     end
   end

--- a/test/models/encryptable_test.rb
+++ b/test/models/encryptable_test.rb
@@ -54,7 +54,7 @@ class EncryptableTest < ActiveSupport::TestCase
   test 'should respect encryptor configuration' do
     swap_with_encryptor Admin, :sha512 do
       admin = create_admin
-      assert_equal admin.encrypted_password, encrypt_password(admin, Admin.pepper, Admin.stretches, ::Devise::Encryptors::Sha512)
+      assert_equal admin.encrypted_password, encrypt_password(admin, Admin.pepper, Admin.stretches, Devise::Encryptors::Sha512)
     end
   end
 


### PR DESCRIPTION
I suggest to clean up code. 
For example in modules [here](https://github.com/plataformatec/devise/blob/master/lib/devise/models/lockable.rb#L181), [here](https://github.com/plataformatec/devise/blob/master/lib/devise/models/recoverable.rb#L136) and [here](https://github.com/plataformatec/devise/blob/master/lib/devise/models/rememberable.rb#L121) isn't used global namespace. So I think we can remove double colon and [here](https://github.com/plataformatec/devise/blob/master/lib/devise/models/token_authenticatable.rb#L73) too.

Tests passed http://travis-ci.org/#!/aderyabin/devise
