### PR TITLE
changes on railties version for rails 4.0.0.beta

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency("warden", "~> 1.1.1")
   s.add_dependency("orm_adapter", "~> 0.0.7")
   s.add_dependency("bcrypt-ruby", "~> 3.0")
-  s.add_dependency("railties", "~> 3.1")
+  s.add_dependency("railties", "~> 4.0.0.beta")
 end


### PR DESCRIPTION
Hello,

This pull request isn't a real. I just changed the version of railties into the Gemspec in order to work with rails 4.0 beta. It's more or less useless but I have tried on my comptuter and it still works (for generator, etc.)

Sorry for my bad english and have a nice day.
