### PR TITLE
Use 'head :no_content' in sessions_controller#destroy

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -28,9 +28,7 @@ class Devise::SessionsController < DeviseController
     respond_to do |format|
       format.any(*navigational_formats) { redirect_to redirect_path }
       format.all do
-        method = "to_#{request_format}"
-        text = {}.respond_to?(method) ? {}.send(method) : ""
-        render :text => text, :status => :ok
+        head :no_content
       end
     end
   end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -461,14 +461,14 @@ class AuthenticationOthersTest < ActionController::IntegrationTest
   test 'sign out with xml format returns ok response' do
     sign_in_as_user
     get destroy_user_session_path(:format => 'xml')
-    assert_response :ok
+    assert_response :no_content
     assert_not warden.authenticated?(:user)
   end
 
   test 'sign out with json format returns empty json response' do
     sign_in_as_user
     get destroy_user_session_path(:format => 'json')
-    assert_response :ok
+    assert_response :no_content
     assert_not warden.authenticated?(:user)
   end
 end


### PR DESCRIPTION
Code cleanup for returning headers instead of an empty string
when destroying sessions.

Lines 464 and 471 on test/integration/autenticatable_test.rb
were adjusted to assert on :no_content
