### PR TITLE
Fixed User model generation for Mongoid 

### DIFF
--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -20,9 +20,12 @@ module Mongoid
       def migration_data
 <<RUBY
   ## Database authenticatable
-  field :email,              :type => String, :null => false, :default => ""
-  field :encrypted_password, :type => String, :null => false, :default => ""
+  field :email,              :type => String, :default => ""
+  field :encrypted_password, :type => String, :default => ""
 
+  validates_presence_of :email
+  validates_presence_of :encrypted_password
+  
   ## Recoverable
   field :reset_password_token,   :type => String
   field :reset_password_sent_at, :type => Time


### PR DESCRIPTION
Mongoid doesn't support :null => false for defining the presence of a field but the correct syntax is:

validates_presence_of <field>
