### PR TITLE
#update_with_password should use mass assignment options when password is not valid

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -64,7 +64,11 @@ module Devise
         result = if valid_password?(current_password)
           update_attributes(params, *options)
         else
-          self.attributes = params
+          if respond_to?(:assign_attributes)
+            self.assign_attributes(params, *options)
+          else
+            self.attributes = params
+          end
           self.valid?
           self.errors.add(:current_password, current_password.blank? ? :blank : :invalid)
           false


### PR DESCRIPTION
I admit this code defensive. I can take out the method check if you do not think it is necessary. It was intended for broad ActiveModel compatibility.

References issue #1893
