### PR TITLE
Persist unlock token before triggering mailer

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -38,11 +38,11 @@ module Devise
         self.locked_at = Time.now.utc
 
         if unlock_strategy_enabled?(:email)
-          generate_unlock_token
+          generate_unlock_token!
           send_unlock_instructions
+        else
+          save(:validate => false)
         end
-
-        save(:validate => false)
       end
 
       # Unlock a user by cleaning locked_at and failed_attempts.
@@ -121,6 +121,10 @@ module Devise
         # Generates unlock token
         def generate_unlock_token
           self.unlock_token = self.class.unlock_token
+        end
+
+        def generate_unlock_token!
+          generate_unlock_token && save(:validate => false)
         end
 
         # Tells if the lock is expired if :time unlock strategy is active


### PR DESCRIPTION
Hey guys,

The fact that the lockable module triggers the email before the token is persisted is annoying me in some specs when associated with devise-async.

Also, even tough very unlikely, the current code would allow a worker to have a tiny time frame in which it would be able to render the email before the token is persisted (devise-async loads the record from db).

This change just ensures the token is persisted before triggering the mailer.

Let me know if you need any change.

Cheers!
