### PR TITLE
Allow setting of default reply_to fields on mailer mails - #1936

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -28,8 +28,9 @@ module Devise
       def headers_for(action)
         headers = {
           :subject       => translate(devise_mapping, action),
-          :from          => mailer_sender(devise_mapping),
           :to            => resource.email,
+          :from          => mailer_sender(devise_mapping),
+          :reply_to      => mailer_reply_to(devise_mapping),
           :template_path => template_paths
         }
 
@@ -37,16 +38,20 @@ module Devise
           headers.merge!(resource.headers_for(action))
         end
 
-        unless headers.key?(:reply_to)
-          headers[:reply_to] = headers[:from]
-        end
-
         headers
       end
 
-      def mailer_sender(mapping)
-        if default_params[:from].present?
-          default_params[:from]
+      def mailer_reply_to(mapping)
+        mailer_sender(mapping, :reply_to)
+      end
+      
+      def mailer_from(mapping)
+        mailer_sender(mapping, :from)
+      end
+
+      def mailer_sender(mapping, sender = :from)
+        if default_params[sender].present?
+          default_params[sender]
         elsif Devise.mailer_sender.is_a?(Proc)
           Devise.mailer_sender.call(mapping.name)
         else

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -50,6 +50,13 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     assert_equal ['test@example.com'], mail.reply_to
   end
 
+  test 'setup reply to as different if set in defaults' do
+    Devise.mailer = 'Users::ReplyToMailer'
+    assert_equal ['custom@example.com'], mail.from
+    assert_equal ['custom_reply_to@example.com'], mail.reply_to
+  end
+
+
   test 'setup subject from I18n' do
     store_translations :en, :devise => { :mailer => { :confirmation_instructions => { :subject => 'Account Confirmation' } } } do
       assert_equal 'Account Confirmation', mail.subject

--- a/test/rails_app/app/mailers/users/mailer.rb
+++ b/test/rails_app/app/mailers/users/mailer.rb
@@ -1,3 +1,8 @@
 class Users::Mailer < Devise::Mailer
-  default :from => 'custom@example.com'
+  default :from     => 'custom@example.com'
+end
+
+class Users::ReplyToMailer < Devise::Mailer
+  default :from     => 'custom@example.com'
+  default :reply_to => 'custom_reply_to@example.com'
 end


### PR DESCRIPTION
I've updated the mailer helper to accept `:reply_to` as a default param as well when making a Devise mailer subclass.

Doing this removes the need to monkey patch the `headers_for` method as discussed below in #1936.

https://github.com/plataformatec/devise/issues/1936
