### PR TITLE
Flash message issue #1898

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -41,7 +41,7 @@ class Devise::RegistrationsController < DeviseController
 
     if resource.update_with_password(resource_params)
       if is_navigational_format?
-        if resource.respond_to?(:pending_reconfirmation?) && resource.pending_reconfirmation?
+        if resource.respond_to?(:pending_reconfirmation?) && resource.pending_reconfirmation? && resource.unconfirmed_email_changed?
           flash_key = :update_needs_confirmation
         end
         set_flash_message :notice, flash_key || :updated


### PR DESCRIPTION
Adding a condition before to set wrong flash message if unconfirmed_email didn't change, as we discussed on https://github.com/plataformatec/devise/issues/1898
