### PR TITLE
Flash message issue #1898

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -38,10 +38,11 @@ class Devise::RegistrationsController < DeviseController
   # the current user in place.
   def update
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
     if resource.update_with_password(resource_params)
       if is_navigational_format?
-        if resource.respond_to?(:pending_reconfirmation?) && resource.pending_reconfirmation?
+        if resource.respond_to?(:pending_reconfirmation?) && resource.pending_reconfirmation? && (prev_unconfirmed_email != resource.unconfirmed_email)
           flash_key = :update_needs_confirmation
         end
         set_flash_message :notice, flash_key || :updated

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -321,4 +321,25 @@ class ReconfirmableRegistrationTest < ActionController::IntegrationTest
 
     assert Admin.first.valid_password?('pas123')
   end
+
+  test 'a signed in admin should not see a reconfirmation message if he did not change his email, despite having an unconfirmed email' do
+    sign_in_as_admin
+
+    get edit_admin_registration_path
+    fill_in 'email', :with => 'admin.new@example.com'
+    fill_in 'current password', :with => '123456'
+    click_button 'Update'
+
+    get edit_admin_registration_path
+    fill_in 'password', :with => 'pas123'
+    fill_in 'password confirmation', :with => 'pas123'
+    fill_in 'current password', :with => '123456'
+    click_button 'Update'
+
+    assert_current_url '/admin_area/home'
+    assert_contain 'You updated your account successfully.'
+
+    assert_equal "admin.new@example.com", Admin.first.unconfirmed_email
+    assert Admin.first.valid_password?('pas123')
+  end
 end


### PR DESCRIPTION
Adding a condition before to set wrong flash message if unconfirmed_email didn't change, as we discussed on https://github.com/plataformatec/devise/issues/1898

Adding a test too.
