### PR TITLE
Patch for Trackable IP

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -20,7 +20,7 @@ module Devise
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.ip
+        old_current, new_current = self.current_sign_in_ip, request.remote_ip
         self.last_sign_in_ip     = old_current || new_current
         self.current_sign_in_ip  = new_current
 


### PR DESCRIPTION
This commit reverts 60822641cb9 which incorrectly switched to using the gateway IP. At the time Rails' remote_ip method was broken and this was simply a workaround.

I'm using Thin daemons behind Nginx and my "last_sign_in_ip" and "current_sign_in_ip" were always 127.0.0.1. With this patch I'm seeing the correct IP addresses.
