### PR TITLE
Replaces update_attribute with update_column

### DIFF
--- a/lib/devise/hooks/lockable.rb
+++ b/lib/devise/hooks/lockable.rb
@@ -2,6 +2,6 @@
 # This is only triggered when the user is explicitly set (with set_user)
 Warden::Manager.after_set_user :except => :fetch do |record, warden, options|
   if record.respond_to?(:failed_attempts) && warden.authenticated?(options[:scope])
-    record.update_attribute(:failed_attempts, 0)
+    record.update_column(:failed_attempts, 0)
   end
 end

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -73,7 +73,7 @@ class HttpAuthenticationTest < ActionController::IntegrationTest
   test 'sign in should authenticate with really long token' do
     token = "token_containing_so_many_characters_that_the_base64_encoding_will_wrap"
     user = create_user
-    user.update_attribute :authentication_token, token
+    user.update_column :authentication_token, token
     get users_path(:format => :xml), {}, "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("#{token}:x")}"
     assert_response :success
     assert_match "<email>user@test.com</email>", response.body

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -293,7 +293,7 @@ class PasswordTest < ActionController::IntegrationTest
 
   test "after recovering a password, should set failed attempts to 0" do
     user = create_user
-    user.update_attribute(:failed_attempts, 10)
+    user.update_column(:failed_attempts, 10)
 
     assert_equal 10, user.failed_attempts
     request_forgot_password

--- a/test/integration/token_authenticatable_test.rb
+++ b/test/integration/token_authenticatable_test.rb
@@ -121,7 +121,7 @@ class TokenAuthenticationTest < ActionController::IntegrationTest
       @user = nil
 
       user2 = create_user_with_authentication_token(:email => "another@test.com")
-      user2.update_attribute(:authentication_token, "ANOTHERTOKEN")
+      user2.update_column(:authentication_token, "ANOTHERTOKEN")
 
       assert_not_equal user1, user2
       visit users_path(Devise.token_authentication_key.to_s + '[$ne]' => user1.authentication_token)


### PR DESCRIPTION
Rails 3.2.7 deprecates update_attribute in favor of update_column. Updated projects using Devise output lots of warnings because Devise uses the deprecated version in some places. This commit replaces update_attribute with update_column to fix that.
