### PR TITLE
Allow after_sign_out_path_for to use current_user

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -20,8 +20,8 @@ class Devise::SessionsController < DeviseController
 
   # DELETE /resource/sign_out
   def destroy
-    redirect_path = after_sign_out_path_for(resource_name)
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    redirect_path = after_sign_out_path_for(resource_name)
     set_flash_message :notice, :signed_out if signed_out && is_navigational_format?
 
     # We actually need to hardcode this as Rails default responder doesn't

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -37,6 +37,18 @@ class SessionsControllerTest < ActionController::TestCase
     assert_equal 204, @response.status
   end
 
+  test "#destroy allows after_sign_out_path_for to properly use current_user when determining a path" do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+
+    user = User.new
+    user.expects(:active_for_authentication?).returns(true)
+    @controller.sign_in(:user, user)
+
+    @controller.instance_eval "def after_sign_out_path_for(resource); if current_user; admin_root_path; else; root_path; end; end"
+    delete :destroy
+    assert_redirected_to root_path
+  end
+
   if defined?(ActiveRecord) && ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
     test "#new doesn't raise mass-assignment exception even if sign-in key is attr_protected" do
       request.env["devise.mapping"] = Devise.mappings[:user]


### PR DESCRIPTION
When `#after_sign_out_path_for` is defined in ApplicationController, it cannot use `current_user` to determine the path. From within `#after_sign_out_path_for`, `current_user` will be the user prior to signing out. As the name of this method implies, this should be called **after** the user has been signed out.

One of my projects does this in the following way:

``` ruby
def after_sign_out_path_for(user)
  if can?(:manage, :users)
    admin_dashboard_path
  else
    root_path
  end
end
```

The `can?` method (of CanCan) returns based on `current_ability` which is derived from `current_user`.

My scenario is as follows:
1. Log in as user A (who can :manage :users)
2. Ghost log in as user B (who can **not** :manage :users)
3. Log out of user B
4. (FAIL) Redirect to root_path instead of admin_dashboard_path

After step 3, the `current_user` should be user A from within `#after_sign_out_path_for`. However, because `#after_sign_out_path_for` is currently being called _before_ the user is signed out ([link](https://github.com/plataformatec/devise/blob/master/app/controllers/devise/sessions_controller.rb#L23-24)), `current_user` is user B.

This regression was introduced in [this commit](https://github.com/plataformatec/devise/commit/9ea724936869e094a10f6c7ee8a718428926d19e).
