### PR TITLE
Deleted unnecessary validation in generator mongoid model

### DIFF
--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -22,9 +22,6 @@ module Mongoid
   ## Database authenticatable
   field :email,              :type => String, :default => ""
   field :encrypted_password, :type => String, :default => ""
-
-  validates_presence_of :email
-  validates_presence_of :encrypted_password
   
   ## Recoverable
   field :reset_password_token,   :type => String


### PR DESCRIPTION
In generator mongoid model there is unnecessary email validation (because duplicated devise email validation) and encrypted_password validation (because it is not needed as we have password validation).
