### PR TITLE
New devise_attr_accessible option

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -40,7 +40,7 @@ class Devise::RegistrationsController < DeviseController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
-    if resource.update_with_password(resource_params)
+    if resource.update_with_password(resource_params, :without_protection => resource_class.devise_attr_accessible)
       if is_navigational_format?
         flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
           :update_needs_confirmation : :updated
@@ -82,9 +82,9 @@ class Devise::RegistrationsController < DeviseController
 
   # Build a devise resource passing in the session. Useful to move
   # temporary session data to the newly created user.
-  def build_resource(hash=nil)
-    hash ||= resource_params || {}
-    self.resource = resource_class.new_with_session(hash, session)
+  def build_resource(params=nil)
+    params ||= resource_params || {}
+    self.resource = resource_class.new_with_session(params, session, :without_protection => resource_class.devise_attr_accessible)
   end
 
   # The path used after sign up. You need to overwrite this method

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -28,8 +28,9 @@ class DeviseController < Devise.parent_controller.constantize
     devise_mapping.to
   end
 
+  # Returns resource params
   def resource_params
-    params[resource_name]
+    check_resource_params(params[resource_name])
   end
 
   # Returns a signed in resource from session (if one exists)
@@ -188,5 +189,20 @@ MESSAGE
 
   def is_navigational_format?
     Devise.navigational_formats.include?(request_format)
+  end
+
+  # Raise an exception if devise_attr_accessible is set
+  # and inappropriate param is among "params".
+  def check_resource_params(params)
+    if resource_class.devise_attr_accessible && params
+      protected_params = params.keys.select do |param|
+        !resource_class.devise_attr_accessible.index(param.to_sym)
+      end
+      unless protected_params.empty?
+        raise "#{protected_params} are not devise_attr_accessible"
+      end
+    end
+
+    params
   end
 end

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -51,6 +51,10 @@ module Devise
   mattr_accessor :stretches
   @@stretches = 10
 
+  # List of accessible attributes
+  mattr_accessor :devise_attr_accessible
+  @@devise_attr_accessible = false
+
   # Keys used when authenticating a user.
   mattr_accessor :authentication_keys
   @@authentication_keys = [ :email ]

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -172,7 +172,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :authentication_keys, :request_keys, :strip_whitespace_keys,
+        Devise::Models.config(self, :devise_attr_accessible, :authentication_keys, :request_keys, :strip_whitespace_keys,
           :case_insensitive_keys, :http_authenticatable, :params_authenticatable, :skip_session_storage)
 
         def serialize_into_session(record)

--- a/lib/devise/models/registerable.rb
+++ b/lib/devise/models/registerable.rb
@@ -16,8 +16,8 @@ module Devise
         #
         # By default discards all information sent by the session by calling
         # new with params.
-        def new_with_session(params, session)
-          new(params)
+        def new_with_session(params, session, *options)
+          new(params, *options)
         end
       end
     end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -72,6 +72,13 @@ Devise.setup do |config|
   # passing :skip => :sessions to `devise_for` in your config/routes.rb
   config.skip_session_storage = [:http_auth]
 
+  # Devise uses update_attributes in its controllers, so fields like :name
+  # and :password should be attr_accessible in your model. If you don't want
+  # them to be attr_accissble, you can use this option. If it is set, Devise
+  # uses update_attributes :without_protection, but doesn't accept any param
+  # not from this list
+  # config.devise_attr_accessible = [:name, :password, :password_confirmation]
+
   # ==> Configuration for :database_authenticatable
   # For bcrypt, this is the cost for hashing the password and defaults to 10. If
   # using other encryptors, it sets how many times you want the password re-encrypted.

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -61,6 +61,20 @@ class RegistrationTest < ActionController::IntegrationTest
     assert_not user.confirmed?
   end
 
+  test 'a guest user shold not be able to sign up with protected params if devise_attr_accissble is truly' do
+    swap Devise, :devise_attr_accessible => [ :email ] do # now user_sign_up() is hack!
+      assert_raise RuntimeError do  
+        user_sign_up
+      end
+    end
+  end
+
+  test 'a guest user shold be able to sign up without protected params if devise_attr_accissble is truly' do
+    swap Devise, :devise_attr_accessible => [ :email, :password, :password_confirmation ] do
+      user_sign_up # Doesn't raise RuntimeError
+    end
+  end
+ 
   test 'a guest user should receive the confirmation instructions from the default mailer' do
     user_sign_up
     assert_equal ['please-change-me@config-initializers-devise.com'], ActionMailer::Base.deliveries.first.from

--- a/test/rails_app/lib/shared_user.rb
+++ b/test/rails_app/lib/shared_user.rb
@@ -14,7 +14,7 @@ module SharedUser
   end
 
   module ExtendMethods
-    def new_with_session(params, session)
+    def new_with_session(params, session, options)
       super.tap do |user|
         if data = session["devise.facebook_data"]
           user.email = data["email"]


### PR DESCRIPTION
Following #716
# Problem

Devise uses `update_attributes` in its controllers, so fields like `:name` and `:password` should be attr_accessible in your model. But it should be client's decision, not Devises's, what fields should be attr_accessible. Some people prefer to control all params by their own, for example.

There must be a way to say to Devise "don't rely on `attr_accessible`". But in this case, we want to provide some list of acceptable attributes to Devise so it can control them by its own.
# Solution

I implement new option: `devise_attr_accissble`.

If it is set:
1. Devise uses `update_attributes params, :without_protection => true`, so `attr_accessible` doesn't matter anymore.
2. Devise checks that any param in resource is among `devise_attr_accissble` list.
# Example

This is going to work:

``` ruby
class User < ActiveRecord::Base
  devise :database_authenticatable, :registerable, :encryptable,
         :recoverable, :rememberable, :trackable, :validatable, :confirmable,
         :devise_attr_accessible => [ :name, :password, :password_confirmation ]

  attr_accessible #nothing
end
```
