### PR TITLE
Test helper was incorrectly returning failure body

### DIFF
--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -107,8 +107,8 @@ module Devise
         env["warden.options"] = options
         Warden::Manager._run_callbacks(:before_failure, env, options)
 
-        status, headers, body = Devise.warden_config[:failure_app].call(env).to_a
-        @controller.send :render, :status => status, :text => body,
+        status, headers, response = Devise.warden_config[:failure_app].call(env).to_a
+        @controller.send :render, :status => status, :text => response.body,
           :content_type => headers["Content-Type"], :location => headers["Location"]
         nil # causes process return @response
       end

--- a/test/test_helpers_test.rb
+++ b/test/test_helpers_test.rb
@@ -9,7 +9,7 @@ class TestHelpersTest < ActionController::TestCase
       self.status = 306
     end
   end
-  
+
   test "redirects if attempting to access a page unauthenticated" do
     get :index
     assert_redirected_to new_user_session_path
@@ -70,7 +70,7 @@ class TestHelpersTest < ActionController::TestCase
     get :index
     assert_redirected_to new_user_session_path
   end
-  
+
   test "respects custom failure app" do
     begin
       Devise.warden_config.failure_app = CustomFailureApp
@@ -79,6 +79,11 @@ class TestHelpersTest < ActionController::TestCase
     ensure
       Devise.warden_config.failure_app = Devise::FailureApp
     end
+  end
+
+  test "returns the body of a failure app" do
+    get :index
+    assert_equal response.body, "<html><body>You are being <a href=\"http://test.host/users/sign_in\">redirected</a>.</body></html>"
   end
 
   test "defined Warden after_authentication callback should not be called when sign_in is called" do


### PR DESCRIPTION
The _process_unauthenticated method in test_helper was returning the response as the body. When setting rendering the text, it was calling to_s on the response which would render something like this: #ActionDispatch::Response:0x007fb9e1efea00. This change renders the body of the response instead of the response itself.
