### PR TITLE
Assigns object to self.resource, changing variable scope.

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -5,14 +5,14 @@ class Devise::SessionsController < DeviseController
 
   # GET /resource/sign_in
   def new
-    resource = build_resource(nil, :unsafe => true)
+    self.resource = build_resource(nil, :unsafe => true)
     clean_up_passwords(resource)
     respond_with(resource, serialize_options(resource))
   end
 
   # POST /resource/sign_in
   def create
-    resource = warden.authenticate!(auth_options)
+    self.resource = warden.authenticate!(auth_options)
     set_flash_message(:notice, :signed_in) if is_navigational_format?
     sign_in(resource_name, resource)
     respond_with resource, :location => after_sign_in_path_for(resource)


### PR DESCRIPTION
The Sessions Controller was assigning resource instead of self.resource, meaning the resource variable wasn't available outside of the method.

For example, RABL templates wouldn't have access to the resource object.

This changes the resource assignment to be similar to the other controllers.
