### PR TITLE
unlock user after password re-set

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -30,6 +30,7 @@ class Devise::PasswordsController < DeviseController
     self.resource = resource_class.reset_password_by_token(resource_params)
 
     if resource.errors.empty?
+      resource.unlock_access! if unlockable?(resource)
       flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
       set_flash_message(:notice, flash_message) if is_navigational_format?
       sign_in(resource_name, resource)
@@ -52,5 +53,13 @@ class Devise::PasswordsController < DeviseController
         set_flash_message(:error, :no_token)
         redirect_to new_session_path(resource_name)
       end
+    end
+
+    # Check if proper Lockable module methods are present & unlock strategy
+    # allows to unlock resource on password reset
+    def unlockable?(resource)
+      resource.respond_to?(:unlock_access!) &&
+        resource.respond_to?(:unlock_strategy_enabled?) &&
+        resource.unlock_strategy_enabled?(:email)
     end
 end


### PR DESCRIPTION
This fixes issue #2090: After user re-sets password, he also should be unlocked if unlock strategy is email or both
