### PR TITLE
Use correct current_password in RegistrationTest of invalid confirmation

### DIFF
--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -203,7 +203,7 @@ class RegistrationTest < ActionController::IntegrationTest
 
     fill_in 'password', :with => 'pas123'
     fill_in 'password confirmation', :with => ''
-    fill_in 'current password', :with => '123456'
+    fill_in 'current password', :with => '12345678'
     click_button 'Update'
 
     assert_contain "Password doesn't match confirmation"


### PR DESCRIPTION
Now that password is deleted in DatabaseAuthenticatable#update_with_password if
the current_password is invalid (plataformatec/devise@7d72121b), this test was failing in dm-devise when using dm-validations (dm-validations will not check password_confirmation if password is not set).
