### PR TITLE
Add failing specs for scope and relative url

### DIFF
--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -59,6 +59,14 @@ class FailureTest < ActiveSupport::TestCase
           assert_equal 'http://test.host/sample/users/sign_in', @response.second['Location']
         end
       end
+
+      test 'returns to the default redirect location considering the relative url root and scope' do
+        swap Rails.application.config, :relative_url_root => "/scoped" do
+          call_failure('warden.options' => { :scope => :scoped_admin })
+          assert_equal 302, @response.first
+          assert_equal 'http://test.host/scoped/scoped_admin/sign_in', @response.second['Location']
+        end
+      end
     end
 
     test 'uses the proxy failure message as symbol' do

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -72,6 +72,10 @@ Rails.application.routes.draw do
     devise_for :sub_admin, :class_name => "Admin"
   end
 
+  scope 'scoped' do
+    devise_for :scoped_admins, :class_name => "Admin"
+  end
+
   namespace :publisher, :path_names => { :sign_in => "i_dont_care", :sign_out => "get_out" } do
     devise_for :accounts, :class_name => "Admin", :path_names => { :sign_in => "get_in" }
   end


### PR DESCRIPTION
When I use in application

``` ruby
ENV['RAILS_RELATIVE_URL_ROOT'] = 'my_app'
```

and in my routes

``` ruby
scope :my_app do
  devise_for :users
end
```

devise double render `relative` part of URL.  I am including a test that does not pass.

`test_returns_to_the_default_redirect_location_considering_the_relative_url_root_and_scope(FailureTest) [/home/lite/work/devise/test/failure_app_test.rb:67]:
<"http://test.host/scoped/scoped_admin/sign_in"> expected but was
<"http://test.host/scoped/scoped/scoped_admins/sign_in">.`
