### PR TITLE
Adding the Gem Version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Devise
 
-[![Build Status](https://secure.travis-ci.org/plataformatec/devise.png?branch=master)](http://travis-ci.org/plataformatec/devise) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/plataformatec/devise)
+[![Build Status](https://secure.travis-ci.org/plataformatec/devise.png?branch=master)](http://travis-ci.org/plataformatec/devise)
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/plataformatec/devise)
+[![Gem Version](https://fury-badge.herokuapp.com/rb/devise.png)](http://badge.fury.io/rb/devise)
 
 This README is [also available in a friendly navigable format](http://devise.plataformatec.com.br/).
 


### PR DESCRIPTION
As discussed with @josevalim, I'm adding the Gem Version badge to help users easily find the corresponding RubyGem and stay current on the latest version number.
