### PR TITLE
Show "Reset password token is invalid" error message immediately on /resource/password/edit

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -21,8 +21,11 @@ class Devise::PasswordsController < DeviseController
 
   # GET /resource/password/edit?reset_password_token=abcdef
   def edit
-    self.resource = resource_class.new
-    resource.reset_password_token = params[:reset_password_token]
+    self.resource = resource_class.find_or_initialize_with_error_by(:reset_password_token, params[:reset_password_token])
+    if resource.errors[:reset_password_token].any?
+      flash[:error] = resource.errors.full_message(:reset_password_token, resource.errors[:reset_password_token].first)
+      redirect_to new_user_password_path
+    end
   end
 
   # PUT /resource/password

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -132,6 +132,16 @@ class PasswordTest < ActionController::IntegrationTest
     assert_redirected_to "/users/sign_in"
   end
 
+  test 'not authenticated user with an invalid reset password token should not be able to visit the edit_user_password page' do
+    get edit_user_password_path(:reset_password_token => 'something_invalid')
+    assert_response :redirect
+    assert_redirected_to "/users/password/new"
+
+    get "/users/password/new"
+    assert_have_selector '#flash_error'
+    assert_contain /Reset password token(.*)invalid/
+  end
+
   test 'not authenticated user with invalid reset password token should not be able to change his password' do
     user = create_user
     reset_password :reset_password_token => 'invalid_reset_password'


### PR DESCRIPTION
I think it would be less confusing and frustrating to users if we showed the "Reset password token
is invalid" error message immediately when they first get to the /resource/password/edit page
rather than waiting until _after_ they've taken the time to enter their new password twice and
submit the form to tell them about the problem.

This behavior also seems more consistent with pull request #1902
