### PR TITLE
Add method to confirmable to improve flexibility on changing emails

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -258,7 +258,9 @@ module Devise
         
         def confirm_changed_by_token(confirmation_token)
           confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_token)
-          if confirmable.persisted?   confirmable        
+          if confirmable.persisted? 
+          confirmable        
+          end
         end
 
         # Generate a token checking if one does not already exist in the database.


### PR DESCRIPTION
I use an overridden confirmations_controller to get users to pay via cc or paypal when they sign up. If they then try to change their email or password they are asked to pay again.

I added confirm_changed_by_token to confirmable.rb to allow devise:confirmable to respond differently to already confirmed accounts.

Could be useful more generally if for example users have to fill in some info when confirming, you don't want that to happen if they just change their email.
