### PR TITLE
Swallow devise routing errors when re-setting database

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -235,6 +235,11 @@ module ActionDispatch::Routing
           end
         end
       end
+    rescue Exception
+      # If we are re-setting the database,
+      # or migrating the database (maybe in production),
+      # then ignore the error
+      raise unless ARGV.join.include?('db:migrate')
     end
 
     # Allow you to add authentication request from the router.


### PR DESCRIPTION
I frequently run 'rake db:migrate:reset db:seed' when developing, to get back to my default mock-up state.  Unfortunately, Devise assumes that the database table should exist at this point, and throws a SQL error.  For example:

```
PG::Error: ERROR:  relation "users" does not exist
```

Since I'm trying to re-set the database, this is frustrating. I have to comment out the "devise_for" line in my routes.rb, run my migrations, then un-comment the devise_for line again.

This pull request simply swallows any exceptions from devise_for when running db:migrate.
