### PR TITLE
Rename Devise::Mailer.translate() to something more inline with what it does

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -27,7 +27,7 @@ module Devise
 
       def headers_for(action, opts)
         headers = {
-          :subject       => translate(devise_mapping, action),
+          :subject       => subject_for(action),
           :to            => resource.email,
           :from          => mailer_sender(devise_mapping),
           :reply_to      => mailer_reply_to(devise_mapping),
@@ -86,8 +86,8 @@ module Devise
       #         confirmation_instructions:
       #           subject: '...'
       #
-      def translate(mapping, key)
-        I18n.t(:"#{mapping.name}_subject", :scope => [:devise, :mailer, key],
+      def subject_for(key)
+        I18n.t(:"#{devise_mapping.name}_subject", :scope => [:devise, :mailer, key],
           :default => [:subject, key.to_s.humanize])
       end
     end


### PR DESCRIPTION
I found the translate() method in devise mailer by accident, trying to make a generic translate helper in my own mailer. Turns out the one in devise only tries to figure out a subject and doesn't handle anything more than that, so I believe it's best if it were named appropriately.

There is also a few helper methods in there that take devise_mapping as an argument when they don't really need to since there is an instance variable and helper containing that info already.
