### PR TITLE
Changed link_to to button_to for cancel registration link in edit registration view

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -24,6 +24,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete %>.</p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete %>.</p>
 
 <%= link_to "Back", :back %>


### PR DESCRIPTION
It is advisable to use link_to for mostly GET operations. Actions like DESTROY when presented as a link can cause severe vulnerabilities.
Hence using a button is advisable.
