### PR TITLE
Affirmative conditionals

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -51,7 +51,7 @@ module Devise
       # Passwords are always required if it's a new record, or if the password
       # or confirmation are being set somewhere.
       def password_required?
-        !persisted? || !password.nil? || !password_confirmation.nil?
+        new_record? || password.present? || password_confirmation.present?
       end
 
       def email_required?


### PR DESCRIPTION
I believe these "affirmative" conditionals express the intention of the code much better than their "negative" counterparts.

Moreover, In this case we don't return `true` if either field is `blank`.

Only gotcha is that `persisted?` also checks if a record is `!destroyed?`, which `new_record?` obviously doesn't.
In this case though, I believe, that check is superfluous.
