### PR TITLE
Use mapping.fullpath in omniauth callbacks

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -392,8 +392,14 @@ module ActionDispatch::Routing
       end
 
       def devise_omniauth_callback(mapping, controllers) #:nodoc:
+        if mapping.fullpath =~ /:[a-zA-Z_]/
+          raise "[DEVISE] Nesting omniauth callbacks under scopes with dynamic segments " \
+            "is not supported. Please, use Devise.omniauth_path_prefix instead."
+        end
+
         path, @scope[:path] = @scope[:path], nil
-        path_prefix = Devise.omniauth_path_prefix || "/#{mapping.path}/auth".squeeze("/")
+        path_prefix = Devise.omniauth_path_prefix || "/#{mapping.fullpath}/auth".squeeze("/")
+
         set_omniauth_path_prefix!(path_prefix)
 
         providers = Regexp.union(mapping.to.omniauth_providers.map(&:to_s))


### PR DESCRIPTION
We need to use `fullpath` to make scoping work for omniauth callbacks.

Previously, the scope would not be applied to omniauth callbacks:

``` ruby
scope '/api' do
  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
end
```

```
...
/api/users/sign_out(.:format)          devise/sessions#destroy
/users/auth/:provider(.:format)        users/omniauth_callbacks#passthru {:provider=>/(?!)/}
...
```

With this patch, the routes look as follows:

```
...
/api/users/sign_out(.:format)          devise/sessions#destroy
/api/users/auth/:provider(.:format)        users/omniauth_callbacks#passthru {:provider=>/(?!)/}
...
```
