### PR TITLE
Prevent infinite loop for ORM's that do not clear record.changes before :after callbacks

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -86,7 +86,8 @@ module Devise
         self.confirmation_token = nil if reconfirmation_required?
         @reconfirmation_required = false
 
-        generate_confirmation_token! if self.confirmation_token.blank?
+        # skip confirmation for ORM's that do not clear the changes of the record in after update callback
+        skip_reconfirmation! and generate_confirmation_token! if self.confirmation_token.blank?
 
         opts = pending_reconfirmation? ? { :to => unconfirmed_email } : { }
         send_devise_notification(:confirmation_instructions, opts)


### PR DESCRIPTION
ActiveRecord clears the record's changes before firing the  after_update callbacks. If this is not the case it will result in an infinite loop updating the token in  send_confirmation_instructions for reconfirming email. This pull request simply prevents this from happening. All tests still passing.
