### PR TITLE
Ignore current password on update_without_password

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -89,6 +89,7 @@ module Devise
       def update_without_password(params, *options)
         params.delete(:password)
         params.delete(:password_confirmation)
+        params.delete(:current_password)
 
         result = update_attributes(params, *options)
         clean_up_passwords

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -189,6 +189,13 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert user.valid_password?('12345678')
   end
 
+  test 'should ignore the current_password field if provided' do
+    user = create_user
+    user.update_without_password(:password => 'pass4321', :password_confirmation => 'pass4321', :current_password => '12345678')
+    assert !user.reload.valid_password?('pass4321')
+    assert user.valid_password?('12345678')
+  end
+
   test 'downcase_keys with validation' do
     user = User.create(:email => "HEllO@example.com", :password => "123456")
     user = User.create(:email => "HEllO@example.com", :password => "123456")


### PR DESCRIPTION
For symmetry we should be ignoring the current_password field as well. This
makes it easier to work in forms where you ask for a password and conditionally
use `update_with_password` or `update_without_password` wether the password is
present or not.
