### PR TITLE
Only skip session timeout check for create and destroy.

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,7 +1,7 @@
 class Devise::SessionsController < DeviseController
   prepend_before_filter :require_no_authentication, :only => [ :new, :create ]
   prepend_before_filter :allow_params_authentication!, :only => :create
-  prepend_before_filter { request.env["devise.skip_timeout"] = true }
+  prepend_before_filter :only => [:create, :destroy] { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new

--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -18,7 +18,7 @@ Warden::Manager.after_set_user do |record, warden, options|
       throw :warden, :scope => scope, :message => :timeout
     end
 
-    unless env['devise.skip_trackable']
+    unless env['devise.skip_timeout'] || env['devise.skip_trackable']
       warden.session(scope)['last_request_at'] = Time.now.utc
     end
   end

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -68,6 +68,20 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
     assert_contain 'You are signed in'
   end
 
+  test 'expired session is not extended by sign in page' do
+    user = sign_in_as_user
+    get expire_user_path(user)
+    assert warden.authenticated?(:user)
+
+    get "/users/sign_in"
+    assert_redirected_to "/users/sign_in"
+    follow_redirect!
+
+    assert_response :success
+    assert_contain 'Sign in'
+    assert_not warden.authenticated?(:user)
+  end
+
   test 'admin does not explode on time out' do
     admin = sign_in_as_admin
     get expire_admin_path(admin)


### PR DESCRIPTION
My understanding of the code is that when a user hits the login page with an expired session, they get redirected to `signed_in_root_path` where the expired session is detected, causing them to be redirected back to the login page. It seems like it would be more efficent to just check the expiration in the first place and avoid the redirect cycle.

We discovered this on a site where we're using devise to authenticate users as part of an an OAuth flow. We discovered that if the user had logged in, waited for the session to expire, and then specifically loaded the sign in page (hitting `Devise::SessionsController#new`), they'd be redirected right through into the OAuth flow without being timed out. We tracked it down to the fact that we'd overridden `after_sign_in_path_for` to send them off to the right callback URL. In that case, 
`request.env["devise.skip_timeout"]` is true, the `require_no_authentication` filter redirects them through the OAuth flow, and the session never expires.

We'd worked around it by just removing the filter e.g. `_process_action_callbacks.reject! {|cb| cb.raw_filter.is_a?(Proc) }` which seemed a little more hacky than it needed to be since the filter was a proc rather than a symbol.
