### PR TITLE
allow_unconfirmed_access_for set to nil means unconfirmed access for unlimited time

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,8 @@
 == master
 
+* enhancements
+  * allow_unconfirmed_access_for config from `:confirmable` module can be set to `nil` that means unconfirmed access for unlimited time. (by @nashby)
+
 * bug fix
   * Generating scoped devise views now uses the correct scoped shared links partial instead of the default devise one (by @nashby)
   * Fix inheriting mailer templates from `Devise::Mailer`

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -102,6 +102,7 @@ module Devise
   @@extend_remember_period = false
 
   # Time interval you can access your account before confirming your account.
+  # nil - allows unconfirmed access for unlimited time
   mattr_accessor :allow_unconfirmed_access_for
   @@allow_unconfirmed_access_for = 0.days
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -158,8 +158,11 @@ module Devise
         #   # allow_unconfirmed_access_for = 0.days
         #   confirmation_period_valid?   # will always return false
         #
+        #   # allow_unconfirmed_access_for = nil
+        #   confirmation_period_valid?   # will always return true
+        #
         def confirmation_period_valid?
-          confirmation_sent_at && confirmation_sent_at.utc >= self.class.allow_unconfirmed_access_for.ago
+          self.class.allow_unconfirmed_access_for.nil? || (confirmation_sent_at && confirmation_sent_at.utc >= self.class.allow_unconfirmed_access_for.ago)
         end
 
         # Checks if the user confirmation happens before the token becomes invalid

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -204,6 +204,13 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert_not user.active_for_authentication?
   end
 
+  test 'should be active when we set allow_unconfirmed_access_for to nil' do
+    Devise.allow_unconfirmed_access_for = nil
+    user = create_user
+    user.confirmation_sent_at = Date.today
+    assert user.active_for_authentication?
+  end
+
   test 'should not be active without confirmation' do
     user = create_user
     user.confirmation_sent_at = nil


### PR DESCRIPTION
closes #2275
