### PR TITLE
Require last_request_at for timeoutable sessions

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -1,25 +1,32 @@
-# Each time a record is set we check whether its session has already timed out
-# or not, based on last request time. If so, the record is logged out and
-# redirected to the sign in page. Also, each time the request comes and the
-# record is set, we set the last request time inside its scoped session to
-# verify timeout in the following request.
-Warden::Manager.after_set_user do |record, warden, options|
+# Each time a record is fetched from a session we check whether its
+# session has already timed out or not, based on last request time.
+# If so, the record is logged out and redirected to the sign in page.
+# Also, each time the record is set, we set the last request time
+# inside its scoped session to verify timeout in the following request.
+
+Warden::Manager.after_fetch do |record, warden, options|
   scope = options[:scope]
   env   = warden.request.env
 
-  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false
+  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false && !env['devise.skip_timeout']
     last_request_at = warden.session(scope)['last_request_at']
 
-    if record.timedout?(last_request_at) && !env['devise.skip_timeout']
+    if record.timedout?(last_request_at)
       warden.logout(scope)
       if record.respond_to?(:expire_auth_token_on_timeout) && record.expire_auth_token_on_timeout
         record.reset_authentication_token!
       end
       throw :warden, :scope => scope, :message => :timeout
     end
-
-    unless env['devise.skip_trackable']
-      warden.session(scope)['last_request_at'] = Time.now.utc
-    end
   end
 end
+
+Warden::Manager.after_set_user do |record, warden, options|
+  scope = options[:scope]
+  env   = warden.request.env
+
+  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false && !env['devise.skip_trackable']
+    warden.session(scope)['last_request_at'] = Time.now.utc
+  end
+end
+

--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -27,7 +27,7 @@ module Devise
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
         return false if remember_exists_and_not_expired?
-        !timeout_in.nil? && last_access && last_access <= timeout_in.ago
+        !timeout_in.nil? && (!last_access || last_access <= timeout_in.ago)
       end
 
       def timeout_in

--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -45,8 +45,16 @@ module Devise
     def sign_in(resource_or_scope, resource=nil)
       scope    ||= Devise::Mapping.find_scope!(resource_or_scope)
       resource ||= resource_or_scope
+
       warden.instance_variable_get(:@users).delete(scope)
-      warden.session_serializer.store(resource, scope)
+      serialized = warden.session_serializer.store(resource, scope)
+
+      if resource.respond_to?(:timedout?)
+        sess = (warden.raw_session["warden.user.#{scope}.session"] ||= {})
+        sess['last_request_at'] = Time.now.utc
+      end
+
+      serialized
     end
 
     # Sign out a given resource or scope by calling logout on Warden.

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -35,6 +35,18 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
     assert warden.authenticated?(:user)
   end
 
+  test 'session without last_request_at is not honored' do
+    user = sign_in_as_user
+    assert_response :success
+    assert warden.authenticated?(:user)
+
+    get clear_timeout_user_path(user)
+
+    get users_path
+    assert_redirected_to users_path
+    assert_not warden.authenticated?(:user)
+  end
+
   test 'time out user session after default limit time' do
     user = sign_in_as_user
     get expire_user_path(user)

--- a/test/models/timeoutable_test.rb
+++ b/test/models/timeoutable_test.rb
@@ -10,8 +10,8 @@ class TimeoutableTest < ActiveSupport::TestCase
     assert_not new_user.timedout?(29.minutes.ago)
   end
 
-  test 'should not be expired when params is nil' do
-    assert_not new_user.timedout?(nil)
+  test 'should be expired when params is nil' do
+    assert new_user.timedout?(nil)
   end
 
   test 'should use timeout_in method' do

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -20,4 +20,9 @@ class UsersController < ApplicationController
     user_session['last_request_at'] = 31.minutes.ago.utc
     render :text => 'User will be expired on next request'
   end
+
+  def clear_timeout
+    user_session['last_request_at'] = nil
+    render :text => 'User will be expired on next request'
+  end
 end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :users, :only => [:index] do
     get :expire, :on => :member
     get :accept, :on => :member
+    get :clear_timeout, :on => :member
 
     authenticate do
       post :exhibit, :on => :member


### PR DESCRIPTION
Currently, `timeoutable` does not invalidate sessions which do not include a `last_request_at` value. This means that any session issued prior to configuring timeoutable or as a result of a request that sets `devise.skip_trackable` will not ever be timed out.

This change would treat any session that does not include a `last_request_at` value as a timed-out session, so that it will not be possible to bypass timeout restrictions by replaying such sessions.

Prior to this change, `last_request_at` was checked as part of the `after_set_user` hook. This change moves the timeout test to the `after_fetch` hook, which is only fired when the user is set from the session. This is to avoid triggering a session timeout event when authenticating with methods that do not rely on the session while continuing to ensure that the session user is only valid when the session is not timed out. 

The `after_set_user` hook is still used to update the value of `last_request_at`, so any authentication method that accompanies a session will continue to refresh that date.

This change highlights but does not correct a latent issue in the interaction of `timeoutable` and `token_authenticatable`. When the `expire_auth_token_on_timeout` is set, the token used by the `token_authenticatable` strategy is invalidated if used along with an expired session.

This behavior is not changed. If an expired session is present, the authentication token will be invalidated by the `after_fetch` hook, which is run before the token authentication strategy is tried.

However, this restriction is easily bypassed by not including a session or session id with the token-authenticated request. Prior to this change, the restriction would have been bypassed because the `after_set_user` hook fired on successful token authentication would have allowed a null `last_request_at`. With this change, the restriction is bypassed because the `after_fetch` hook is never fired.

It might be worth considering deprecating `expire_auth_token_on_timeout` or replacing it with a mechanism like that used by `rememberable`, since it may be providing a false sense of security.
