### PR TITLE
Add #skip_confirmation_notification! to Confirmable

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -34,7 +34,7 @@ module Devise
 
       included do
         before_create :generate_confirmation_token, :if => :confirmation_required?
-        after_create  :send_on_create_confirmation_instructions, :if => :confirmation_required?
+        after_create  :send_on_create_confirmation_instructions, :if => :send_confirmation_notification?
         before_update :postpone_email_change_until_confirmation, :if => :postpone_email_change?
         after_update  :send_confirmation_instructions, :if => :reconfirmation_required?
       end
@@ -117,6 +117,12 @@ module Devise
       # to be generated, call skip_confirmation!
       def skip_confirmation!
         self.confirmed_at = Time.now.utc
+      end
+
+      # Skips sending the confirmation notification email after_create. Unlike
+      # #skip_confirmation!, record still requires confirmation.
+      def skip_confirmation_notification!
+        @skip_confirmation_notification = true
       end
 
       # If you don't want reconfirmation to be sent, neither a code
@@ -221,6 +227,10 @@ module Devise
 
         def reconfirmation_required?
           self.class.reconfirmable && @reconfirmation_required
+        end
+
+        def send_confirmation_notification?
+          confirmation_required? && !@skip_confirmation_notification
         end
 
       module ClassMethods

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -104,6 +104,16 @@ class ConfirmableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should skip confirmation e-mail without confirming if skip_confirmation_notification! is invoked' do
+    user = new_user
+    user.skip_confirmation_notification!
+
+    assert_email_not_sent do
+      user.save!
+      assert !user.confirmed?
+    end
+  end
+
   test 'should find a user to send confirmation instructions' do
     user = create_user
     confirmation_user = User.send_confirmation_instructions(:email => user.email)


### PR DESCRIPTION
This pull request adds an instance method, `#skip_confirmation_notification!`, which sets a flag on a confirmable object that will skip the `send_on_create_confirmation_instructions` callback, allowing you to manually `send_confirmation_instructions` at your leisure.

I have an app in which I want to create a confirmable user record as part of a transaction, and only send the confirmation e-mail if the entire transaction succeeds. `#skip_confirmation!` is not the correct solution for my use case, because it does not _only_ skip sending the confirmation e-mail, but it also immediately confirms the user account.

[This stackoverflow post](http://stackoverflow.com/questions/4343454/delay-and-or-resend-devises-confirmation-email-for-manually-created-users) and devise issue #2198 also suggest that there are other use cases in which this behavior would be desirable.

This is my first attempt at contributing to an open source project, and I'm pretty new to software development generally, so I would appreciate any feedback on ways this pull request could be improved.
