### PR TITLE
Make use of warden's scoped serialization

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -421,6 +421,17 @@ module Devise
 
       Devise.mappings.each_value do |mapping|
         warden_config.scope_defaults mapping.name, :strategies => mapping.strategies
+
+        warden_config.serialize_into_session(mapping.name) do |record|
+          mapping.to.serialize_into_session(record)
+        end
+
+        warden_config.serialize_from_session(mapping.name) do |key|
+          # Previous versions contained an additional entry at the beginning of
+          # key with the record's class name.
+          args = key[-2, 2]
+          mapping.to.serialize_from_session(*args)
+        end
       end
 
       @@warden_config_block.try :call, Devise.warden_config

--- a/lib/devise/rails/warden_compat.rb
+++ b/lib/devise/rails/warden_compat.rb
@@ -12,32 +12,3 @@ module Warden::Mixins::Common
     request.cookie_jar
   end
 end
-
-class Warden::SessionSerializer
-  def serialize(record)
-    klass = record.class
-    array = klass.serialize_into_session(record)
-    array.unshift(klass.name)
-  end
-
-  def deserialize(keys)
-    klass_name, *args = keys
-
-    begin
-      klass = ActiveSupport::Inflector.constantize(klass_name)
-      if klass.respond_to? :serialize_from_session
-        klass.serialize_from_session(*args)
-      else
-        Rails.logger.warn "[Devise] Stored serialized class #{klass_name} seems not to be Devise enabled anymore. Did you do that on purpose?"
-        nil
-      end
-    rescue NameError => e
-      if e.message =~ /uninitialized constant/
-        Rails.logger.debug "[Devise] Trying to deserialize invalid class #{klass_name}"
-        nil
-      else
-        raise
-      end
-    end
-  end
-end


### PR DESCRIPTION
This is in response to the second point in the following discussion with @josevalim on the devise mailing list:
[devise incompatibilities with other gems based on warden](https://groups.google.com/forum/?fromgroups=#!topic/plataformatec-devise/ubEiaFSJwNc)
