### PR TITLE
Require password confirmation not to be nil on a new record

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -31,6 +31,7 @@ module Devise
           validates_format_of     :email, :with  => email_regexp, :allow_blank => true, :if => :email_changed?
 
           validates_presence_of     :password, :if => :password_required?
+          validates_presence_of     :password_confirmation, :if => :password_required?
           validates_confirmation_of :password, :if => :password_required?
           validates_length_of       :password, :within => password_length, :allow_blank => true
         end

--- a/test/models/authenticatable_test.rb
+++ b/test/models/authenticatable_test.rb
@@ -6,7 +6,7 @@ class AuthenticatableTest < ActiveSupport::TestCase
   end
 
   test 'find_first_by_auth_conditions allows custom filtering parameters' do
-    user = User.create!(:email => "example@example.com", :password => "123456")
+    user = User.create!(:email => "example@example.com", :password => "123456", :password_confirmation => "123456")
     assert_equal User.find_first_by_auth_conditions({ :email => "example@example.com" }), user
     assert_nil User.find_first_by_auth_conditions({ :email => "example@example.com" }, :id => user.id.to_s.next)
   end

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -54,6 +54,12 @@ class ValidatableTest < ActiveSupport::TestCase
   end
 
   test 'should require confirmation to be set when creating a new record' do
+    user = new_user(:password => 'new_password', :password_confirmation => nil)
+    assert user.invalid?
+    assert_equal 'can\'t be blank', user.errors[:password_confirmation].join
+  end
+
+  test 'should require confirmation to match password when creating a new record' do
     user = new_user(:password => 'new_password', :password_confirmation => 'blabla')
     assert user.invalid?
     assert_equal 'doesn\'t match confirmation', user.errors[:password].join


### PR DESCRIPTION
Change Validatable module to validate password confirmation presence
when creating a new record.
Previously only matching validation was being performed and the
following would work:

`User.create!(:email => 'johndoe@gmail.com', :password => '12345678', :password_confirmation => nil)`

Signed-off-by: João Soares jsoaresgeral@gmail.com
