### PR TITLE
Improve documentation on sending delayed emails

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -141,13 +141,25 @@ module Devise
       #       protected
       #
       #       def send_devise_notification(notification)
-      #         pending_notifications << notification
+      #         # if the record is new or changed then delay the
+      #         # delivery until the after_commit callback otherwise
+      #         # send now because after_commit will not be called.
+      #         if new_record? || changed?
+      #           pending_notifications << notification
+      #         else
+      #           devise_mailer.send(notification, self).deliver
+      #         end
       #       end
       #
       #       def send_pending_notifications
       #         pending_notifications.each do |n|
       #           devise_mailer.send(n, self).deliver
       #         end
+      #
+      #         # Empty the pending notifications array because the
+      #         # after_commit hook can be called multiple times which
+      #         # could cause multiple emails to be sent.
+      #         pending_notifications.clear
       #       end
       #
       #       def pending_notifications


### PR DESCRIPTION
There are a couple of gotchas in the existing documentation about the `send_devise_notification` hook.
1.  The `after_commit` callback can be called multiple times so you should clear the array otherwise any additional invocations will trigger extra copies of the email.
2.  The `after_commit` callback is only called when a record is created or updated so you need to check for `new_record?` or `changed?` before adding it to `pending_notifications` otherwise it's okay to send it immediately.

The `new_record? || changed?` condition is necessary because the latter isn't always true for new records, e.g:

``` ruby
>> User.new.changed?
=> false
```
