### PR TITLE
Fixed Bug: "You are already signed in" after login

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -126,7 +126,7 @@ MESSAGE
       warden.authenticated?(resource_name)
     end
 
-    if authenticated && resource = warden.user(resource_name)
+    if authenticated && resource == warden.user(resource_name)
       flash[:alert] = I18n.t("devise.failure.already_authenticated")
       redirect_to after_sign_in_path_for(resource)
     end


### PR DESCRIPTION
In #require_no_authentication changed line
 if authenticated && resource = warden.user(resource_name)
to
 if authenticated && resource == warden.user(resource_name)
(note the equal signs) to fix a Bug that showed "You are already signed in" after login.
