### PR TITLE
Separates sign_up and sign_in on ConfirmationsController

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -21,7 +21,7 @@ class Devise::ConfirmationsController < DeviseController
 
     if resource.errors.empty?
       set_flash_message(:notice, :confirmed) if is_navigational_format?
-      sign_in(resource_name, resource)
+      sign_up(resource_name, resource)
       respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
     else
       respond_with_navigational(resource.errors, :status => :unprocessable_entity){ render :new }
@@ -38,6 +38,12 @@ class Devise::ConfirmationsController < DeviseController
     # The path used after confirmation.
     def after_confirmation_path_for(resource_name, resource)
       after_sign_in_path_for(resource)
+    end
+
+    # Signs in a user on sign up. You can overwrite this method in your own
+    # ConfirmationsController.
+    def sign_up(resource_name, resource)
+      sign_in(resource_name, resource)
     end
 
 end


### PR DESCRIPTION
Currently the RegistrationsController allows you to hook into the sign_up flow by overriding sign_up in that controller. This work was done in 

https://github.com/plataformatec/devise/pull/2111

If you were to use the confirmable module, this hook does not work because the sign_up call gets bypassed when resource.active_for_authentication? gets called (and returns false). 

We would be able to reintroduce this hook by using the same pattern in the ConfirmationsController and allowing it to be overridden there instead. It also makes things more consistent and is a minor code change.

Hope this works! 

p/s Thanks for the work on Devise, it is awesome!
