### PR TITLE
Simply SCrypt

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -3,6 +3,7 @@
 * enhancements
   * Add `#skip_confirmation_notification!` method to `Confirmable`. Allows skipping confirmation email without auto-confirming. (by @gregates)
   * allow_unconfirmed_access_for config from `:confirmable` module can be set to `nil` that means unconfirmed access for unlimited time. (by @nashby)
+  * Prefer scrypt if available to bcrypt (no bcrypt/other -> scrypt migrations yet)
 
 * bug fix
   * Generating scoped devise views now uses the correct scoped shared links partial instead of the default devise one (by @nashby)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -222,7 +222,7 @@ module Devise
   @@omniauth_path_prefix = nil
 
   def self.encryptor=(value)
-    warn "\n[DEVISE] To select a encryption which isn't bcrypt, you should use devise-encryptable gem.\n"
+    warn "\n[DEVISE] To select a encryption which isn't bcrypt, you should use devise-encryptable gem.\n" unless value.to_s == 'scrypt' || value.to_s == 'bcrypt'
   end
 
   def self.use_salt_as_remember_token=(value)


### PR DESCRIPTION
Because `devise-encryptable` + `devise-scrypt` + `scrypt` currently doesn't work and are too many moving/incompatible parts, this is patch makes it far simpler to choose from the two best available secure hash engines available.  Note: the `scrypt` gem is stable but seeking a new maintainer.

For a project without existing users, this works:
1. Ensure these are in your Gemfile

``` ruby

    gem 'devise' # or :git => 'https://github.com/steakknife/devise.git', :branch => 'feature__proper_scrypt' # for now
    gem 'scrypt'
```
1. Don't use `devise-encryptable`
2. Remove `:encryptable` from the User model
3. Set `config.encryptor = :scrypt` in config/initializers/devise.rb
4. Optionally set SCrypt settings

``` ruby
    # config/initializers/scrypt.rb
    SCrypt::Engine::DEFAULTS[:key_len]     = 128
    SCrypt::Engine::DEFAULTS[:salt_size]   = 32
    SCrypt::Engine::DEFAULTS[:max_mem]     = 4*1024*1024
    SCrypt::Engine::DEFAULTS[:max_time]    = 0.4
    SCrypt::Engine::DEFAULTS[:max_memfrac] = 0.3
```

6a. Create a new migration `rails g migration DeviseScryptPasswordLength`
6b. Drop this into your project's migrations:

``` ruby
    # db/migrate/20130331100000_devise_scrypt_password_length.rb
   class DeviseScryptPasswordLength < ActiveRecord::Migration  
      def up  
        change_column :users, :encrypted_password, :text
      end
      def down
        change_column :users, :encrypted_password, :string
      end
    end
```

Note: This does not convert passwords using Bcrypt or anything else.  It's only for projects without any existing users.
