### PR TITLE
Generate documentation for protected methods.

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--protected
+--no-private
+--embed-mixin ClassMethods
+-
+README.md
+CHANGELOG.rdoc
+CONTRIBUTING.md
+MIT-LICENSE
+


### PR DESCRIPTION
Some important method documentation as [send_devise_notification](https://github.com/plataformatec/devise/blob/master/lib/devise/models/authenticatable.rb#L130) is not
being generated.

This configuration file will customize documentation to include
protected methods and should work with rubydoc.info.

I've also added the embed-mixin option, that is not currently working
because yard cannot identify them correctly, but it should simplify
documentation a lot once someone can fix it.
