### PR TITLE
Fix devise sender bug with custom devise mailers.

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -54,8 +54,9 @@ module Devise
       end
 
       def mailer_sender(mapping, sender = :from)
-        if default_params[sender].present?
-          default_params[sender]
+        default_sender = default_params[sender]
+        if default_sender.present?
+          default_sender.respond_to?(:call) ? default_sender.bind(self).call : default_sender
         elsif Devise.mailer_sender.is_a?(Proc)
           Devise.mailer_sender.call(mapping.name)
         else

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -46,6 +46,11 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     assert_equal ['custom@example.com'], mail.from
   end
 
+  test 'setup sender from curstom mailer defaults with proc' do
+    Devise.mailer = 'Users::FromProcMailer'
+    assert_equal ['custom@example.com'], mail.from
+  end
+
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
     assert_not_blank mail.body.encoded

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -48,6 +48,11 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
     assert_equal ['custom@example.com'], mail.from
   end
 
+  test 'setup sender from curstom mailer defaults with proc' do
+    Devise.mailer = 'Users::FromProcMailer'
+    assert_equal ['custom@example.com'], mail.from
+  end
+
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
     assert_not_blank mail.body.encoded

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -49,6 +49,11 @@ class UnlockInstructionsTest < ActionMailer::TestCase
     assert_equal ['custom@example.com'], mail.from
   end
 
+  test 'setup sender from curstom mailer defaults with proc' do
+    Devise.mailer = 'Users::FromProcMailer'
+    assert_equal ['custom@example.com'], mail.from
+  end
+
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
     assert_not_blank mail.body.encoded

--- a/test/rails_app/app/mailers/users/mailer.rb
+++ b/test/rails_app/app/mailers/users/mailer.rb
@@ -6,3 +6,7 @@ class Users::ReplyToMailer < Devise::Mailer
   default :from     => 'custom@example.com'
   default :reply_to => 'custom_reply_to@example.com'
 end
+
+class Users::FromProcMailer < Devise::Mailer
+  default :from     => proc { 'custom@example.com' }
+end


### PR DESCRIPTION
The devise sender detection must take into account that the default
sender set in the custom devise mailer can be a proc.

``` ruby
class CustomMailer < Devise::Mailer
  default from: -> { 'custom@example.com' }
end
```

This breaks the mailer, the lambda is passed to the delivery mechanism as is and it breaks.
