### PR TITLE
Renaming _filter to _action for rails4.

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -564,7 +564,7 @@ Notes: https://github.com/plataformatec/devise/wiki/How-To:-Upgrade-to-Devise-2.
 == 1.0.5
 
 * bug fix
-  * Use prepend_before_filter in require_no_authentication.
+  * Use prepend_before_action in require_no_authentication.
   * require_no_authentication on unlockable.
   * Fix a bug when giving an association proxy to devise.
   * Do not use lock! on lockable since it's part of ActiveRecord API.
@@ -819,7 +819,7 @@ Notes: https://github.com/plataformatec/devise/wiki/How-To:-Upgrade-to-Devise-2.
   * Renamed mail_sender to mailer_sender
 
 * enhancements
-  * skip_before_filter added in Devise controllers
+  * skip_before_action added in Devise controllers
   * Use home_or_root_path on require_no_authentication as well
   * Added devise_controller?, useful to select or reject filters in ApplicationController
   * Allow :path_prefix to be given to devise_for

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Note that you should re-start your app here if you've already started it. Otherw
 
 ### Controller filters and helpers
 
-Devise will create some helpers to use inside your controllers and views. To set up a controller with user authentication, just add this before_filter:
+Devise will create some helpers to use inside your controllers and views. To set up a controller with user authentication, just add this before_action:
 
 ```ruby
-before_filter :authenticate_user!
+before_action :authenticate_user!
 ```
 
 To verify if a user is signed in, use the following helper:
@@ -155,7 +155,7 @@ config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 Notice that if your devise model is not called "user" but "member", then the helpers you should use are:
 
 ```ruby
-before_filter :authenticate_member!
+before_action :authenticate_member!
 
 member_signed_in?
 
@@ -188,7 +188,7 @@ In case you want to customize the permitted parameters (the lazy way™) you can
 
 ```ruby
 class ApplicationController < ActionController::Base
-  before_filter :configure_permitted_parameters, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
@@ -367,7 +367,7 @@ devise :database_authenticatable, :timeoutable
 devise_for :admins
 
 # Inside your protected controller
-before_filter :authenticate_admin!
+before_action :authenticate_admin!
 
 # Inside your controllers and views
 admin_signed_in?

--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Devise::OmniauthCallbacksController < DeviseController
-  prepend_before_filter { request.env["devise.skip_timeout"] = true }
+  prepend_before_action { request.env["devise.skip_timeout"] = true }
 
   def passthru
     render :status => 404, :text => "Not found. Authentication passthru."

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -1,7 +1,7 @@
 class Devise::PasswordsController < DeviseController
-  prepend_before_filter :require_no_authentication
+  prepend_before_action :require_no_authentication
   # Render the #edit only if coming from a reset password email link
-  append_before_filter :assert_reset_token_passed, :only => :edit
+  append_before_action :assert_reset_token_passed, :only => :edit
 
   # GET /resource/password/new
   def new

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -1,6 +1,6 @@
 class Devise::RegistrationsController < DeviseController
-  prepend_before_filter :require_no_authentication, :only => [ :new, :create, :cancel ]
-  prepend_before_filter :authenticate_scope!, :only => [:edit, :update, :destroy]
+  prepend_before_action :require_no_authentication, :only => [ :new, :create, :cancel ]
+  prepend_before_action :authenticate_scope!, :only => [:edit, :update, :destroy]
 
   # GET /resource/sign_up
   def new

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,7 +1,7 @@
 class Devise::SessionsController < DeviseController
-  prepend_before_filter :require_no_authentication, :only => [ :new, :create ]
-  prepend_before_filter :allow_params_authentication!, :only => :create
-  prepend_before_filter { request.env["devise.skip_timeout"] = true }
+  prepend_before_action :require_no_authentication, :only => [ :new, :create ]
+  prepend_before_action :allow_params_authentication!, :only => :create
+  prepend_before_action { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -1,5 +1,5 @@
 class Devise::UnlocksController < DeviseController
-  prepend_before_filter :require_no_authentication
+  prepend_before_action :require_no_authentication
 
   # GET /resource/unlock/new
   def new

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -9,7 +9,7 @@ class DeviseController < Devise.parent_controller.constantize
   hide_action *helpers
   helper_method *helpers
 
-  prepend_before_filter :assert_is_devise_resource!
+  prepend_before_action :assert_is_devise_resource!
   respond_to :html if mimes_for_respond_to.empty?
 
   # Gets the actual resource stored in the instance variable
@@ -89,10 +89,10 @@ MESSAGE
     instance_variable_set(:"@#{resource_name}", new_resource)
   end
 
-  # Helper for use in before_filters where no authentication is required.
+  # Helper for use in before_actions where no authentication is required.
   #
   # Example:
-  #   before_filter :require_no_authentication, :only => :new
+  #   before_action :require_no_authentication, :only => :new
   def require_no_authentication
     assert_is_devise_resource!
     return unless is_navigational_format?

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -16,7 +16,7 @@ module Devise
       end
 
       # Define authentication filters and accessor helpers based on mappings.
-      # These filters should be used inside the controllers as before_filters,
+      # These filters should be used inside the controllers as before_actions,
       # so you can control the scope of the user who should be signed in to
       # access that specific controller/action.
       # Example:
@@ -36,8 +36,8 @@ module Devise
       #     admin_session       # Session data available only to the admin scope
       #
       #   Use:
-      #     before_filter :authenticate_user!  # Tell devise to use :user map
-      #     before_filter :authenticate_admin! # Tell devise to use :admin map
+      #     before_action :authenticate_user!  # Tell devise to use :user map
+      #     before_action :authenticate_admin! # Tell devise to use :admin map
       #
       def self.define_helpers(mapping) #:nodoc:
         mapping = mapping.name
@@ -75,7 +75,7 @@ module Devise
       # the controllers defined inside devise. Useful if you want to apply a before
       # filter to all controllers, except the ones in devise:
       #
-      #   before_filter :my_filter, :unless => :devise_controller?
+      #   before_action :my_filter, :unless => :devise_controller?
       def devise_controller?
         is_a?(DeviseController)
       end

--- a/lib/devise/models/token_authenticatable.rb
+++ b/lib/devise/models/token_authenticatable.rb
@@ -24,7 +24,7 @@ module Devise
     # request will be considered as a new sign in (since there is no session in
     # APIs). You can disable this by creating a before filter as follow:
     #
-    #   before_filter :skip_trackable
+    #   before_action :skip_trackable
     #
     #   def skip_trackable
     #     request.env['devise.skip_trackable'] = true

--- a/test/rails_app/app/controllers/admins_controller.rb
+++ b/test/rails_app/app/controllers/admins_controller.rb
@@ -1,5 +1,5 @@
 class AdminsController < ApplicationController
-  before_filter :authenticate_admin!
+  before_action :authenticate_admin!
 
   def index
   end

--- a/test/rails_app/app/controllers/application_controller.rb
+++ b/test/rails_app/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  before_filter :current_user, :unless => :devise_controller?
-  before_filter :authenticate_user!, :if => :devise_controller?
+  before_action :current_user, :unless => :devise_controller?
+  before_action :authenticate_user!, :if => :devise_controller?
   respond_to *Mime::SET.map(&:to_sym)
 end

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
-  prepend_before_filter :current_user, :only => :exhibit
-  before_filter :authenticate_user!, :except => [:accept, :exhibit]
+  prepend_before_action :current_user, :only => :exhibit
+  before_action :authenticate_user!, :except => [:accept, :exhibit]
   respond_to :html, :xml
 
   def index


### PR DESCRIPTION
_filter methods will still work with no deprecation warnings in Rails4
but to future proof the code, replaced filter with action.
