### PR TITLE
Add ability to override the redirect path after user has reset their password

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -34,14 +34,14 @@ class Devise::PasswordsController < DeviseController
       flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
       set_flash_message(:notice, flash_message) if is_navigational_format?
       sign_in(resource_name, resource)
-      respond_with resource, :location => after_reseting_password_path_for(resource)
+      respond_with resource, :location => after_resetting_password_path_for(resource)
     else
       respond_with resource
     end
   end
 
   protected
-    def after_reseting_password_path_for(resource)
+    def after_resetting_password_path_for(resource)
       after_sign_in_path_for(resource)
     end
 

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -14,15 +14,15 @@ class PasswordsControllerTest < ActionController::TestCase
     put :update, "user"=>{"reset_password_token"=>@user.reset_password_token, "password"=>"123456", "password_confirmation"=>"123456"}
   end
 
-  test 'redirect to after_sign_in_path_for if after_reseting_password_path_for is not overridden' do
+  test 'redirect to after_sign_in_path_for if after_resetting_password_path_for is not overridden' do
     put_update_with_params
     assert_redirected_to "http://test.host/"
   end
 
-  test 'redirect accordingly if after_reseting_password_path_for is overridden' do
+  test 'redirect accordingly if after_resetting_password_path_for is overridden' do
     custom_path = "http://custom.path/"
-    # Overwrite after_reseting_password_path_for with custom_path
-    Devise::PasswordsController.any_instance.stubs(:after_reseting_password_path_for).with(@user).returns(custom_path)
+    # Overwrite after_resetting_password_path_for with custom_path
+    Devise::PasswordsController.any_instance.stubs(:after_resetting_password_path_for).with(@user).returns(custom_path)
     put_update_with_params
     assert_redirected_to custom_path
   end


### PR DESCRIPTION
I added the ability to override the redirect path after user has reset their password. If `after_reseting_password_path_for` is not overridden, user will get redirect to `after_sign_in_path_for`. 

I found the need for this while working on a project, where we want to redirect the user to profile edit page after resetting their password, and wanted the after sign in path to be the homepage.
