### PR TITLE
License in Gem Spec

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.name        = "devise"
   s.version     = Devise::VERSION.dup
   s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
+  s.license     = ["MIT"]
   s.summary     = "Flexible authentication solution for Rails with Warden"
   s.email       = "contact@plataformatec.com.br"
   s.homepage    = "http://github.com/plataformatec/devise"


### PR DESCRIPTION
 Hi!
  I fixed the gemspec so the license actually displays when you look at 
gem specification devise 
or 
gem list devise -d

The license has to be listed as an array ie: ["MIT"] to actually display. Please let me know if you need anything else with this.

Thanks!
**Renée
