### PR TITLE
Fix spelling error in doc block

### DIFF
--- a/lib/devise/models/omniauthable.rb
+++ b/lib/devise/models/omniauthable.rb
@@ -8,7 +8,7 @@ module Devise
     #
     # Oauthable adds the following options to devise_for:
     #
-    #   * +omniauth_providers+: Which providers are avaialble to this model. It expects an array:
+    #   * +omniauth_providers+: Which providers are available to this model. It expects an array:
     #
     #       devise_for :database_authenticatable, :omniauthable, :omniauth_providers => [:twitter]
     #


### PR DESCRIPTION
Just noticed a small typo in the doc for "available"
