### PR TITLE
Allow to change email for already created user with blank email

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -226,14 +226,14 @@ module Devise
           self.email = self.email_was
         end
 
-        def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && !@bypass_postpone
+        def postpone_email_change?          
+          postpone = self.class.reconfirmable && email_changed? && email_was.present? && !@bypass_postpone
           @bypass_postpone = false
           postpone
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required
+          self.class.reconfirmable && @reconfirmation_required && email_was.blank?
         end
 
         def send_confirmation_notification?


### PR DESCRIPTION
Hi, 

I have the following config: 
# config/devise.rb

Devise.allow_unconfirmed_access_for = 30.days
# app/models/user.rb

 def email_required?
    (created_at || Time.now) < Devise.allow_unconfirmed_access_for.ago
  end

Users are signing up through omniauth only, so I'm not asking for email address if they do not provide it. However when later on the user want's to change his email - the system won't allow him to do so, because of :postpone_email_change? and sends mail to the user ( to blank email address ), while sending mail is cool, I want it to go to the real email address and email address to be changed accordingly. 

This logic only works if the user had blank email initially
