### PR TITLE
Fix redundant assignment of self.resource in Devise::RegistrationsController

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -10,7 +10,7 @@ class Devise::RegistrationsController < DeviseController
 
   # POST /resource
   def create
-    self.resource = build_resource(sign_up_params)
+    build_resource(sign_up_params)
 
     if resource.save
       if resource.active_for_authentication?


### PR DESCRIPTION
`Devise::RegistrationsController#create` sets `self.resource` (on line 13) to the return value of `build_resource`—which is `nil`, because `build_resource` sets `self.resource` to an actual resource object. This caused attempting to save the resource (two lines down, on line 15) to fail with "undefined method `save' on nil:NilClass", e.g. when attempting to register a new user.
