### PR TITLE
Avoid sending confirmations to blank emails.

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -227,17 +227,17 @@ module Devise
         end
 
         def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && !@bypass_postpone
+          postpone = self.class.reconfirmable && email_changed? && !@bypass_postpone && !self.email.blank?
           @bypass_postpone = false
           postpone
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required
+          self.class.reconfirmable && @reconfirmation_required && !self.email.blank?
         end
 
         def send_confirmation_notification?
-          confirmation_required? && !@skip_confirmation_notification
+          confirmation_required? && !@skip_confirmation_notification && !self.email.blank?
         end
 
       module ClassMethods

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -114,6 +114,14 @@ class ConfirmableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should not send confirmation when no email is provided' do
+    assert_email_not_sent do
+      user = new_user
+      user.email = ''
+      user.save(:validate => false)
+    end
+  end
+
   test 'should find a user to send confirmation instructions' do
     user = create_user
     confirmation_user = User.send_confirmation_instructions(:email => user.email)
@@ -334,6 +342,15 @@ class ReconfirmableTest < ActiveSupport::TestCase
     assert admin.confirm!
     assert_email_not_sent do
       assert admin.update_attributes(:password => 'newpass', :password_confirmation => 'newpass')
+    end
+  end
+
+  test 'should not send confirmation by email after changing to a blank email' do
+    admin = create_admin
+    assert admin.confirm!
+    assert_email_not_sent do
+      admin.email = ''
+      admin.save(:validate => false)
     end
   end
 


### PR DESCRIPTION
When writing tests for my Devise model, I came across an issue when using the `should validate_uniqueness_of` matcher from [Shoulda](https://github.com/thoughtbot/shoulda-matchers).

```
  1) User
     Failure/Error: it { should validate_uniqueness_of :username }
     ArgumentError:
       At least one recipient (To, Cc or Bcc) is required to send a message
     # ./spec/models/user_spec.rb:6:in `block (2 levels) in <top (required)>'
```

Shoulda [skips validations](https://github.com/thoughtbot/shoulda-matchers/blob/2b9130b46266d062dd731ce58950406c5fa94f71/lib/shoulda/matchers/active_model/validate_uniqueness_of_matcher.rb#L126) when creating records for this matcher. As it is only filling in one attribute, which in this case is username, Devise tries to send a confirmation email to a blank email address after the first record is created because it assumes validations won't be skipped. This results in the error above.

I fixed this issue by modifying the methods inside confirmable that consider whether to send (re)confirmations and consider whether postponing the email address change for reconfirmations to account for blank email addresses.
