### PR TITLE
permit password param on sign in

### DIFF
--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -41,7 +41,7 @@ module Devise
     end
 
     def sign_in
-      default_params.permit(auth_keys)
+      default_params.permit(auth_keys + [:password])
     end
 
     def sign_up


### PR DESCRIPTION
without this, I'm seeing:

Unpermitted parameters: password
