### PR TITLE
Expose reset password and confirmation tokens

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -93,7 +93,7 @@ module Devise
         self.confirmation_token = nil if reconfirmation_required?
         @reconfirmation_required = false
 
-        generate_confirmation_token! if self.confirmation_token.blank?
+        ensure_confirmation_token!
 
         opts = pending_reconfirmation? ? { :to => unconfirmed_email } : { }
         send_devise_notification(:confirmation_instructions, opts)
@@ -107,9 +107,9 @@ module Devise
         end
       end
       
-      def get_or_create_confirmation_token
+      # Generate a confirmation token unless already exists and save the record.
+      def ensure_confirmation_token!
         generate_confirmation_token! if should_generate_confirmation_token?
-        self.confirmation_token
       end 
 
       # Overwrites active_for_authentication? for confirmation

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -44,13 +44,13 @@ module Devise
 
       # Resets reset password token and send reset password instructions by email
       def send_reset_password_instructions
-        generate_reset_password_token! if should_generate_reset_token?
+        ensure_reset_password_token!
         send_devise_notification(:reset_password_instructions)
       end
       
-      def get_or_create_reset_password_token
+      # Generate reset password token unless already exists and save the record.
+      def ensure_reset_password_token!
         generate_reset_password_token! if should_generate_reset_token?
-        self.reset_password_token
       end 
       
       # Checks if the reset password token sent is within the limit time.

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -300,16 +300,17 @@ class ConfirmableTest < ActiveSupport::TestCase
       user = create_user
       user.update_attribute(:confirmation_sent_at, 4.days.ago)
       old = user.confirmation_token
-      token = user.get_or_create_confirmation_token
+      user.ensure_confirmation_token!
       assert_not_equal user.confirmation_token, old
-      assert_equal user.confirmation_token, token
     end
   end
   
   test 'should not generate a new token when a valid one exists' do
     user = create_user
     assert_not_nil user.confirmation_token
-    assert_equal user.confirmation_token, user.get_or_create_confirmation_token
+    old = user.confirmation_token
+    user.ensure_confirmation_token!
+    assert_equal user.confirmation_token, old
   end
 end
 

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -110,7 +110,7 @@ class RecoverableTest < ActiveSupport::TestCase
 
   test 'should find a user to reset his password based on reset_password_token' do
     user = create_user
-    user.get_or_create_reset_password_token
+    user.ensure_reset_password_token!
 
     reset_password_user = User.reset_password_by_token(:reset_password_token => user.reset_password_token)
     assert_equal reset_password_user, user
@@ -130,7 +130,7 @@ class RecoverableTest < ActiveSupport::TestCase
 
   test 'should return a new record with errors if password is blank' do
     user = create_user
-    user.get_or_create_reset_password_token
+    user.ensure_reset_password_token!
 
     reset_password_user = User.reset_password_by_token(:reset_password_token => user.reset_password_token, :password => '')
     assert_not reset_password_user.errors.empty?
@@ -140,7 +140,7 @@ class RecoverableTest < ActiveSupport::TestCase
   test 'should reset successfully user password given the new password and confirmation' do
     user = create_user
     old_password = user.password
-    user.get_or_create_reset_password_token
+    user.ensure_reset_password_token!
 
     User.reset_password_by_token(
       :reset_password_token => user.reset_password_token,
@@ -179,7 +179,7 @@ class RecoverableTest < ActiveSupport::TestCase
     swap Devise, :reset_password_within => 1.hour do
       user = create_user
       old_password = user.password
-      user.get_or_create_reset_password_token
+      user.ensure_reset_password_token!
       user.reset_password_sent_at = 2.days.ago
       user.save!
 
@@ -207,7 +207,7 @@ class RecoverableTest < ActiveSupport::TestCase
     user = create_user
     assert_nil user.reset_password_token
     
-    token = user.get_or_create_reset_password_token
+    user.ensure_reset_password_token!
     assert_not_nil user.reset_password_token
   end
   
@@ -215,6 +215,8 @@ class RecoverableTest < ActiveSupport::TestCase
     user = create_user
     user.send :generate_reset_password_token!
     assert_not_nil user.reset_password_token
-    assert_equal user.reset_password_token, user.get_or_create_reset_password_token
+    old = user.reset_password_token
+    user.ensure_reset_password_token!
+    assert_equal user.reset_password_token, old
   end  
 end


### PR DESCRIPTION
Picked up from https://github.com/plataformatec/devise/issues/2462

Currently there is no way to use custom mailers that include single use confirmation/password reset tokens generated by Devise. A developer might want to do this if the app should send different types of mail depending on the type or status of the user. For example, one reset password mail for a regular user, another for premium users.
