### PR TITLE
Enable to skip sending reconfirmation email when reconfirmable is on and skip_confirmation_notification! is invoked

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -231,11 +231,16 @@ module Devise
 
         # Regenerates a new token.
         def regenerate_confirmation_token
+          unconfirm if confirmed?
           generate_confirmation_token
         end
 
         def regenerate_confirmation_token!
           regenerate_confirmation_token && save(:validate => false)
+        end
+
+        def unconfirm
+          self.confirmed_at = nil
         end
 
         def after_password_reset

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -382,11 +382,11 @@ class ReconfirmableTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should stay confirmed when email is changed' do
+  test 'should be unconfirmed when email is changed' do
     admin = create_admin
     assert admin.confirm!
     assert admin.update_attributes(:email => 'new_test@example.com')
-    assert admin.confirmed?
+    assert !admin.confirmed?
   end
 
   test 'should update email only when it is confirmed' do


### PR DESCRIPTION
We could always generate a confirmation token but not sending a
confirmation email by invoking the skip_confirmation_notification!
method when creating the account.
But there were no way to do that when we were turning on reconfirmable
and updating email.
By merging this PR, it will be possible :)

I also made it unconfirm the account when the email has been changed in commit 76ab508.
If there's any particular reason why it should stay confirmed even though the email has been changed and reconfirmable is on, tell me and I'll delete that commit :)

Thank you.
