### PR TITLE
install bin stubs so theres no need to type bundle exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-script: "bundle exec rake test"
+
+bundler_args: '--binstubs --without documentation'
+script: "rake test"
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
In order to stop typing <code>bundle exec</code> on Travis CI.
We can install <code>bundler_args: --binstubs</code> and it does the 'magic' for us.

[Travis CI Extra options](http://about.travis-ci.org/docs/user/languages/ruby/)

:)
