### PR TITLE
Update README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def devise_parameter_sanitizer
-    if resource_class.is_a?(User)
+    case resource_class
+    when User
       User::ParameterSanitizer.new(User, :user, params)
     else
       super # Use the default one


### PR DESCRIPTION
Fix the example for Strong parameters multi roles as resource_class is actually a class not an instance (so is_a? would always returns false).
