### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def devise_parameter_sanitizer
-    case resource_class
-    when User
+    if resource_class == User
       User::ParameterSanitizer.new(User, :user, params)
     else
       super # Use the default one


### PR DESCRIPTION
Since we're comparing two classes here, a case statement is going to call [Module#===](http://www.ruby-doc.org/core-2.0/Module.html#method-i-3D-3D-3D). That will check whether resource_class is an instance of User (which it would never be) when really we just want to see if they are equivalent, which is easily accomplished here by just using an if statement.
