### PR TITLE
Added API for excluding flash messages, fixed typo in test

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -153,7 +153,9 @@ MESSAGE
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
     options = devise_i18n_options(options) if respond_to?(:devise_i18n_options, true)
-    I18n.t("#{options[:resource_name]}.#{kind}", options)
+    if Devise.skip_flash_message.all? { |excluded| excluded != "#{options[:resource_name]}.#{kind}" }
+      I18n.t("#{options[:resource_name]}.#{kind}", options)
+    end
   end
 
   def clean_up_passwords(object)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -222,6 +222,10 @@ module Devise
   # Devise is used in a mountable engine
   mattr_accessor :omniauth_path_prefix
   @@omniauth_path_prefix = nil
+  
+  # Don't set the flash for the given keys
+  mattr_accessor :skip_flash_message
+  @@skip_flash_message = []
 
   def self.encryptor=(value)
     warn "\n[DEVISE] To select a encryption which isn't bcrypt, you should use devise-encryptable gem.\n"

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -93,6 +93,13 @@ class HelpersTest < ActionController::TestCase
     assert flash[:notice].nil?
   end
 
+  test 'does not issue flash messages with excluded keys' do
+    swap Devise, :skip_flash_message => ["user.send_instructions"] do
+      @controller.send :set_flash_message, :notice, :send_instructions
+      assert flash[:notice].nil?
+    end
+  end
+
   test 'issues non-blank flash messages normally' do
     I18n.stubs(:t).returns('non-blank')
     @controller.send :set_flash_message, :notice, :send_instructions


### PR DESCRIPTION
According to https://groups.google.com/forum/#!searchin/plataformatec-devise/flash/plataformatec-devise/IGmB_jvr3Ws/3MbPcsANmR4J you can already exclude specific flash messages by setting their value in `devise.en.yml` to either a blank string or `~`. This doesn't seem to be officially documented and my concern is that this behavior might change at some point.
