### PR TITLE
ignore yanked warden gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)
       railties (~> 3.1)
-      warden (~> 1.1.1)
+      warden (~> 1.1.1, != 1.2.2)
 
 GEM
   remote: http://rubygems.org/
@@ -39,7 +39,7 @@ GEM
       multi_json (~> 1.0)
     addressable (2.2.6)
     arel (3.0.0)
-    bcrypt-ruby (3.0.1)
+    bcrypt-ruby (3.1.1)
     bson (1.5.1)
     bson_ext (1.3.1)
     builder (3.0.0)

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency("warden", "~> 1.1.1")
+  s.add_dependency("warden", "~> 1.1.1", "!= 1.2.2")
   s.add_dependency("orm_adapter", "~> 0.0.3")
   s.add_dependency("bcrypt-ruby", "~> 3.0")
   s.add_dependency("railties", "~> 3.1")


### PR DESCRIPTION
This is a minor fix.

Warden 1.2.2 was yanked from Gemcutter, I've just added an extra restriction `"!= 1.2.2"` to ignore it.

I'm not sure how useful this would be since any new devise 2 users would get the newer (1.2.3) warden version, but as we have an app at production already we've got some weird bundler errors.

```
Could not find warden-1.2.2 in any of the sources
```

Cheers.
