### PR TITLE
Fixed checking for rememberable in timeoutable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 PATH
   remote: .
   specs:
-    devise (3.0.0.rc)
+    devise (3.0.0)
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)

--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -37,7 +37,7 @@ module Devise
       private
 
       def remember_exists_and_not_expired?
-        return false unless respond_to?(:remember_created_at)
+        return false unless respond_to?(:remember_created_at) && respond_to?(:remember_expired?)
         remember_created_at && !remember_expired?
       end
 

--- a/test/models/timeoutable_test.rb
+++ b/test/models/timeoutable_test.rb
@@ -43,4 +43,14 @@ class TimeoutableTest < ActiveSupport::TestCase
   test 'required_fields should contain the fields that Devise uses' do
     assert_same_content Devise::Models::Timeoutable.required_fields(User), []
   end
+
+  test 'should not raise error if remember_created_at is not empty and rememberable is disabled' do
+    user = create_admin(remember_created_at: Time.current)
+
+    begin
+      assert user.timedout?(31.minutes.ago)
+    rescue NoMethodError => e
+      refute_includes e.message, "undefined method `remember_expired?' for #<Admin:"
+    end
+  end
 end


### PR DESCRIPTION
Fixed bug when an user has field `remember_created_at` but the module `rememberable` is not enabled for the user.

Example:

``` ruby
class User < ActiveRecord::Base
  devise :timeoutable, ...

  def remember_created_at
    Time.now.utc
  end
end
```
