### PR TITLE
Using urlsafe_base64 cause it already handle url sensitive chars, keepin...

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -451,7 +451,7 @@ module Devise
 
   # Generate a friendly string randomly to be used as token.
   def self.friendly_token
-    SecureRandom.base64(15).tr('+/=lIO0', 'pqrsxyz')
+    SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz')
   end
 
   # constant-time comparison algorithm to prevent timing attacks


### PR DESCRIPTION
...g the replacement of the confusing chars, though. Tests just passed so I assume I don't have to add anything.
