### PR TITLE
Removed incorrect Strong Parameters example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :username
+    devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(:username, :email) }
   end
-end
-```
-
-To completely change Devise defaults or invoke custom behaviour, you can also pass a block:
-
-```ruby
-def configure_permitted_parameters
-  devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:username, :email) }
 end
 ```
 


### PR DESCRIPTION
The first Strong Parameters additional parameter permit example does not work, as it attempts to shovel a symbol into a hash (specific error `undefined method '<<' for {}:ActionController::Paramters`). Removed that code snippet, replacing it the block style example that had previously followed.
