### PR TITLE
Allowed updating of attributes without a password if password_required? resolves to false.

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -40,15 +40,7 @@ class Devise::RegistrationsController < DeviseController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
-    #check to see if a password is required. If not, update_without_password
-    update_status = false
-    if resource.password_required?
-      update_status = resource.update_with_password(account_update_params)
-    else
-      update_status = resource.update_without_password(account_update_params)
-    end
-
-    if update_status
+    if update_resource(resource, account_update_params)
       if is_navigational_format?
         flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
           :update_needs_confirmation : :updated
@@ -86,6 +78,12 @@ class Devise::RegistrationsController < DeviseController
     resource.respond_to?(:pending_reconfirmation?) &&
       resource.pending_reconfirmation? &&
       previous != resource.unconfirmed_email
+  end
+
+  # By default we want to require a password checks on update.
+  # You can overwrite this method in your own RegistrationsController.
+  def update_resource(resource, params)
+    resource.update_with_password(params)
   end
 
   # Build a devise resource passing in the session. Useful to move


### PR DESCRIPTION
I am using omniauth plugins for all of my authentications, so no user has or needs passwords. I ran into a problem where I was trying to add some custom fields for my users, but I kept getting "Unpermitted parameters:" even though I had allowed it using devise_parameter_sanitizer.for. I finally tracked the problem down to the line of code I replaced in this commit. I felt it was better to fix this in the upstream rather than just overriding the update method in my code. Devise already has the "password_required?" infrastructure, so why not use it?
