### PR TITLE
Fixes incorrect flash message on confirmation

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -20,8 +20,12 @@ class Devise::ConfirmationsController < DeviseController
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
 
     if resource.errors.empty?
-      set_flash_message(:notice, :confirmed) if is_navigational_format?
-      sign_in(resource_name, resource) if Devise.allow_insecure_sign_in_after_confirmation
+      if Devise.allow_insecure_sign_in_after_confirmation
+        set_flash_message(:notice, :confirmed_and_signed_in) if is_navigational_format?
+        sign_in(resource_name, resource)
+      else
+        set_flash_message(:notice, :confirmed) if is_navigational_format?
+      end
       respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
     else
       respond_with_navigational(resource.errors, :status => :unprocessable_entity){ render :new }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,8 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. You are now signed in."
+      confirmed: "Your account was successfully confirmed. Please sign in."
+      confirmed_and_signed_in: "Your account was successfully confirmed. You are now signed in."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:


### PR DESCRIPTION
The `:confirmed` default message in `devise.en.yml` used to say "You are now signed in." It is no longer the default behavior in v3.1.0 to automatically sign in a confirmed user. The new default is to confirm the account and redirect to the new session page without signing in the user (unless `Devise.allow_insecure_sign_in_after_confirmation` is set to true).

The default message shouldn't lie :wink:

This pull request renames the old message to `:confirmed_and_signed_in` and changes the :confirmed message to be appropriate for the new default behavior. The new `:confirmed` message reads:

> "Your account was successfully confirmed. Please sign in."
