### PR TITLE
Update link to new contributors page

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ https://github.com/hassox/warden
 
 We have a long list of valued contributors. Check them all at:
 
-https://github.com/plataformatec/devise/contributors
+https://github.com/plataformatec/devise/graphs/contributors
 
 ## License
 


### PR DESCRIPTION
GitHub has moved the contributors listing under their graphs page. This pull request updates the README to the new location.
