### PR TITLE
Template engines

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -163,8 +163,7 @@ module Devise
       desc "Copies Devise views to your application."
 
       argument :scope, :required => false, :default => nil,
-                       :desc => "The scope to copy views to",
-                       :haml => false
+                       :desc => "The scope to copy views to"
 
       invoke SharedViewsGenerator
 


### PR DESCRIPTION
The oficial solution for using haml or slim from version 1.2 is: https://github.com/plataformatec/devise/wiki/How-To:-Create-Haml-and-Slim-Views

It's complicated learn this or open bookmarks and execute in all projects, with way we can use this

``` ruby
rails g devise:views -t --template=haml 
```

or

``` ruby
rails g devise:views -t --template=slim
```

In your gemfile you must have 

``` ruby
group :development do
  gem 'html2haml'
end
```

or

``` ruby
group :development do
  gem 'html2slim'
end
```
