### PR TITLE
Stop sending `klass` param to Devise.token_generator.digest since not used

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -272,7 +272,7 @@ module Devise
         # Options must have the confirmation_token
         def confirm_by_token(confirmation_token)
           original_token     = confirmation_token
-          confirmation_token = Devise.token_generator.digest(self, :confirmation_token, confirmation_token)
+          confirmation_token = Devise.token_generator.digest(:confirmation_token, confirmation_token)
 
           confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_token)
           confirmable.confirm! if confirmable.persisted?

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -162,7 +162,7 @@ module Devise
         # Options must have the unlock_token
         def unlock_access_by_token(unlock_token)
           original_token = unlock_token
-          unlock_token   = Devise.token_generator.digest(self, :unlock_token, unlock_token)
+          unlock_token   = Devise.token_generator.digest(:unlock_token, unlock_token)
 
           lockable = find_or_initialize_with_error_by(:unlock_token, unlock_token)
           lockable.unlock_access! if lockable.persisted?

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -108,7 +108,7 @@ module Devise
         # Attributes must contain reset_password_token, password and confirmation
         def reset_password_by_token(attributes={})
           original_token       = attributes[:reset_password_token]
-          reset_password_token = Devise.token_generator.digest(self, :reset_password_token, original_token)
+          reset_password_token = Devise.token_generator.digest(:reset_password_token, original_token)
 
           recoverable = find_or_initialize_with_error_by(:reset_password_token, reset_password_token)
 

--- a/lib/devise/token_generator.rb
+++ b/lib/devise/token_generator.rb
@@ -10,7 +10,7 @@ module Devise
       @digest = digest
     end
 
-    def digest(klass, column, value)
+    def digest(column, value)
       value.present? && OpenSSL::HMAC.hexdigest(@digest, key_for(column), value.to_s)
     end
 

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -86,7 +86,7 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     host = ActionMailer::Base.default_url_options[:host]
 
     if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/confirmation\?confirmation_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :confirmation_token, $1), user.confirmation_token
+      assert_equal Devise.token_generator.digest(:confirmation_token, $1), user.confirmation_token
     else
       flunk "expected confirmation url regex to match"
     end

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -82,7 +82,7 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
     host = ActionMailer::Base.default_url_options[:host]
 
     if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/password/edit\?reset_password_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :reset_password_token, $1), user.reset_password_token
+      assert_equal Devise.token_generator.digest(:reset_password_token, $1), user.reset_password_token
     else
       flunk "expected reset password url regex to match"
     end

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -83,7 +83,7 @@ class UnlockInstructionsTest < ActionMailer::TestCase
     host = ActionMailer::Base.default_url_options[:host]
 
     if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/unlock\?unlock_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :unlock_token, $1), user.unlock_token
+      assert_equal Devise.token_generator.digest(:unlock_token, $1), user.unlock_token
     else
       flunk "expected unlock url regex to match"
     end


### PR DESCRIPTION
Stop sending `klass` param to `Devise.token_generator.digest` since it doesn't get used.
