### PR TITLE
Tweaks confirmation flow for signed_in users

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -36,6 +36,10 @@ class Devise::ConfirmationsController < DeviseController
 
     # The path used after confirmation.
     def after_confirmation_path_for(resource_name, resource)
-      new_session_path(resource_name)
+      if signed_in?
+        signed_in_root_path(resource)
+      else
+        new_session_path(resource_name)
+      end
     end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your account was successfully confirmed. Please sign in."
+      confirmed: "Your account was successfully confirmed."
       send_instructions: "You will receive an email with instructions about how to confirm your account in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -56,7 +56,7 @@ class ConfirmationTest < ActionDispatch::IntegrationTest
       assert_not user.confirmed?
       visit_user_confirmation_with_token(user.raw_confirmation_token)
 
-      assert_contain 'Your account was successfully confirmed. Please sign in.'
+      assert_contain 'Your account was successfully confirmed.'
       assert_current_url '/users/sign_in'
       assert user.reload.confirmed?
     end
@@ -120,6 +120,16 @@ class ConfirmationTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert warden.authenticated?(:user)
+    end
+  end
+
+  test 'unconfirmed but signed in user should be redirected to their root path' do
+    swap Devise, :allow_unconfirmed_access_for => 1.day do
+      user = sign_in_as_user(:confirm => false)
+
+      visit_user_confirmation_with_token(user.raw_confirmation_token)
+      assert_contain 'Your account was successfully confirmed.'
+      assert_current_url '/'
     end
   end
 


### PR DESCRIPTION
For #2627

When allow_unconfirmed_access_for > 0, users may be already signed in at the time they confirm their account. Consequently, the default confirmation should be compatible with this possibility. Additionally, they should not be
redirected to the sign in form after confirmation in this case. So I've changed ConfirmationsController#after_confirmation_path_for to send the user to the root path when signed in, or the sign in form otherwise.
