### PR TITLE
Don't clobber CSRF token for other scopes

### DIFF
--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -341,6 +341,20 @@ class AuthenticationSessionTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'does not clobber existing csrf token for authenticated users' do
+    swap ApplicationController, :allow_forgery_protection => true do
+      sign_in_as_user
+      get users_path
+      csrf_token = request.session[:_csrf_token]
+
+      sign_in_as_admin
+      get admins_path
+
+      post exhibit_user_path(1), {'authenticity_token' => csrf_token}
+      assert warden.authenticated?(:user), 'User should still be authenticated after posting a form'
+    end
+  end
+
   test 'allows session to be set for a given scope' do
     sign_in_as_user
     get '/users'

--- a/test/rails_app/app/controllers/admins_controller.rb
+++ b/test/rails_app/app/controllers/admins_controller.rb
@@ -2,6 +2,7 @@ class AdminsController < ApplicationController
   before_filter :authenticate_admin!
 
   def index
+    form_authenticity_token
   end
 
   def expire

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   respond_to :html, :xml
 
   def index
+    form_authenticity_token
     user_session[:cart] = "Cart"
     respond_with(current_user)
   end


### PR DESCRIPTION
This is another approach for #2640.

If a user is already authenticated in one scope, we should not clobber their CSRF token when they sign into additional scopes in case they have unsubmitted forms.

This still resets the unauthenticated csrf token when the session is authenticated for the first time.
