### PR TITLE
Show last attempt message for last attempt, not for one-before-last one

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -128,7 +128,7 @@ module Devise
         end
 
         def last_attempt?
-          self.failed_attempts == self.class.maximum_attempts - 1
+          self.failed_attempts == self.class.maximum_attempts
         end
 
         # Tells if the lock is expired if :time unlock strategy is active

--- a/test/models/lockable_test.rb
+++ b/test/models/lockable_test.rb
@@ -284,11 +284,14 @@ class LockableTest < ActiveSupport::TestCase
     swap Devise, :last_attempt_warning => :true do
       swap Devise, :lock_strategy => :failed_attempts do
         user = create_user
-        user.failed_attempts = Devise.maximum_attempts - 2
+        user.failed_attempts = Devise.maximum_attempts - 1
         assert_equal :invalid, user.unauthenticated_message
 
-        user.failed_attempts = Devise.maximum_attempts - 1
+        user.failed_attempts = Devise.maximum_attempts
         assert_equal :last_attempt, user.unauthenticated_message
+
+        user.failed_attempts = Devise.maximum_attempts + 1
+        assert_equal :locked, user.unauthenticated_message
       end
     end
   end


### PR DESCRIPTION
Sorry, I've made mistake with defining of last attempt before account locking. This pull request should fix it.
