### PR TITLE
Splat the arguments to strong_parameters#permit, fixes #2716

### DIFF
--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -47,18 +47,22 @@ module Devise
     end
 
     def sign_in
-      default_params.permit self.for(:sign_in)
+      permit self.for(:sign_in)
     end
 
     def sign_up
-      default_params.permit self.for(:sign_up)
+      permit self.for(:sign_up)
     end
 
     def account_update
-      default_params.permit self.for(:account_update)
+      permit self.for(:account_update)
     end
 
     private
+
+    def permit(keys)
+      default_params.permit(*Array(keys))
+    end
 
     # Change for(kind) to return the values in the @permitted
     # hash, allowing the developer to customize at runtime.

--- a/test/parameter_sanitizer_test.rb
+++ b/test/parameter_sanitizer_test.rb
@@ -68,5 +68,14 @@ if defined?(ActionController::StrongParameters)
         sanitizer.sanitize(:unknown)
       end
     end
+
+    test 'passes parameters to filter as arguments to sanitizer' do
+      params = {user: stub}
+      sanitizer = Devise::ParameterSanitizer.new(User, :user, params)
+
+      params[:user].expects(:permit).with(kind_of(Symbol), kind_of(Symbol), kind_of(Symbol))
+
+      sanitizer.sanitize(:sign_in)
+    end
   end
 end


### PR DESCRIPTION
There is a discrepancy between rails' strong_parameter implementation,
and the strong_parameter gem's [0](https://github.com/rails/strong_parameters/pull/170). While this is obviously a problem
with the other gem, it doesn't hurt to explicitly splat the parameters.
