### PR TITLE
Adds yield around resource on devise controllers

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -7,6 +7,7 @@ class Devise::ConfirmationsController < DeviseController
   # POST /resource/confirmation
   def create
     self.resource = resource_class.send_confirmation_instructions(resource_params)
+    yield resource if block_given?
 
     if successfully_sent?(resource)
       respond_with({}, :location => after_resending_confirmation_instructions_path_for(resource_name))
@@ -18,6 +19,7 @@ class Devise::ConfirmationsController < DeviseController
   # GET /resource/confirmation?confirmation_token=abcdef
   def show
     self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+    yield resource if block_given?
 
     if resource.errors.empty?
       set_flash_message(:notice, :confirmed) if is_flashing_format?

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -11,6 +11,7 @@ class Devise::PasswordsController < DeviseController
   # POST /resource/password
   def create
     self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
 
     if successfully_sent?(resource)
       respond_with({}, :location => after_sending_reset_password_instructions_path_for(resource_name))
@@ -28,6 +29,7 @@ class Devise::PasswordsController < DeviseController
   # PUT /resource/password
   def update
     self.resource = resource_class.reset_password_by_token(resource_params)
+    yield resource if block_given?
 
     if resource.errors.empty?
       resource.unlock_access! if unlockable?(resource)

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -13,6 +13,7 @@ class Devise::RegistrationsController < DeviseController
     build_resource(sign_up_params)
 
     if resource.save
+      yield resource if block_given?
       if resource.active_for_authentication?
         set_flash_message :notice, :signed_up if is_flashing_format?
         sign_up(resource_name, resource)
@@ -41,6 +42,7 @@ class Devise::RegistrationsController < DeviseController
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
     if update_resource(resource, account_update_params)
+      yield resource if block_given?
       if is_flashing_format?
         flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
           :update_needs_confirmation : :updated
@@ -59,6 +61,7 @@ class Devise::RegistrationsController < DeviseController
     resource.destroy
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message :notice, :destroyed if is_flashing_format?
+    yield resource if block_given?
     respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
   end
 

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -15,6 +15,7 @@ class Devise::SessionsController < DeviseController
     self.resource = warden.authenticate!(auth_options)
     set_flash_message(:notice, :signed_in) if is_flashing_format?
     sign_in(resource_name, resource)
+    yield resource if block_given?
     respond_with resource, :location => after_sign_in_path_for(resource)
   end
 
@@ -23,6 +24,7 @@ class Devise::SessionsController < DeviseController
     redirect_path = after_sign_out_path_for(resource_name)
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
     set_flash_message :notice, :signed_out if signed_out && is_flashing_format?
+    yield resource if block_given?
 
     # We actually need to hardcode this as Rails default responder doesn't
     # support returning empty response on GET request

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -9,6 +9,7 @@ class Devise::UnlocksController < DeviseController
   # POST /resource/unlock
   def create
     self.resource = resource_class.send_unlock_instructions(resource_params)
+    yield resource if block_given?
 
     if successfully_sent?(resource)
       respond_with({}, :location => after_sending_unlock_instructions_path_for(resource))
@@ -20,6 +21,7 @@ class Devise::UnlocksController < DeviseController
   # GET /resource/unlock?unlock_token=abcdef
   def show
     self.resource = resource_class.unlock_access_by_token(params[:unlock_token])
+    yield resource if block_given?
 
     if resource.errors.empty?
       set_flash_message :notice, :unlocked if is_flashing_format?


### PR DESCRIPTION
If you want to add a new behavior to your devise controllers but you don't want to override devise's default workflow, just pass a block around resource.

This would give you for example, the ability to trigger background jobs after user signs in and continue with the usual devise workflow.

``` ruby
class Overrided::PasswordsController < Devise::PasswordsController

  def update
    super do |resource|
      BackgroundWorker.trigger
    end
  end

end
```

We do it around the resource, because all devise controllers has the resource as main subject, so it should be available to make decisions. 
This way, we avoid copying and pasting the whole devise controller method just to add an extra behavior. Just like this:

``` ruby
class Overrided::PasswordsController < Devise::PasswordsController

  def update
    self.resource = resource_class.reset_password_by_token(resource_params)
    BackgroundWorker.trigger

    if resource.errors.empty?
      resource.unlock_access! if unlockable?(resource)
      flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
      set_flash_message(:notice, flash_message) if is_navigational_format?
      sign_in(resource_name, resource)
      respond_with resource, :location => after_resetting_password_path_for(resource)
    else
      respond_with resource
    end
  end

end
```
