### PR TITLE
Bring `password_digest` back.

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -39,7 +39,7 @@ module Devise
       # Generates password encryption based on the given value.
       def password=(new_password)
         @password = new_password
-        self.encrypted_password = Devise.bcrypt(self.class, @password) if @password.present?
+        self.encrypted_password = password_digest(@password) if @password.present?
       end
 
       # Verifies whether an password (ie from sign in) is the user password.
@@ -134,6 +134,15 @@ module Devise
       end
 
     protected
+
+      # Digests the password using bcrypt. Custom encryption should override
+      # this method to apply their own algorithm.
+      #
+      # See https://github.com/plataformatec/devise-encryptable for examples
+      # of other encryption engines.
+      def password_digest(password)
+        Devise.bcrypt(self.class, password)
+      end
 
       module ClassMethods
         Devise::Models.config(self, :pepper, :stretches)

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -93,6 +93,11 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_present user.encrypted_password
   end
 
+  test 'should support custom encryption methods' do
+    user = UserWithCustomEncryption.new(:password => '654321')
+    assert_equal user.encrypted_password, '123456'
+  end
+
   test 'allow authenticatable_salt to work even with nil encrypted password' do
     user = User.new
     user.encrypted_password = nil

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -12,6 +12,13 @@ class UserWithValidation < User
   validates_presence_of :username
 end
 
+class UserWithCustomEncryption < User
+  protected
+  def password_digest(password)
+    password.reverse
+  end
+end
+
 class UserWithVirtualAttributes < User
   devise :case_insensitive_keys => [ :email, :email_confirmation ]
   validates :email, :presence => true, :confirmation => {:on => :create}


### PR DESCRIPTION
This method is part of the protected API and is used by custom encryption
engines (like `devise-encryptable`) to hook the custom encryption logic in the
models.

Fixes #2730
