### PR TITLE
Keep the query string and path in store_location_for

### DIFF
--- a/lib/devise/controllers/store_location.rb
+++ b/lib/devise/controllers/store_location.rb
@@ -33,7 +33,10 @@ module Devise
       #
       def store_location_for(resource_or_scope, location)
         session_key = stored_location_key_for(resource_or_scope)
-        session[session_key] = URI.parse(location).path.sub(/\A\/+/, '/') if location
+        if location
+          uri = URI.parse(location)
+          session[session_key] = [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
+        end
       end
 
       private

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -198,11 +198,16 @@ class ControllerAuthenticatableTest < ActionController::TestCase
     assert_equal "/foo.bar", @controller.stored_location_for(User.new)
   end
 
-  test 'store location for stores only paths' do
+  test 'store location for stores paths' do
     @controller.store_location_for(:user, "//host/foo.bar")
     assert_equal "/foo.bar", @controller.stored_location_for(:user)
     @controller.store_location_for(:user, "///foo.bar")
     assert_equal "/foo.bar", @controller.stored_location_for(:user)
+  end
+
+  test 'store location for stores query string' do
+    @controller.store_location_for(:user, "/foo?bar=baz")
+    assert_equal "/foo?bar=baz", @controller.stored_location_for(:user)
   end
 
   test 'after sign in path defaults to root path if none by was specified for the given scope' do


### PR DESCRIPTION
Persist the URI's query when saving to the session.

Fixes #2742
