### PR TITLE
Removing regexp anchors in routing constraints

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -393,13 +393,13 @@ and you have set #{mapping.fullpath.inspect}. You can work around by passing
 `skip: :omniauth_callbacks` and manually defining the routes. Here is an example:
 
     match "/users/auth/:provider",
-      :constraints => { :provider => /\A(google|facebook)\z/ },
+      :constraints => { :provider => /google|facebook/ },
       :to => "devise/omniauth_callbacks#passthru",
       :as => :omniauth_authorize,
       :via => [:get, :post]
 
     match "/users/auth/:action/callback",
-      :constraints => { :action => /\A(google|facebook)\z/ },
+      :constraints => { :action => /google|facebook/ },
       :to => "devise/omniauth_callbacks",
       :as => :omniauth_callback,
       :via => [:get, :post]


### PR DESCRIPTION
They're not allowed according to [this](http://guides.rubyonrails.org/routing.html#segment-constraints) and this:

```
Regexp anchor characters are not allowed in routing requirements: /^(google|facebook)$/
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:137:in `verify_regexp_requirement'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:122:in `block in normalize_requirements!'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:120:in `each'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:120:in `normalize_requirements!'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:66:in `initialize'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1443:in `new'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1443:in `add_route'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1422:in `decomposed_match'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1403:in `block in match'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1394:in `each'
/ruby-2.0.0-p353/gems/actionpack-4.0.1/lib/action_dispatch/routing/mapper.rb:1394:in `match'
```
