### PR TITLE
Add sequel ORM support

### DIFF
--- a/lib/devise/orm/sequel.rb
+++ b/lib/devise/orm/sequel.rb
@@ -1,0 +1,6 @@
+require 'orm_adapter-sequel'
+
+ def self.apply(model, options = {})
+   model.extend ::Devise::Models
+   model.plugin :hook_class_methods # Devise requires a before_validation
+ end


### PR DESCRIPTION
For users who is using a maintained ORM called "Sequel". This solves the problem of having the error:

cannot load such file -- devise/orm/sequel
