### PR TITLE
Remove some authentication token stuffs

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -56,7 +56,7 @@ module Devise
       BLACKLIST_FOR_SERIALIZATION = [:encrypted_password, :reset_password_token, :reset_password_sent_at,
         :remember_created_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip,
         :last_sign_in_ip, :password_salt, :confirmation_token, :confirmed_at, :confirmation_sent_at,
-        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at, :authentication_token]
+        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
 
       included do
         class_attribute :devise_modules, :instance_writer => false

--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -102,9 +102,9 @@ module Devise
         params_auth_hash.is_a?(Hash)
       end
 
-      # Check if password is present and is not equal to "X" (default value for token).
+      # Check if password is present.
       def valid_password?
-        password.present? && password != "X"
+        password.present?
       end
 
       # Helper to decode credentials from HTTP.


### PR DESCRIPTION
Since we don't have authentication token, I think there is no reason to check if password is "X".

:authentication_token don't have to be in the blacklist for serialization too.
