### PR TITLE
[close #2755] Raise incompatible route error

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -229,6 +229,14 @@ module ActionDispatch::Routing
           raise_no_devise_method_error!(mapping.class_name)
         end
 
+        if options[:controllers] && options[:controllers][:omniauth_callbacks]
+          unless mapping.omniauthable?
+            msg =  "Mapping omniauth_callbacks on a resource that is not omniauthable\n"
+            msg << "Please add `devise :omniauthable` to the `#{mapping.class_name}` model"
+            raise msg
+          end
+        end
+
         routes  = mapping.used_routes
 
         devise_scope mapping.name do

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -235,6 +235,14 @@ class CustomizedRoutingTest < ActionController::TestCase
   test 'map with format false is not permanent' do
     assert_equal "/set.xml", @routes.url_helpers.set_path(:xml)
   end
+
+  test 'checks if mapping has proper configuration for omniauth callback' do
+    assert_raise ArgumentError do
+      @routes.dup.eval_block do
+        devise_for :admin, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
+      end
+    end
+  end
 end
 
 class ScopedRoutingTest < ActionController::TestCase


### PR DESCRIPTION
Right now if you try to use a route that you have defined in your `omniauth_callbacks` but you have not declared that resource to be `omniauthable` you will get a weird route missing error which causes the user to look in the routes for the fix:

``` ruby
devise_for  :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks"}
```

This PR checks to see if the mapping of `:user` has the module `omniauthable` included in it when `omniauth_callbacks` is specified in the route. If it does not, an instructional error is raised:

```
Mapping omniauth_callbacks on a resource that is not omniauthable
Please add `devise :omniauthable` to the `User` model
```
