### PR TITLE
Add support for Rails 4.1 secrets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+* enhancements
+  * Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`.
+    You can change this and use your own secret by changing the `devise.rb` initializer.
+
 ### 3.2.2
 
 * bug fix

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -29,7 +29,13 @@ module Devise
       end
     end
 
-    initializer "devise.secret_key" do
+    config.after_initialize do |app|
+      if app.respond_to?(:secrets)
+        Devise.secret_key ||= app.secrets.secret_key_base
+      elsif app.config.respond_to?(:secret_key_base)
+        Devise.secret_key ||= app.config.secret_key_base
+      end
+
       Devise.token_generator ||=
         if secret_key = Devise.secret_key
           Devise::TokenGenerator.new(

--- a/lib/generators/devise/install_generator.rb
+++ b/lib/generators/devise/install_generator.rb
@@ -20,6 +20,10 @@ module Devise
       def show_readme
         readme "README" if behavior == :invoke
       end
+
+      def rails_4?
+        Rails::VERSION::MAJOR == 4
+      end
     end
   end
 end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -4,7 +4,11 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
+<% if rails_4? -%>
+  # config.secret_key = '<%= SecureRandom.hex(64) %>'
+<% else -%>
   config.secret_key = '<%= SecureRandom.hex(64) %>'
+<% end -%>
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
This is a first spike for that @josevalim proposed on #2821. Upgrade existing apps will be simple - developers just need to move their keys to the `secrets.yml` - but on fresh apps its required to add the `secret_key` key manually. We could still generate a token inside the initializer as a fallback (so the app can boot without this step) or figure out an automatic way of placing the token on the application configuration.
