### PR TITLE
Use _devise_route_context in omniauth url_helpers

### DIFF
--- a/lib/devise/omniauth/url_helpers.rb
+++ b/lib/devise/omniauth/url_helpers.rb
@@ -6,12 +6,12 @@ module Devise
 
       def omniauth_authorize_path(resource_or_scope, *args)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
-        send("#{scope}_omniauth_authorize_path", *args)
+        _devise_route_context.send("#{scope}_omniauth_authorize_path", *args)
       end
 
       def omniauth_callback_path(resource_or_scope, *args)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
-        send("#{scope}_omniauth_callback_path", *args)
+        _devise_route_context.send("#{scope}_omniauth_callback_path", *args)
       end
     end
   end


### PR DESCRIPTION
The omniauth helpers do not take the `config.router_name` into account.

Related to #2692?
