### PR TITLE
Fix ruby 2.1 deprecation warning for .ago

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -27,7 +27,7 @@ module Devise
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
         return false if remember_exists_and_not_expired?
-        !timeout_in.nil? && last_access && last_access <= timeout_in.ago
+        !timeout_in.nil? && last_access && last_access <= timeout_in.seconds.ago
       end
 
       def timeout_in


### PR DESCRIPTION
Ruby 2.1 has deprecated .ago and .until for Fixnum causing a lot of warnings if the Timeoutable module is enabled.

DEPRECATION WARNING: Calling #ago or #until on a number (e.g. 5.ago) is deprecated and will be removed in the future, use 5.seconds.ago instead. (called from service at /Users/joe/.rvm/rubies/ruby-2.1.0/lib/ruby/2.1.0/webrick/httpserver.rb:138)
