### PR TITLE
allow customized password length validation

### DIFF
--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -33,13 +33,14 @@ module Devise
       accessors.each do |accessor|
         mod.class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def #{accessor}
-            if defined?(@#{accessor})
+            value = if defined?(@#{accessor})
               @#{accessor}
             elsif superclass.respond_to?(:#{accessor})
               superclass.#{accessor}
             else
               Devise.#{accessor}
             end
+            value.is_a?(Proc) ? value.call : value
           end
 
           def #{accessor}=(value)

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -32,7 +32,7 @@ module Devise
 
           validates_presence_of     :password, :if => :password_required?
           validates_confirmation_of :password, :if => :password_required?
-          validates_length_of       :password, :within => password_length, :allow_blank => true
+          validate :password_should_be_valid
         end
       end
 
@@ -46,6 +46,15 @@ module Devise
       end
 
     protected
+
+
+      # validates_length_of       :password, :within => password_length, :allow_blank => true
+      def password_should_be_valid
+        unless password.blank?
+          errors.add(:password, :too_short, count: self.class.password_length.begin)  if password.length < self.class.password_length.begin
+          errors.add(:password, :too_long, count: self.class.password_length.end)  if password.length > self.class.password_length.end
+        end
+      end
 
       # Checks whether a password is needed or not. For validations only.
       # Passwords are always required if it's a new record, or if the password

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -115,6 +115,15 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too long (maximum is 128 characters)', user.errors[:password].join
   end
 
+  test 'password_length can be customized using Proc' do
+    default = Devise.password_length
+    Devise.password_length = Proc.new { 129..200 }
+    user = new_user(:password => 'x'*129, :password_confirmation => 'x'*129)
+    user.stubs(:password_required?).returns(false)
+    assert user.valid?
+    Devise.password_length = default
+  end
+
   test 'should not be included in objects with invalid API' do
     assert_raise RuntimeError do
       Class.new.send :include, Devise::Models::Validatable

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -24,13 +24,9 @@ class ActiveRecordTest < ActiveSupport::TestCase
   test 'validations options are not applied too late' do
     validators = WithValidation.validators_on :password
     length = validators.find { |v| v.kind == :length }
-    assert_equal 2, length.options[:minimum]
-    assert_equal 6, length.options[:maximum]
-  end
-
-  test 'validations are applied just once' do
-    validators = Several.validators_on :password
-    assert_equal 1, validators.select{ |v| v.kind == :length }.length
+    assert !WithValidation.new(email: 'john@example.com', password: '1').valid?
+    assert !WithValidation.new(email: 'john@example.com', password: '1231456789').valid?
+    assert WithValidation.new(email: 'john@example.com', password: '12').valid?
   end
 
   test 'chosen modules are inheritable' do


### PR DESCRIPTION
Allow to use dynamic settings in Devise.setup, this is useful for multitenant app, example :
in initializers/devise.rb

``` ruby
 Devise.setup do |config|
  config.password_length  = Proc.new { Domain.current.try(:password_regex) }
 end
```
