### PR TITLE
Update password_length docs in config template

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -138,7 +138,7 @@ Devise.setup do |config|
   # config.rememberable_options = {}
 
   # ==> Configuration for :validatable
-  # Range for password length. Default is 8..128.
+  # Range for password length.
   config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that


### PR DESCRIPTION
The default specified in the docs does not match up with the default specified in the config code.

See https://github.com/plataformatec/devise/blob/cc8636cfed2801db00bf38f335a3bcc5c79660d3/lib/devise.rb#L127
