### PR TITLE
Disable autocompletion on all password inputs

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -5,10 +5,10 @@
   <%= f.hidden_field :reset_password_token %>
 
   <div><%= f.label :password, "New password" %><br />
-  <%= f.password_field :password, :autofocus => true %></div>
+    <%= f.password_field :password, :autofocus => true, :autocomplete => "off" %></div>
 
   <div><%= f.label :password_confirmation, "Confirm new password" %><br />
-  <%= f.password_field :password_confirmation %></div>
+    <%= f.password_field :password_confirmation, :autocomplete => "off" %></div>
 
   <div><%= f.submit "Change my password" %></div>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,13 +11,13 @@
   <% end %>
 
   <div><%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-  <%= f.password_field :password, :autocomplete => "off" %></div>
+    <%= f.password_field :password, :autocomplete => "off" %></div>
 
   <div><%= f.label :password_confirmation %><br />
-  <%= f.password_field :password_confirmation %></div>
+    <%= f.password_field :password_confirmation, :autocomplete => "off" %></div>
 
   <div><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-  <%= f.password_field :current_password %></div>
+    <%= f.password_field :current_password, :autocomplete => "off" %></div>
 
   <div><%= f.submit "Update" %></div>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,10 +7,10 @@
   <%= f.email_field :email, :autofocus => true %></div>
 
   <div><%= f.label :password %><br />
-  <%= f.password_field :password %></div>
+    <%= f.password_field :password, :autocomplete => "off" %></div>
 
   <div><%= f.label :password_confirmation %><br />
-  <%= f.password_field :password_confirmation %></div>
+    <%= f.password_field :password_confirmation, :autocomplete => "off" %></div>
 
   <div><%= f.submit "Sign up" %></div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
   <%= f.email_field :email, :autofocus => true %></div>
 
   <div><%= f.label :password %><br />
-  <%= f.password_field :password %></div>
+    <%= f.password_field :password, :autocomplete => "off" %></div>
 
   <% if devise_mapping.rememberable? -%>
     <div><%= f.check_box :remember_me %> <%= f.label :remember_me %></div>


### PR DESCRIPTION
Autocomplete should be disabled on all password inputs for security reasons. It was disabled on some of the inputs in version 2.0.2, but a number of fields still allow it.
