### PR TITLE
Update bcrypt version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: .
   specs:
     devise (3.2.3)
-      bcrypt (~> 3.0)
+      bcrypt (~> 3.1.6)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
       thread_safe (~> 0.1)
@@ -48,7 +48,7 @@ GEM
       tzinfo (~> 0.3.37)
     arel (4.0.0)
     atomic (1.1.12)
-    bcrypt (3.1.3)
+    bcrypt (3.1.6)
     builder (3.1.4)
     erubis (2.7.0)
     faraday (0.8.8)

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("warden", "~> 1.2.3")
   s.add_dependency("orm_adapter", "~> 0.1")
-  s.add_dependency("bcrypt", "~> 3.0")
+  s.add_dependency("bcrypt", "~> 3.1.6")
   s.add_dependency("thread_safe", "~> 0.1")
   s.add_dependency("railties", ">= 3.2.6", "< 5")
 end


### PR DESCRIPTION
Resolves issue #2878.  Devise couldn't require the classes it needed from bcrypt, updated the bcrypt version to the latest and ran tests, all passed.
