### PR TITLE
Devise + Mongoid store wrong data in session

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -200,8 +200,16 @@ module Devise
           :case_insensitive_keys, :http_authenticatable, :params_authenticatable, :skip_session_storage,
           :http_authentication_key)
 
+        def stringify(item)
+          if item.kind_of?(Array)
+            item.first.to_s
+          else
+            item
+          end
+        end
+
         def serialize_into_session(record)
-          [record.to_key, record.authenticatable_salt].flatten
+          [stringify(record.to_key), record.authenticatable_salt]
         end
 
         def serialize_from_session(key, salt)

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -200,16 +200,9 @@ module Devise
           :case_insensitive_keys, :http_authenticatable, :params_authenticatable, :skip_session_storage,
           :http_authentication_key)
 
-        def stringify(item)
-          if item.kind_of?(Array)
-            item.first.to_s
-          else
-            item
-          end
-        end
 
         def serialize_into_session(record)
-          [stringify(record.to_key), record.authenticatable_salt]
+          [[*record.to_key].first.to_s, record.authenticatable_salt]
         end
 
         def serialize_from_session(key, salt)

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -201,7 +201,7 @@ module Devise
           :http_authentication_key)
 
         def serialize_into_session(record)
-          [record.to_key, record.authenticatable_salt]
+          [record.to_key, record.authenticatable_salt].flatten
         end
 
         def serialize_from_session(key, salt)


### PR DESCRIPTION
I'm using Devise 3.2.3 + Mongoid 4.0.0.beta1 and when I try to call `current_user` I get:

~~~
The operation: #<Moped::Protocol::Query
  @length=125
  @request_id=18
  @response_to=0
  @op_code=2004
  @flags=[]
  @full_collection_name="orodruin_development.users"
  @skip=0
  @limit=-1
  @selector={"$query"=>{"_id"=>{"$oid"=>BSON::ObjectId('530a1ec84e49550fbd000000')}}, "$orderby"=>{:_id=>1}}
  @fields=nil>
failed with error 10068: "invalid operator: $oid"

See https://github.com/mongodb/mongo/blob/master/docs/errors.md
for details about this error.
~~~

Bug is somewhere where this is set:

    warden.user.user.key: [[{"$oid"=>BSON::ObjectId('530a1ec84e49550fbd000000')}], "$2a$10$/J1DMorvMdGZm6aQicsYL."]