### PR TITLE
Set default secret_key before eager load

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -29,7 +29,7 @@ module Devise
       end
     end
 
-    config.after_initialize do |app|
+    initializer "devise.secret_key" do |app|
       if app.respond_to?(:secrets)
         Devise.secret_key ||= app.secrets.secret_key_base
       elsif app.config.respond_to?(:secret_key_base)


### PR DESCRIPTION
In eba91e65803cf1cbf8dc6a482507596ab7c23e47 and Devise 3.2.3, a new enhancement was introduced to read Rails' `secret_key_base` for Devise's `secret_token`.

However, this feature wouldn't work on production environment since the following codes:

``` ruby
# Force routes to be loaded if we are doing any eager load.
config.before_eager_load { |app| app.reload_routes! }
```

will raise a secret token not found error since the token reading happens during `after_initialize`.

This commit fixed my deployment on Heroku. Please let me know if there's any concern.
