### PR TITLE
Use SVG for status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 By [Plataformatec](http://plataformatec.com.br/).
 
-[![Build Status](https://api.travis-ci.org/plataformatec/devise.png?branch=master)](http://travis-ci.org/plataformatec/devise)
-[![Code Climate](https://codeclimate.com/github/plataformatec/devise.png)](https://codeclimate.com/github/plataformatec/devise)
+[![Build Status](https://img.shields.io/travis/plataformatec/devise/master.svg)](https://travis-ci.org/plataformatec/devise)
+[![Code Climate](https://img.shields.io/codeclimate/github/plataformatec/devise.svg)](https://codeclimate.com/github/plataformatec/devise)
 
 This README is [also available in a friendly navigable format](http://devise.plataformatec.com.br/).
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the images currently used, but the SVG versions added here are more legible on high pixel density displays.
