### PR TITLE
Fix typo in initializer template comment

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -119,8 +119,8 @@ Devise.setup do |config|
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
-  # db field (see migrations). Until confirmed new email is stored in
-  # unconfirmed email column, and copied to email column on successful confirmation.
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
   config.reconfirmable = true
 
   # Defines which key will be used when confirming an account


### PR DESCRIPTION
The name of the column is `unconfirmed_email`. That is not immediately clear from the original text (which seems to indicate an unconfirmed ... email column).
