### PR TITLE
Add ability to generate only specified view directories

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -16,7 +16,7 @@ module Devise
         # It should be fixed in future Rails releases
         class_option :form_builder, aliases: "-b"
         class_option :markerb
-        class_option :selective, aliases: "-d", type: :array, desc: "Select specific view directories to generate (confirmations, passwords, registrations, sessions, unlocks, mailer)"
+        class_option :views, aliases: "-v", type: :array, desc: "Select specific view directories to generate (confirmations, passwords, registrations, sessions, unlocks, mailer)"
 
         public_task :copy_views
       end
@@ -29,8 +29,8 @@ module Devise
       end
 
       def copy_views
-        if options[:selective]
-          options[:selective].each do |directory|
+        if options[:views]
+          options[:views].each do |directory|
             view_directory directory.to_sym
           end
         else
@@ -92,7 +92,7 @@ module Devise
       hide!
 
       def copy_views
-        if !options[:selective] || options[:selective].include?('mailer')
+        if !options[:views] || options[:views].include?('mailer')
           view_directory :mailer
         end
       end
@@ -105,7 +105,7 @@ module Devise
       hide!
 
       def copy_views
-        if !options[:selective] || options[:selective].include?('mailer')
+        if !options[:views] || options[:views].include?('mailer')
           view_directory :markerb, target_path
         end
       end

--- a/test/generators/views_generator_test.rb
+++ b/test/generators/views_generator_test.rb
@@ -38,7 +38,7 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
 
 
   test "Assert only views within specified directories" do
-    run_generator %w(-d sessions registrations)
+    run_generator %w(-v sessions registrations)
     assert_file "app/views/devise/sessions/new.html.erb"
     assert_file "app/views/devise/registrations/new.html.erb"
     assert_file "app/views/devise/registrations/edit.html.erb"
@@ -47,19 +47,19 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
   end
 
   test "Assert specified directories with scope" do
-    run_generator %w(users -d sessions)
+    run_generator %w(users -v sessions)
     assert_file "app/views/users/sessions/new.html.erb"
     assert_no_file "app/views/users/confirmations/new.html.erb"
   end
 
   test "Assert specified directories with simple form" do
-    run_generator %w(-d registrations -b simple_form_for)
+    run_generator %w(-v registrations -b simple_form_for)
     assert_file "app/views/devise/registrations/new.html.erb", /simple_form_for/
     assert_no_file "app/views/devise/confirmations/new.html.erb"
     end
 
   test "Assert specified directories with markerb" do
-    run_generator %w(--markerb -d passwords mailer)
+    run_generator %w(--markerb -v passwords mailer)
     assert_file "app/views/devise/passwords/new.html.erb"
     assert_no_file "app/views/devise/confirmations/new.html.erb"
     assert_file "app/views/devise/mailer/reset_password_instructions.markerb"


### PR DESCRIPTION
Added a flag (-d) to the views generator that allows user to specify which view directories they want copied from Devise into their app.

Ex: `rails generate devise:views -d sessions passwords` will only generate the sessions and passwords views. 

Added some tests for the new flag in views_generator_test.rb. Can be used along with any of the existing options for the views generator (markerb, scope, etc).

Let me know what you think, thanks!
