### PR TITLE
Use `case_sensitive: false` when validating uniquess using ActiveRecord

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -27,7 +27,7 @@ module Devise
 
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
-          validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+          validates_uniqueness_of :email, allow_blank: true, case_sensitive: false, if: :email_changed?
           validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
 
           validates_presence_of     :password, if: :password_required?


### PR DESCRIPTION
Hello,

When using mysql with active record, using `case_sensitive: true` (AR default) causes the validation to be executed using a `BINARY` operator. 

This causes some problems because the validation might pass and the insert fail, for example in the case where an existing user's email is `ó@example.com` and the new user's email is `o@example.com`.
The validation would not raise an error, because it uses `BINARY`, but the insert would fail, because there is an index on that column and the index will not use a `BINARY` equivalent to compare both email addresses.

`case_insensitive: false` should be used anyway, since we are just validating emails and two emails with the different case are indeed the same email.

I could not write a test case because sqlite is being used for tests.
