### PR TITLE
Fixed documentation for configured_permitted_parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you have some checkboxes that express the roles a user may take on registrati
 
 ```ruby
 def configure_permitted_parameters
-  devise_parameter_sanitizer.for(:sign_up) { |u| u.permit(roles: [], :email, :password, :password_confirmation) }
+  devise_parameter_sanitizer.for(:sign_up) { |u| u.permit({roles: []}, :email, :password, :password_confirmation) }
 end
 ```
 For the list of permitted scalars, and how to declare permitted keys in nested hashes and arrays, see


### PR DESCRIPTION
Documentation on including non-scalar configured_parameters was incorrect,
