### PR TITLE
Serialize the `last_request_at` entry as an Integer

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -9,6 +9,11 @@ Warden::Manager.after_set_user do |record, warden, options|
 
   if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false
     last_request_at = warden.session(scope)['last_request_at']
+
+    if last_request_at.is_a? Integer
+      last_request_at = Time.at(last_request_at).utc
+    end
+
     proxy = Devise::Hooks::Proxy.new(warden)
 
     if record.timedout?(last_request_at) && !env['devise.skip_timeout']
@@ -22,7 +27,7 @@ Warden::Manager.after_set_user do |record, warden, options|
     end
 
     unless env['devise.skip_trackable']
-      warden.session(scope)['last_request_at'] = Time.now.utc
+      warden.session(scope)['last_request_at'] = Time.now.utc.to_i
     end
   end
 end

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -8,12 +8,11 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
 
   test 'set last request at in user session after each request' do
     sign_in_as_user
-    old_last_request = last_request_at
     assert_not_nil last_request_at
 
+    @controller.user_session.delete('last_request_at')
     get users_path
     assert_not_nil last_request_at
-    assert_not_equal old_last_request, last_request_at
   end
 
   test 'set last request at in user session after each request is skipped if tracking is disabled' do


### PR DESCRIPTION
Possible solution for #2930.

My first though was of adding support for `timedout?` to receive Strings, but this logic really belongs to the callback. Thinking out loud on Campfire I realized that storing the object as an integer would make more sense than bending Strings around, but I don't know if this change might break existing session data on apps out there.

Regarding to the testing bits, the existing integration tests felt a bit pointless due the semantics of numbers vs dates - between requests not just the values are the same, but the objects in memory too. 

I wanted to cover this better with a unit test for the callback code, but the current state of just passing the blocks to `Warden` makes it impossible. What do you guys think of extracting these blocks to classes like `Devise::Hooks::Timeoutable` instead? I can do this on another Pull Request.
