### PR TITLE
Password reset tokens stored as raw 'friendly token'

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -196,6 +196,10 @@ module Devise
   @@reset_password_keys = [ :email ]
 
   # Time interval you can reset your password with a reset password key
+  mattr_accessor :store_reset_password_tokens_as_raw
+  @@store_reset_password_tokens_as_raw = false
+
+  # Time interval you can reset your password with a reset password key
   mattr_accessor :reset_password_within
   @@reset_password_within = 6.hours
 

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -153,6 +153,15 @@ class RecoverableTest < ActiveSupport::TestCase
     assert user.valid_password?('new_password')
   end
 
+  test 'should store raw reset_password_token if store_reset_password_tokens_as_raw = true' do
+    swap Devise, store_reset_password_tokens_as_raw: true do
+      user = create_user
+      raw  = user.send_reset_password_instructions
+
+      assert_equal raw, user.reset_password_token
+    end
+  end
+
   test 'should not reset password after reset_password_within time' do
     swap Devise, reset_password_within: 1.hour do
       user = create_user

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -132,6 +132,10 @@ Devise.setup do |config|
   # change their passwords.
   config.reset_password_within = 2.hours
 
+  # Password reset tokens are stored in an encrypted form
+  # Set this to true to store them in plaintext, corresponding to the raw 'devise friendly' tokens
+  config.store_reset_password_tokens_as_raw = false
+
   # Setup a pepper to generate the encrypted password.
   config.pepper = "d142367154e5beacca404b1a6a4f8bc52c6fdcfa3ccc3cf8eb49f3458a688ee6ac3b9fae488432a3bfca863b8a90008368a9f3a3dfbe5a962e64b6ab8f3a3a1a"
 


### PR DESCRIPTION
Added a devise config to store the reset_password_token in its raw form. As generated by Devise friendly_token.
