### PR TITLE
Add configuration to invalidate all the remember me tokens when the user signs out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 3.3.0 (unreleased)
 
 * enhancements
+  * Add the `expire_all_remember_me_on_sign_out` configuration to invalidate
+    all the remember me tokens when the user signs out. (by @laurocaetano)
   * Default email messages was updated with grammar fixes, check the diff on
     #2906 for the updated copy (by @p-originate)
   * Allow a resource to be found based on its encrypted password token (by @karlentwistle)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -134,6 +134,10 @@ module Devise
   mattr_accessor :extend_remember_period
   @@extend_remember_period = false
 
+  # If true, all the remember me tokens are going to be invalidated when the user signs out.
+  mattr_accessor :expire_all_remember_me_on_sign_out
+  @@expire_all_remember_me_on_sign_out = true
+
   # Time interval you can access your account before confirming your account.
   # nil - allows unconfirmed access for unlimited time
   mattr_accessor :allow_unconfirmed_access_for

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -58,7 +58,7 @@ module Devise
       def forget_me!
         return unless persisted?
         self.remember_token = nil if respond_to?(:remember_token=)
-        self.remember_created_at = nil
+        self.remember_created_at = nil if self.class.expire_all_remember_me_on_sign_out
         save(validate: false)
       end
 
@@ -122,7 +122,7 @@ module Devise
           end
         end
 
-        Devise::Models.config(self, :remember_for, :extend_remember_period, :rememberable_options)
+        Devise::Models.config(self, :remember_for, :extend_remember_period, :rememberable_options, :expire_all_remember_me_on_sign_out)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -132,6 +132,9 @@ Devise.setup do |config|
   # The time the user will be remembered without asking for credentials again.
   # config.remember_for = 2.weeks
 
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 

--- a/test/models/rememberable_test.rb
+++ b/test/models/rememberable_test.rb
@@ -55,12 +55,27 @@ class RememberableTest < ActiveSupport::TestCase
     assert resource_class.new.respond_to?(:remember_me=)
   end
 
-  test 'forget_me should clear remember_created_at' do
-    resource = create_resource
-    resource.remember_me!
-    assert_not resource.remember_created_at.nil?
-    resource.forget_me!
-    assert resource.remember_created_at.nil?
+  test 'forget_me should clear remember_created_at if expire_all_remember_me_on_sign_out is true' do
+    swap Devise, expire_all_remember_me_on_sign_out: true do
+      resource = create_resource
+      resource.remember_me!
+      assert_not_nil resource.remember_created_at
+
+      resource.forget_me!
+      assert_nil resource.remember_created_at
+    end
+  end
+
+  test 'forget_me should not clear remember_created_at if expire_all_remember_me_on_sign_out is false' do
+    swap Devise, expire_all_remember_me_on_sign_out: false do
+      resource = create_resource
+      resource.remember_me!
+
+      assert_not_nil resource.remember_created_at
+
+      resource.forget_me!
+      assert_not_nil resource.remember_created_at
+    end
   end
 
   test 'forget_me should not try to update resource if it has been destroyed' do


### PR DESCRIPTION
Closes #2862

This PR adds the `expire_all_remember_me_on_sign_out` configuration, that  when enabled will invalidate all the remember me tokens when the user signs out. Without it, the remember me tokens won't be invalidated.

cc/ @josevalim 
