### PR TITLE
Use port option in default url options for ActionMailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Replace MODEL by the class name used for the applications users, it's frequently
 Next, you need to set up the default url options for the Devise mailer in each environment. Here is a possible configuration for `config/environments/development.rb`:
 
 ```ruby
-config.action_mailer.default_url_options = { host: 'localhost:3000' }
+config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 ```
 
 You should restart your application after changing Devise's configuration options. Otherwise you'll run into strange errors like users being unable to login and route helpers being undefined.

--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -6,7 +6,7 @@ Some setup you must do manually if you haven't yet:
      is an example of default_url_options appropriate for a development environment
      in config/environments/development.rb:
 
-       config.action_mailer.default_url_options = { host: 'localhost:3000' }
+       config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
      In production, :host should be set to the actual host of your application.
 

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -83,9 +83,9 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
   end
 
   test 'body should have link to confirm the account' do
-    host = ActionMailer::Base.default_url_options[:host]
+    host, port = ActionMailer::Base.default_url_options.values_at :host, :port
 
-    if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/confirmation\?confirmation_token=([^"]+)">}
+    if mail.body.encoded =~ %r{<a href=\"http://#{host}:#{port}/users/confirmation\?confirmation_token=([^"]+)">}
       assert_equal Devise.token_generator.digest(user.class, :confirmation_token, $1), user.confirmation_token
     else
       flunk "expected confirmation url regex to match"

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -79,9 +79,9 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
   end
 
   test 'body should have link to confirm the account' do
-    host = ActionMailer::Base.default_url_options[:host]
+    host, port = ActionMailer::Base.default_url_options.values_at :host, :port
 
-    if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/password/edit\?reset_password_token=([^"]+)">}
+    if mail.body.encoded =~ %r{<a href=\"http://#{host}:#{port}/users/password/edit\?reset_password_token=([^"]+)">}
       assert_equal Devise.token_generator.digest(user.class, :reset_password_token, $1), user.reset_password_token
     else
       flunk "expected reset password url regex to match"

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -80,9 +80,9 @@ class UnlockInstructionsTest < ActionMailer::TestCase
   end
 
   test 'body should have link to unlock the account' do
-    host = ActionMailer::Base.default_url_options[:host]
+    host, port = ActionMailer::Base.default_url_options.values_at :host, :port
 
-    if mail.body.encoded =~ %r{<a href=\"http://#{host}/users/unlock\?unlock_token=([^"]+)">}
+    if mail.body.encoded =~ %r{<a href=\"http://#{host}:#{port}/users/unlock\?unlock_token=([^"]+)">}
       assert_equal Devise.token_generator.digest(user.class, :unlock_token, $1), user.unlock_token
     else
       flunk "expected unlock url regex to match"

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -30,7 +30,7 @@ module RailsApp
     config.filter_parameters << :password
     config.assets.enabled = false
 
-    config.action_mailer.default_url_options = { host: "localhost:3000" }
+    config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
     # This was used to break devise in some situations
     config.to_prepare do


### PR DESCRIPTION
Better comply with ActionMailer default_url_options.
