### PR TITLE
Support multiple warden configuration blocks

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -272,7 +272,7 @@ module Devise
   # Private methods to interface with Warden.
   mattr_accessor :warden_config
   @@warden_config = nil
-  @@warden_config_block = nil
+  @@warden_config_blocks = []
 
   # When true, enter in paranoid mode to avoid user enumeration.
   mattr_accessor :paranoid
@@ -413,7 +413,7 @@ module Devise
   #    end
   #  end
   def self.warden(&block)
-    @@warden_config_block = block
+    @@warden_config_blocks << block
   end
 
   # Specify an omniauth provider.
@@ -467,7 +467,7 @@ module Devise
         end
       end
 
-      @@warden_config_block.try :call, Devise.warden_config
+      @@warden_config_blocks.map { |block| block.call Devise.warden_config }
       true
     end
   end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 module Devise
   def self.yield_and_restore
     @@warden_configured = nil
-    c, b = @@warden_config, @@warden_config_block
+    c, b = @@warden_config, @@warden_config_blocks
     yield
   ensure
-    @@warden_config, @@warden_config_block = c, b
+    @@warden_config, @@warden_config_blocks = c, b
   end
 end
 
@@ -50,6 +50,23 @@ class DeviseTest < ActiveSupport::TestCase
 
       Devise.configure_warden!
       assert @executed
+    end
+  end
+
+  test 'warden manager user configuration through multiple blocks' do
+    Devise.yield_and_restore do
+      @first_executed = false
+      @second_executed = false
+      Devise.warden do |config|
+        @first_executed = true
+      end
+      Devise.warden do |config|
+        @second_executed = true
+      end
+
+      Devise.configure_warden!
+      assert @first_executed
+      assert @second_executed
     end
   end
 


### PR DESCRIPTION
This pull request extends the behavior of `Devise.warden` such that calling it multiple times with different blocks will result in a call to each block on `Devise.configure_warden!` rather than "last block wins". 

This is especially useful for plugins that wish to extend warden functionality without clobbering base app configuration or vice versa:

``` ruby
# my Rails app
# config/initializers/devise.rb
config.warden do |manager|
  manager.oauth(:twitter)
end

# a Rails engine
# lib/open_sesame/engine.rb
config.warden do |manager|
  manager.serialize_into_session(:opensesame) { |user| user.login }
  manager.serialize_from_session(:opensesame) { |login| OpenSesame::User.find(login) }
end
```
