### PR TITLE
Switched all instances of 'not blank?' to 'present?'

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -236,17 +236,17 @@ module Devise
         end
 
         def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && !self.email.blank?
+          postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && self.email.present?
           @bypass_confirmation_postpone = false
           postpone
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required && !self.email.blank?
+          self.class.reconfirmable && @reconfirmation_required && self.email.present?
         end
 
         def send_confirmation_notification?
-          confirmation_required? && !@skip_confirmation_notification && !self.email.blank?
+          confirmation_required? && !@skip_confirmation_notification && self.email.present?
         end
 
         def after_confirmation

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -53,7 +53,7 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
 
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
-    assert_not_blank mail.body.encoded
+    assert_present mail.body.encoded
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -55,7 +55,7 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
 
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
-    assert_not_blank mail.body.encoded
+    assert_present mail.body.encoded
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -56,7 +56,7 @@ class UnlockInstructionsTest < ActionMailer::TestCase
 
   test 'custom mailer renders parent mailer template' do
     Devise.mailer = 'Users::Mailer'
-    assert_not_blank mail.body.encoded
+    assert_present mail.body.encoded
   end
 
   test 'setup reply to as copy from sender' do

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -9,10 +9,9 @@ class ActiveSupport::TestCase
     assert assertion.blank?
   end
 
-  def assert_not_blank(assertion)
-    assert !assertion.blank?
+  def assert_present(assertion)
+    assert assertion.present?
   end
-  alias :assert_present :assert_not_blank
 
   def assert_email_sent(address = nil, &block)
     assert_difference('ActionMailer::Base.deliveries.size', &block)


### PR DESCRIPTION
`!thing.blank?` is harder to reason about than `thing.present?` (not _way_ harder, but still). Maybe it's just me, but I think it's a little better this way.
