### PR TITLE
=, should be ==

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -75,7 +75,7 @@ module Devise
       def rememberable_value
         if respond_to?(:remember_token)
           remember_token
-        elsif respond_to?(:authenticatable_salt) && (salt = authenticatable_salt)
+        elsif respond_to?(:authenticatable_salt) && (salt == authenticatable_salt)
           salt
         else
           raise "authenticable_salt returned nil for the #{self.class.name} model. " \


### PR DESCRIPTION
I think it should be == instead of =? Since (salt = authenticatable_salt) always evaluates to true.
If the intention is to set salt to be authenticatable_salt and then return salt, I don' think this is a very clear way of expressing that. 
