### PR TITLE
Fix Devise::ConfirmationsController#after_confirmation_path_for

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -38,7 +38,7 @@ class Devise::ConfirmationsController < DeviseController
 
     # The path used after confirmation.
     def after_confirmation_path_for(resource_name, resource)
-      if signed_in?
+      if signed_in?(resource_name)
         signed_in_root_path(resource)
       else
         new_session_path(resource_name)

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -133,6 +133,15 @@ class ConfirmationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'user should be redirected to sign in page whenever signed in as another resource at same session already' do
+    sign_in_as_admin
+
+    user = create_user(confirm: false)
+    visit_user_confirmation_with_token(user.raw_confirmation_token)
+
+    assert_current_url '/users/sign_in'
+  end
+
   test 'error message is configurable by resource name' do
     store_translations :en, devise: {
       failure: { user: { unconfirmed: "Not confirmed user" } }


### PR DESCRIPTION
after_confirmation_path_for checks whether the user already signed in
by calling signed_in? after confirmation succeeded.
Since it was called without scope specification, the user treated as
signed in inappropriately when the user signed in as another resource
(such as 'admin').
