### PR TITLE
Split send_reset_password_instructions for better hooking

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -46,7 +46,7 @@ module Devise
       # Returns the token sent in the e-mail.
       def send_reset_password_instructions
         token = set_reset_password_token
-        send_reset_password_instruction_notification(token)
+        send_reset_password_instructions_notification(token)
 
         token
       end
@@ -90,13 +90,12 @@ module Devise
           raw, enc = Devise.token_generator.generate(self.class, :reset_password_token)
 
           self.reset_password_token   = enc
+          self.reset_password_sent_at = Time.now.utc
           self.save(validate: false)
           raw
         end
 
-        def send_reset_password_instruction_notification(token)
-          self.reset_password_sent_at = Time.now.utc
-          self.save(validate: false)
+        def send_reset_password_instructions_notification(token)
           send_devise_notification(:reset_password_instructions, token, {})
         end
 


### PR DESCRIPTION
Earlier, when we used to customize the recoverable module of the Devise, we need to override both the reset_password_token generation logic and the email sending logic in the same function i.e. `send_reset_password_instructions`. 
Now, consider a use case where we want to generate the random link for our users and send the SMS instead of an email to the user. If we were to override the `send_reset_password_instructions` then we have to use the `reset_password_token` generation logic as it is and the email sending logic needs to be replaced with the SMS sending one. The principle of DRY is violated here. So here, I suggest the splitting up of the `send_reset_password_instructions` into two methods namely `set_reset_password_token` and `send_reset_password_instruction_notification`.

The `set_reset_password_token` is responsible for the generation and setting of the `reset_password_token` of the user. The `send_reset_password_instruction_notification` is responsible for the delivery of the email. 
You can override the `set_reset_password_token` if you want to customize the reset_password_token generation and setting logic. Similarly, you can override the `send_reset_password_instruction_notification` for sending the SMS or changing Email sending logic.
