### PR TITLE
Omniauth can't cleanup CSRF

### DIFF
--- a/lib/devise/hooks/csrf_cleaner.rb
+++ b/lib/devise/hooks/csrf_cleaner.rb
@@ -1,5 +1,7 @@
 Warden::Manager.after_authentication do |record, warden, options|
-  if Devise.clean_up_csrf_token_on_authentication
+  clean_up_for_winning_strategy = !warden.winning_strategy.respond_to?(:clean_up_csrf?) ||
+    warden.winning_strategy.clean_up_csrf?
+  if Devise.clean_up_csrf_token_on_authentication && clean_up_for_winning_strategy
     warden.request.session.try(:delete, :_csrf_token)
   end
 end

--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -16,6 +16,13 @@ module Devise
         valid_for_params_auth? || valid_for_http_auth?
       end
 
+      # Override and set to false for things like OmniAuth that technically
+      # run through Authentication (user_set) very often, which would normally
+      # reset CSRF data in the session
+      def clean_up_csrf?
+        true
+      end
+
     private
 
       # Receives a resource and check if it is valid by calling valid_for_authentication?


### PR DESCRIPTION
In regards to https://github.com/plataformatec/devise/commit/747751a20f50aa8814dcd3eb9a3648f00ab6a707

Perhaps I'm misunderstanding the problem (or approaching the solution incorrectly), but it seems that some OmniAuth functions lose their CSRF token and cause some CSRF errors with forms thereafter. For instance, I work with a growing SOA setup that authenticates via some tokens in session, and the CSRF is reset because of this Warden Hook, causing a number of form issues. I've gotten around in one of the applications by disabling this hook (via the config option) and re-implementing what I've provided here.

These changes allow a Strategy to define `clean_up_csrf?` and set it to false to _not_ reset CSRF after the strategy is run.
