### PR TITLE
Getting Started instructions: clarification on dynamic method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Devise will create some helpers to use inside your controllers and views. To set
 before_action :authenticate_user!
 ```
 
-If your devise MODEL is something other than User, replace "_user" with "_yourmodel". The same logic applies to the instructions below.
+If your devise model is something other than User, replace "_user" with "_yourmodel". The same logic applies to the instructions below.
 
 To verify if a user is signed in, use the following helper:
 


### PR DESCRIPTION
It took awhile to figure out why "before_action :authenticate_user!" was producing an "undefined method `authenticate_user!'" error. It was because my Devise model is "Account", instead of User, and I didn't realize that the helper method names are dynamic. This minor documentation change will help other new Devise developers avoid this confusion.
