### PR TITLE
Set default sender only when not set in the application

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
     config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
   end
 <% else -%>
-  # ActionMailer::Base.default :sender => "email@example.com"
+  #ActionMailer::Base.default({sender: "email@example.com"})
   unless ActionMailer::Base.default.try(:[], :sender)
     config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
   end


### PR DESCRIPTION
Only set the default sender if it's not set in the application config.
This reduces duplicate effort when changing the sender. (I've forgotten it in a few projects)
