### PR TITLE
Changes to support devise-neo4j

### DIFF
--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -17,7 +17,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert warden.authenticated?(:admin)
     assert_current_url "/admin_area/home"
 
-    admin = AdminAdapter.find_first(order: [:id, :desc])
+    admin = Admin.to_adapter.find_first(order: [:id, :desc])
     assert_equal admin.email, 'new_user@test.com'
   end
 
@@ -56,7 +56,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
 
     assert_not warden.authenticated?(:user)
 
-    user = UserAdapter.find_first(order: [:id, :desc])
+    user = User.to_adapter.find_first(order: [:id, :desc])
     assert_equal user.email, 'new_user@test.com'
     assert_not user.confirmed?
   end
@@ -103,7 +103,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_contain Devise.rails4? ?
       "Password confirmation doesn't match Password" : "Password doesn't match confirmation"
     assert_contain "2 errors prohibited"
-    assert_nil UserAdapter.find_first
+    assert_nil User.to_adapter.find_first
 
     assert_not warden.authenticated?(:user)
   end
@@ -151,7 +151,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_current_url '/'
     assert_contain 'Your account has been updated successfully.'
 
-    assert_equal "user.new@example.com", UserAdapter.find_first.email
+    assert_equal "user.new@example.com", User.to_adapter.find_first.email
   end
 
   test 'a signed in user should still be able to use the website after changing their password' do
@@ -180,7 +180,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_contain 'user@test.com'
     assert_have_selector 'form input[value="user.new@example.com"]'
 
-    assert_equal "user@test.com", UserAdapter.find_first.email
+    assert_equal "user@test.com", User.to_adapter.find_first.email
   end
 
   test 'a signed in user should be able to edit their password' do
@@ -195,7 +195,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_current_url '/'
     assert_contain 'Your account has been updated successfully.'
 
-    assert UserAdapter.find_first.valid_password?('pass1234')
+    assert User.to_adapter.find_first.valid_password?('pass1234')
   end
 
   test 'a signed in user should not be able to edit their password with invalid confirmation' do
@@ -209,7 +209,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
 
     assert_contain Devise.rails4? ?
       "Password confirmation doesn't match Password" : "Password doesn't match confirmation"
-    assert_not UserAdapter.find_first.valid_password?('pas123')
+    assert_not User.to_adapter.find_first.valid_password?('pas123')
   end
 
   test 'a signed in user should be able to cancel their account' do
@@ -219,7 +219,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     click_button "Cancel my account"
     assert_contain "Bye! Your account has been successfully cancelled. We hope to see you again soon."
 
-    assert UserAdapter.find_all.empty?
+    assert User.to_adapter.find_all.empty?
   end
 
   test 'a user should be able to cancel sign up by deleting data in the session' do
@@ -253,7 +253,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert response.body.include? %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<admin>)
 
-    admin = AdminAdapter.find_first(order: [:id, :desc])
+    admin = Admin.to_adapter.find_first(order: [:id, :desc])
     assert_equal admin.email, 'new_user@test.com'
   end
 
@@ -262,7 +262,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert response.body.include? %(<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<user>)
 
-    user = UserAdapter.find_first(order: [:id, :desc])
+    user = User.to_adapter.find_first(order: [:id, :desc])
     assert_equal user.email, 'new_user@test.com'
   end
 
@@ -290,7 +290,7 @@ class RegistrationTest < ActionDispatch::IntegrationTest
     sign_in_as_user
     delete user_registration_path(format: 'xml')
     assert_response :success
-    assert_equal UserAdapter.find_all.size, 0
+    assert_equal User.to_adapter.find_all.size, 0
   end
 end
 
@@ -305,7 +305,7 @@ class ReconfirmableRegistrationTest < ActionDispatch::IntegrationTest
 
     assert_current_url '/admin_area/home'
     assert_contain 'but we need to verify your new email address'
-    assert_equal 'admin.new@example.com', AdminAdapter.find_first.unconfirmed_email
+    assert_equal 'admin.new@example.com', Admin.to_adapter.find_first.unconfirmed_email
 
     get edit_admin_registration_path
     assert_contain 'Currently waiting confirmation for: admin.new@example.com'
@@ -323,7 +323,7 @@ class ReconfirmableRegistrationTest < ActionDispatch::IntegrationTest
     assert_current_url '/admin_area/home'
     assert_contain 'Your account has been updated successfully.'
 
-    assert AdminAdapter.find_first.valid_password?('pas123')
+    assert Admin.to_adapter.find_first.valid_password?('pas123')
   end
 
   test 'a signed in admin should not see a reconfirmation message if they did not change their email, despite having an unconfirmed email' do
@@ -343,7 +343,7 @@ class ReconfirmableRegistrationTest < ActionDispatch::IntegrationTest
     assert_current_url '/admin_area/home'
     assert_contain 'Your account has been updated successfully.'
 
-    assert_equal "admin.new@example.com", AdminAdapter.find_first.unconfirmed_email
-    assert AdminAdapter.find_first.valid_password?('pas123')
+    assert_equal "admin.new@example.com", Admin.to_adapter.find_first.unconfirmed_email
+    assert Admin.to_adapter.find_first.valid_password?('pas123')
   end
 end

--- a/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def sign_in_facebook
-    user = UserAdapter.find_first(email: 'user@test.com')
+    user = User.to_adapter.find_first(email: 'user@test.com')
     user.remember_me = true
     sign_in user
     render text: ""

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,6 @@ require "rails_app/config/environment"
 require "rails/test_help"
 require "orm/#{DEVISE_ORM}"
 
-AdminAdapter = Admin.to_adapter unless Admin.is_a?(OrmAdapter::Base)
-UserAdapter  = User.to_adapter unless User.is_a?(OrmAdapter::Base)
-
 I18n.load_path << File.expand_path("../support/locale/en.yml", __FILE__)
 
 require 'mocha/setup'


### PR DESCRIPTION
I've been working to get the devise-neo4j gem working with the alpha version of neo4j.  I've done the work in the neo4j gem to make it support an orm_adapter, but when I ran the devise tests I hit a couple of snags which needed to be addressed in the devise gem.  They are:
- Using adapters for User and Admin in the devise tests
- Supporting both Time and DateTime model properties

Let me know if you have any questions about these changes!
