### PR TITLE
guard recall_app() to allow for alternate rack failure apps

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -142,6 +142,7 @@ module Devise
     end
 
     def recall_app(app)
+      return app unless app.is_a?(String)
       controller, action = app.split("#")
       controller_name  = ActiveSupport::Inflector.camelize(controller)
       controller_klass = ActiveSupport::Inflector.constantize("#{controller_name}Controller")


### PR DESCRIPTION
Single line of code to allow for using Warden managed by Devise in an app where Rack apps (e.g. Grape) are mounted within Rails' routes.rb.

This change adds a single conditional guard to `FailureApp#recall_app()` to allow for alternate rack failure apps passed with`warden.authenticate(recall: <alternate_app>)`.

Without this Devise always hijacks 401 errors thrown with `:warden` from Grape.  But Grape needs to manage it's own error statuses, and wants the 401 to be a 401 in the API.

This change is likely applicable on up the release chain, but we are still stuck on legacy for other reasons.

Example usage in a Grape::Api class:

```
      post 'login' do
        warden.authenticate!(:scope => :user, :recall => FailureApp)
        { :auth_token => current_user.authentication_token }
      end
```

An example alternative Failure App:

```
require 'json'
class FailureApp
    # This is the "recall" application sent by all warden.authenticate! calls in Grape for when auth fails.
    # The result is that this will cause devise to use this as the render instead of it's own 302 override.

    attr_reader :env
    include Warden::Mixins::Common

    def initialize(env)
      @env = env
    end

    def self.call(env)
      new(env).respond!
    end

    def respond!
      headers = {'Content-Type' => 'application/json'}
      body = {}
      body[:error] = 'access_denied'
      [401, headers, [JSON.dump(body)]]
    end

end
```
