### PR TITLE
Silence Warning Regarding Use of Splat

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -6,8 +6,8 @@ class DeviseController < Devise.parent_controller.constantize
 
   helpers = %w(resource scope_name resource_name signed_in_resource
                resource_class resource_params devise_mapping)
-  hide_action *helpers
-  helper_method *helpers
+  hide_action(*helpers)
+  helper_method(*helpers)
 
   prepend_before_filter :assert_is_devise_resource!
   respond_to :html if mimes_for_respond_to.empty?


### PR DESCRIPTION
I was seeing the following in my console:

```
/home/vagrant/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/devise-3.2.4/app/controllers/devise_controller.rb:9: warning: `*' interpreted as argument prefix
/home/vagrant/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/devise-3.2.4/app/controllers/devise_controller.rb:10: warning: `*' interpreted as argument prefix
```

This change silences this warning.
