### PR TITLE
make lockable default

### DIFF
--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -64,8 +64,8 @@ module ActiveRecord
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
-      # t.string   :unlock_token # Only if unlock strategy is :email or :both
-      # t.datetime :locked_at
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
 RUBY
       end
 

--- a/lib/generators/devise/orm_helpers.rb
+++ b/lib/generators/devise/orm_helpers.rb
@@ -4,9 +4,9 @@ module Devise
       def model_contents
         buffer = <<-CONTENT
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :lockable
 
 CONTENT
         buffer += <<-CONTENT if needs_attr_accessible?


### PR DESCRIPTION
Without the `lockable` module it is possible to do a timing based username enumeration so I propose to make `lockable` opt-out rather than opt-in.
