### PR TITLE
Non-hash resource param throws exception

### DIFF
--- a/test/parameter_sanitizer_test.rb
+++ b/test/parameter_sanitizer_test.rb
@@ -10,6 +10,11 @@ class BaseSanitizerTest < ActiveSupport::TestCase
     sanitizer = sanitizer(user: { "email" => "jose" })
     assert_equal({ "email" => "jose" }, sanitizer.sanitize(:sign_in))
   end
+
+  test 'handles non-hash user param' do
+    sanitizer = sanitizer(user: 'this-is-a-string-not-a-hash')
+    assert_equal({}, sanitizer.sanitize(:sign_in))
+  end
 end
 
 if defined?(ActionController::StrongParameters)

--- a/test/parameter_sanitizer_test.rb
+++ b/test/parameter_sanitizer_test.rb
@@ -69,6 +69,11 @@ if defined?(ActionController::StrongParameters)
       end
     end
 
+    test 'handles non-hash user param' do
+      sanitizer = sanitizer(user: 'this-is-a-string-not-a-hash')
+      assert_equal({}, sanitizer.sanitize(:sign_in))
+    end
+
     test 'passes parameters to filter as arguments to sanitizer' do
       params = {user: stub}
       sanitizer = Devise::ParameterSanitizer.new(User, :user, params)


### PR DESCRIPTION
Saw some kind of malicious user/bot posting invalid params, which was triggering 5xx errors.

Instead, I think it should be returning kind of 4xx error without an exception, since it's bad data coming from a user.

Haven't patched it yet, but here's a start - a failing test case.