### PR TITLE
Fix mapping not set when using devise_scope without devise_for.

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -342,6 +342,19 @@ module ActionDispatch::Routing
     #
     # Notice and be aware of the differences above between :user and :users
     def devise_scope(scope)
+      unless Devise.mappings.has_key?(scope)
+        options = {}
+        options[:as]            = @scope[:as]     if @scope[:as].present?
+        options[:module]        = @scope[:module] if @scope[:module].present?
+        options[:path_prefix]   = @scope[:path]   if @scope[:path].present?
+        options[:path_names]    = @scope[:path_names] || {}
+        options[:constraints]   = @scope[:constraints] || {}
+        options[:defaults]      = @scope[:defaults] || {}
+        options[:options]       = @scope[:options] || {}
+        options[:options][:format] = false if options[:format] == false
+        Devise.add_mapping(scope, options)
+      end
+      
       constraint = lambda do |request|
         request.env["devise.mapping"] = Devise.mappings[scope]
         true


### PR DESCRIPTION
This patch fixes https://github.com/plataformatec/devise/issues/2840. When setting solely custom routes with `devise_scope`, `Devise.add_mapping` is never called, thus resulting in 

``` AbstractController::ActionNotFound:
   Could not find devise mapping for path "/users/sign_in".
   This may happen for two reasons:

   1) You forgot to wrap your route inside the scope block. For example:

     devise_scope :user do
       get "/some/route" => "some_devise_controller"
     end

   2) You are testing a Devise controller bypassing the router.
      If so, you can explicitly tell Devise which mapping to use:

      @request.env["devise.mapping"] = Devise.mappings[:user]
```

This patch adds the mapping inside devise_scope, but only if the mapping is not already set.
