### PR TITLE
Do not pass down 'ActionController::Parameters' to outside the controller

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -253,7 +253,7 @@ module Devise
 
         # Find an initialize a group of attributes based on a list of required attributes.
         def find_or_initialize_with_errors(required_attributes, attributes, error=:invalid) #:nodoc:
-          attributes = attributes.slice(*required_attributes)
+          attributes = attributes.slice(*required_attributes).with_indifferent_access
           attributes.delete_if { |key, value| value.blank? }
 
           if attributes.size == required_attributes.size

--- a/test/models/authenticatable_test.rb
+++ b/test/models/authenticatable_test.rb
@@ -10,4 +10,14 @@ class AuthenticatableTest < ActiveSupport::TestCase
     assert_equal User.find_first_by_auth_conditions({ email: "example@example.com" }), user
     assert_nil User.find_first_by_auth_conditions({ email: "example@example.com" }, id: user.id.to_s.next)
   end
+
+  if defined?(ActionController::Parameters)
+    test 'does not passes an ActionController::Parameters to find_first_by_auth_conditions through find_or_initialize_with_errors' do
+      user = create_user(email: 'example@example.com')
+      attributes = ActionController::Parameters.new(email: 'example@example.com')
+
+      User.expects(:find_first_by_auth_conditions).with('email' => 'example@example.com').returns(user)
+      User.find_or_initialize_with_errors([:email], attributes)
+    end
+  end
 end


### PR DESCRIPTION
This deals with regressions similar to #3157. This way the models will always receive a `HashWithIndifferentAccess` instead of a `ActionController::Parameters`. 

One alternative would be to change the `resource_params` helper to always return a plain Hash, but I don't know if we should change the return type of that method and even if we should have it around since most of the parameters manipulation is currently on the parameters sanitizer.

/cc @rafaelfranca @carlosantoniodasilva @josevalim 
