### PR TITLE
Url helpers raise "undefined method `router_name' for nil:NilClass"

### DIFF
--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -33,7 +33,7 @@ module Devise
     def self.find_scope!(obj)
       case obj
       when String, Symbol
-        return obj
+        return obj.to_sym
       when Class
         Devise.mappings.each_value { |m| return m.name if obj <= m.to }
       else

--- a/test/controllers/url_helpers_test.rb
+++ b/test/controllers/url_helpers_test.rb
@@ -13,6 +13,12 @@ class RoutesTest < ActionController::TestCase
     assert_equal @controller.send(:"#{prepend_path}#{name}_url", :user),
                  send(:"#{prepend_path}user_#{name}_url")
 
+    # With string
+    assert_equal @controller.send(:"#{prepend_path}#{name}_path", "user"),
+                 send(:"#{prepend_path}user_#{name}_path")
+    assert_equal @controller.send(:"#{prepend_path}#{name}_url", "user"),
+                 send(:"#{prepend_path}user_#{name}_url")
+
     # Default url params
     assert_equal @controller.send(:"#{prepend_path}#{name}_path", :user, param: 123),
                  send(:"#{prepend_path}user_#{name}_path", param: 123)

--- a/test/mapping_test.rb
+++ b/test/mapping_test.rb
@@ -62,6 +62,7 @@ class MappingTest < ActiveSupport::TestCase
   test 'find scope for a given object' do
     assert_equal :user, Devise::Mapping.find_scope!(User)
     assert_equal :user, Devise::Mapping.find_scope!(:user)
+    assert_equal :user, Devise::Mapping.find_scope!("user")
     assert_equal :user, Devise::Mapping.find_scope!(User.new)
   end
 


### PR DESCRIPTION
When I update devise from 3.2.4 to 3.3.0, url helpers with string raises an Exception, although the comment for [UrlHelpers](/plataformatec/devise/blob/master/lib/devise/controllers/url_helpers.rb) says it can receive string.

```
<%= link_to new_session_path(:user), "Sign in" %> # OK
<%= link_to new_session_path("user"), "Sign in" %> # => undefined method `router_name' for nil:NilClass
```

It seems to be a bug which Devise::Mapping.find_scope! returns String instead of Symbol and can not find the value in Devise.mappings hash.  But it may be better to change Devise.Mappings to `ActiveSupport::HashWithIndifferentAccess`.

Anyway, here is a pull request to fix the find_scope! method.
