### PR TITLE
Update Simple Form templates for 3.3.0

### DIFF
--- a/lib/generators/templates/simple_form_for/registrations/new.html.erb
+++ b/lib/generators/templates/simple_form_for/registrations/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="form-inputs">
     <%= f.input :email, required: true, autofocus: true %>
-    <%= f.input :password, required: true %>
+    <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @validatable) %>
     <%= f.input :password_confirmation, required: true %>
   </div>
 

--- a/lib/generators/templates/simple_form_for/sessions/new.html.erb
+++ b/lib/generators/templates/simple_form_for/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Sign in</h2>
+<h2>Log in</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">
@@ -8,7 +8,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, "Sign in" %>
+    <%= f.button :submit, "Log in" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Fixes #3146.

Please note that while internally, methods, routes etc are currently still named `sign_in`, there are still some strings in [YAML](https://github.com/plataformatec/devise/search?l=yaml&q=%22Sign+in%22&utf8=%E2%9C%93) and [HTML ERB](https://github.com/plataformatec/devise/search?l=html%2Berb&q=%22Sign+in%22&utf8=%E2%9C%93) files that use _sign in_. Is that a leftover?
