### PR TITLE
Handling string AND symbol resource name in Devise::Mapping.find_scope!

### DIFF
--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -33,7 +33,7 @@ module Devise
     def self.find_scope!(obj)
       case obj
       when String, Symbol
-        return obj
+        return obj.to_sym
       when Class
         Devise.mappings.each_value { |m| return m.name if obj <= m.to }
       else

--- a/test/mapping_test.rb
+++ b/test/mapping_test.rb
@@ -65,6 +65,10 @@ class MappingTest < ActiveSupport::TestCase
     assert_equal :user, Devise::Mapping.find_scope!(User.new)
   end
 
+  test 'find scope for a given object, use string instead of symbol' do
+    assert_equal :user, Devise::Mapping.find_scope!('user')
+  end
+
   test 'find scope works with single table inheritance' do
     assert_equal :user, Devise::Mapping.find_scope!(Class.new(User))
     assert_equal :user, Devise::Mapping.find_scope!(Class.new(User).new)


### PR DESCRIPTION
Handling string AND symbol resource name in Devise::Mapping.find_scope! as previous used Devise::Mapping.find_mapping!, make thing compatible.
