### PR TITLE
Explicitly use null default for timestamps in migrations.

### DIFF
--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -33,7 +33,7 @@ class CreateTables < ActiveRecord::Migration
       t.string   :unlock_token # Only if unlock strategy is :email or :both
       t.datetime :locked_at
 
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :admins do |t|
@@ -60,7 +60,7 @@ class CreateTables < ActiveRecord::Migration
       ## Attribute for testing route blocks
       t.boolean :active, default: false
 
-      t.timestamps
+      t.timestamps null: true
     end
   end
 


### PR DESCRIPTION
I dropped in this while working on my app, thought I'd share. It's a small thing, but I hope this is helpful!

This clears the following deprecation warning in Rails 4.2.0.beta1, preparing for Rails 5:

==> Devise.orm = :active_record
DEPRECATION WARNING: `timestamp` was called without specifying an option for `null`. In Rails
5.0, this behavior will change to `null: false`. You should manually
specify `null: true` to prevent the behavior of your existing migrations
from changing.
