### PR TITLE
Add a seconds call to timeout_in calculation

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -27,7 +27,7 @@ module Devise
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
         return false if remember_exists_and_not_expired?
-        !timeout_in.nil? && last_access && last_access <= timeout_in.ago
+        !timeout_in.nil? && last_access && last_access <= timeout_in.seconds.ago
       end
 
       def timeout_in


### PR DESCRIPTION
Currently, by simply calling `timeout_in.ago`, a warning is raised when the user provides a native, Numeric type to the timeout configuration ("Using 5.ago is deprecated," for example).

By calling `.seconds` on the configured value, it allows users to provide a native, Numeric to the timeout configuration value, rather than requiring an ActiveSupport::Duration instance, to avoid these warnings.