### PR TITLE
fix path bug

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -33,7 +33,7 @@ class Devise::ConfirmationsController < DeviseController
 
     # The path used after resending confirmation instructions.
     def after_resending_confirmation_instructions_path_for(resource_name)
-      new_session_path(resource_name) if is_navigational_format?
+      is_navigational_format? ? new_session_path(resource_name) : '/'
     end
 
     # The path used after confirmation.


### PR DESCRIPTION
when `is_navigational_format?` returns false, Exception will be throw: 
ArgumentError (Nil location provided. Can't build URI.)
