### PR TITLE
Added new_account_instructions method to recoverable model

### DIFF
--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -12,6 +12,11 @@ if defined?(ActionMailer)
       devise_mail(record, :reset_password_instructions, opts)
     end
 
+    def new_account_instructions(record, token, opts={})
+      @token = token
+      devise_mail(record, :new_account_instructions, opts)
+    end
+
     def unlock_instructions(record, token, opts={})
       @token = token
       devise_mail(record, :unlock_instructions, opts)

--- a/app/views/devise/mailer/new_account_instructions.html.erb
+++ b/app/views/devise/mailer/new_account_instructions.html.erb
@@ -1,0 +1,5 @@
+Hello <%= @resource.email %>!
+
+An account has been created for you. Please use the link below to set your password.
+
+<%= link_to 'Set my password', edit_password_url(@resource, reset_password_token: @token) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
         subject: "Confirmation instructions"
       reset_password_instructions:
         subject: "Reset password instructions"
+      new_account_instructions:
+        subject: "Welcome"
       unlock_instructions:
         subject: "Unlock instructions"
     omniauth_callbacks:

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -51,6 +51,15 @@ module Devise
         token
       end
 
+      # Resets reset password token and send new account instructions by email.
+      # Returns the token sent in the e-mail.
+      def send_new_account_instructions
+        token = set_reset_password_token
+        send_new_account_instructions_notification(token)
+
+        token
+      end
+
       # Checks if the reset password token sent is within the limit time.
       # We do this by calculating if the difference between today and the
       # sending date does not exceed the confirm in time configured.
@@ -97,6 +106,10 @@ module Devise
 
         def send_reset_password_instructions_notification(token)
           send_devise_notification(:reset_password_instructions, token, {})
+        end
+
+        def send_new_account_instructions_notification(token)
+          send_devise_notification(:new_account_instructions, token, {})
         end
 
       module ClassMethods

--- a/lib/generators/templates/markerb/new_account_instructions.markerb
+++ b/lib/generators/templates/markerb/new_account_instructions.markerb
@@ -1,0 +1,5 @@
+Hello <%= @resource.email %>!
+
+An account has been created for you. Please use the link below to set your password.
+
+<%= link_to 'Set my password', edit_password_url(@resource, reset_password_token: @token) %>

--- a/test/generators/views_generator_test.rb
+++ b/test/generators/views_generator_test.rb
@@ -72,6 +72,7 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/#{scope}/confirmations/new.html.erb"
     assert_file "app/views/#{scope}/mailer/confirmation_instructions.#{mail_template_engine}"
     assert_file "app/views/#{scope}/mailer/reset_password_instructions.#{mail_template_engine}"
+    assert_file "app/views/#{scope}/mailer/new_account_instructions.#{mail_template_engine}"
     assert_file "app/views/#{scope}/mailer/unlock_instructions.#{mail_template_engine}"
     assert_file "app/views/#{scope}/passwords/edit.html.erb"
     assert_file "app/views/#{scope}/passwords/new.html.erb"

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -65,6 +65,15 @@ class RecoverableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should reset reset password token and send new account instructions by email' do
+    user = create_user
+    assert_email_sent do
+      token = user.reset_password_token
+      user.send_new_account_instructions
+      assert_not_equal token, user.reset_password_token
+    end
+  end
+
   test 'should find a user to send instructions by email' do
     user = create_user
     reset_password_user = User.send_reset_password_instructions(email: user.email)


### PR DESCRIPTION
This allows reuse of the forgot password token logic but with an
email template designed for new accounts.

Resolves #3233
