### PR TITLE
Revert "Removes reloading of routes when eager loading ..."

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -10,6 +10,9 @@ module Devise
       Devise.warden_config = config
     end
 
+    # Force routes to be loaded if we are doing any eager load.
+    config.before_eager_load { |app| app.reload_routes! }
+
     initializer "devise.url_helpers" do
       Devise.include_helpers(Devise::Controllers)
     end


### PR DESCRIPTION
Reverts plataformatec/devise#3195, that proved to be create an regression @ https://github.com/plataformatec/devise/pull/3153#issuecomment-57259282. We need to eager load the routes to ensure that the our mappings and helpers are defined before loading the rest of the app. 
