### PR TITLE
Fix no confirmation is allowed.

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -186,6 +186,8 @@ module Devise
         #   confirmation_period_valid?   # will always return true
         #
         def confirmation_period_valid?
+          return false if self.class.allow_unconfirmed_access_for == 0.days
+
           self.class.allow_unconfirmed_access_for.nil? || (confirmation_sent_at && confirmation_sent_at.utc >= self.class.allow_unconfirmed_access_for.ago)
         end
 


### PR DESCRIPTION
when `allow_unconfirmed_access_for` is set to `0.days`
and `confirmation_sent_at` is any day after today (include today)
the `confirmation_sent_at && confirmation_sent_at.utc >=
self.class.allow_unconfirmed_access_for.ago`
will always return true.

This patch check for 0.days case and return false immediately.

fixes #3244