### PR TITLE
allow set_flash_message to set flash.now messages

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -129,8 +129,11 @@ MESSAGE
   end
 
   # Sets the flash message with :key, using I18n. By default you are able
-  # to setup your messages using specific resource scope, and if no one is
-  # found we look to default scope.
+  # to setup your messages using specific resource scope, and if no message is
+  # found we look to the default scope. Set the "now" options key to a true
+  # value to populate the flash.now hash in lieu of the default flash hash (so
+  # the flash message will be available to the current action instead of the
+  # next action).
   # Example (i18n locale file):
   #
   #   en:
@@ -144,7 +147,11 @@ MESSAGE
   # available.
   def set_flash_message(key, kind, options = {})
     message = find_message(kind, options)
-    flash[key] = message if message.present?
+    if options[:now]
+      flash.now[key] = message if message.present?
+    else
+      flash[key] = message if message.present?
+    end
   end
 
   def devise_i18n_options(options)

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -99,6 +99,12 @@ class HelpersTest < ActionController::TestCase
     assert_equal 'non-blank', flash[:notice]
   end
 
+  test 'issues non-blank flash.now messages normally' do
+    I18n.stubs(:t).returns('non-blank')
+    @controller.send :set_flash_message, :notice, :send_instructions, { now: true }
+    assert_equal 'non-blank', flash.now[:notice]
+  end
+
   test 'uses custom i18n options' do
     @controller.stubs(:devise_i18n_options).returns(default: "devise custom options")
     @controller.send :set_flash_message, :notice, :invalid_i18n_messagesend_instructions


### PR DESCRIPTION
This lets you set a flash message into the flash.now hash if the :now key is set in the options hash in the set_flash_message method.
