### PR TITLE
Unable to reset password, due to false error about 'wrong reset_password_token'

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -123,9 +123,7 @@ module Devise
         # containing an error in reset_password_token attribute.
         # Attributes must contain reset_password_token, password and confirmation
         def reset_password_by_token(attributes={})
-          original_token       = attributes[:reset_password_token]
-          reset_password_token = Devise.token_generator.digest(self, :reset_password_token, original_token)
-
+          reset_password_token = attributes[:reset_password_token]
           recoverable = find_or_initialize_with_error_by(:reset_password_token, reset_password_token)
 
           if recoverable.persisted?
@@ -136,7 +134,7 @@ module Devise
             end
           end
 
-          recoverable.reset_password_token = original_token
+          recoverable.reset_password_token = reset_password_token
           recoverable
         end
 


### PR DESCRIPTION
The line former 127:-
reset_password_token = Devise.token_generator.digest(self, :reset_password_token, original_token)

looks like it was counter productive. It sticks user in a deadlock when they try to reset their password.

The link is clicked with the reset token. But when user enters password information they get an error saying invalid token even though token is still valid and exists. I found out that this line which I am requesting to take out, was generating a new token, then using that new token to fetch for the user, which it wouldn't find and therefore the user will not be able to reset their password, even though they have a valid token.

Thanks.