### PR TITLE
Flash message when invalid password reset token is provided.

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -38,6 +38,7 @@ class Devise::PasswordsController < DeviseController
       sign_in(resource_name, resource)
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
+      set_flash_message(:alert, :invalid_token) if is_flashing_format? && resource.errors[:reset_password_token].present?
       respond_with resource
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,7 @@ en:
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      invalid_token: "The password reset link you have been provided is invalid or has already been used. Please request another password reset email."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."


### PR DESCRIPTION
This field is hidden in the form so if for whatever reason the token is invalid, you will be taken back to a form without errors and wonder why your reset failed.