### PR TITLE
Include URI's fragment in `store_location_for`

### DIFF
--- a/lib/devise/controllers/store_location.rb
+++ b/lib/devise/controllers/store_location.rb
@@ -35,7 +35,9 @@ module Devise
         session_key = stored_location_key_for(resource_or_scope)
         uri = parse_uri(location)
         if uri
-          session[session_key] = [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
+          path = [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
+          path = [path, uri.fragment].compact.join('#')
+          session[session_key] = path
         end
       end
 

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -245,6 +245,11 @@ class ControllerAuthenticatableTest < ActionController::TestCase
     assert_equal "/foo?bar=baz", @controller.stored_location_for(:user)
   end
 
+  test 'store location for stores fragments' do
+    @controller.store_location_for(:user, "/foo#bar")
+    assert_equal "/foo#bar", @controller.stored_location_for(:user)
+  end
+
   test 'after sign in path defaults to root path if none by was specified for the given scope' do
     assert_equal root_path, @controller.after_sign_in_path_for(:user)
   end


### PR DESCRIPTION
Hey devise,

`store_location_for` currently ignores the fragment part of the URI, ie:

``` ruby
store_location_for(:user, '/#/course/1')
# => "/"
```

Is this intended? If not, I'd be more than happy to provide a pull-request that changes the behaviour to include the fragment.

Cheers!
