### PR TITLE
Fix link to Michael Hartl's Rails Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You will usually want to write tests for your changes.  To run the test suite, g
 
 If you are building your first Rails application, we recommend you to *not* use Devise. Devise requires a good understanding of the Rails Framework. In such cases, we advise you to start a simple authentication system from scratch, today we have two resources:
 
-* Michael Hartl's online book: http://www.railstutorial.org/book/demo_app#sec-modeling_demo_users
+* Michael Hartl's online book: https://www.railstutorial.org/book/modeling_users
 * Ryan Bates' Railscast: http://railscasts.com/episodes/250-authentication-from-scratch
 
 Once you have solidified your understanding of Rails and authentication mechanisms, we assure you Devise will be very pleasant to work with. :)


### PR DESCRIPTION
Update link to go to authentication chapter of latest edition (3rd) of online book
