### PR TITLE
Update casing of 'OmniAuth' to match that of official OmniAuth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Devise is a flexible authentication solution for Rails based on Warden. It:
 It's composed of 10 modules:
 
 * [Database Authenticatable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/DatabaseAuthenticatable): encrypts and stores a password in the database to validate the authenticity of a user while signing in. The authentication can be done both through POST requests or HTTP Basic Authentication.
-* [Omniauthable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Omniauthable): adds Omniauth (https://github.com/intridea/omniauth) support.
+* [Omniauthable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Omniauthable): adds OmniAuth (https://github.com/intridea/omniauth) support.
 * [Confirmable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Confirmable): sends emails with confirmation instructions and verifies whether an account is already confirmed during sign in.
 * [Recoverable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Recoverable): resets the user password and sends reset instructions.
 * [Registerable](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/Registerable): handles signing up users through a registration process, also allowing them to edit and destroy their account.
@@ -439,15 +439,15 @@ There are two things that are important to keep in mind:
     get :new
     ```
 
-### Omniauth
+### OmniAuth
 
-Devise comes with Omniauth support out of the box to authenticate with other providers. To use it, just specify your omniauth configuration in `config/initializers/devise.rb`:
+Devise comes with OmniAuth support out of the box to authenticate with other providers. To use it, just specify your OmniAuth configuration in `config/initializers/devise.rb`:
 
 ```ruby
 config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 ```
 
-You can read more about Omniauth support in the wiki:
+You can read more about OmniAuth support in the wiki:
 
 * https://github.com/plataformatec/devise/wiki/OmniAuth:-Overview
 

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -246,7 +246,7 @@ module Devise
   mattr_accessor :router_name
   @@router_name = nil
 
-  # Set the omniauth path prefix so it can be overridden when
+  # Set the OmniAuth path prefix so it can be overridden when
   # Devise is used in a mountable engine
   mattr_accessor :omniauth_path_prefix
   @@omniauth_path_prefix = nil
@@ -261,7 +261,7 @@ module Devise
   mattr_reader :mappings
   @@mappings = ActiveSupport::OrderedHash.new
 
-  # Omniauth configurations.
+  # OmniAuth configurations.
   mattr_reader :omniauth_configs
   @@omniauth_configs = ActiveSupport::OrderedHash.new
 
@@ -417,7 +417,7 @@ module Devise
     @@warden_config_blocks << block
   end
 
-  # Specify an omniauth provider.
+  # Specify an OmniAuth provider.
   #
   #   config.omniauth :github, APP_ID, APP_SECRET
   #

--- a/lib/devise/controllers/rememberable.rb
+++ b/lib/devise/controllers/rememberable.rb
@@ -2,7 +2,7 @@ module Devise
   module Controllers
     # A module that may be optionally included in a controller in order
     # to provide remember me behavior. Useful when signing in is done
-    # through a callback, like in Omniauth.
+    # through a callback, like in OmniAuth.
     module Rememberable
       # Return default cookie values retrieved from session options.
       def self.cookie_values

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -402,7 +402,7 @@ module ActionDispatch::Routing
       def devise_omniauth_callback(mapping, controllers) #:nodoc:
         if mapping.fullpath =~ /:[a-zA-Z_]/
           raise <<-ERROR
-Devise does not support scoping omniauth callbacks under a dynamic segment
+Devise does not support scoping OmniAuth callbacks under a dynamic segment
 and you have set #{mapping.fullpath.inspect}. You can work around by passing
 `skip: :omniauth_callbacks` and manually defining the routes. Here is an example:
 

--- a/lib/generators/templates/controllers/omniauth_callbacks_controller.rb
+++ b/lib/generators/templates/controllers/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class <%= @scope_prefix %>OmniauthCallbacksController < Devise::OmniauthCallback
 
   # protected
 
-  # The path used when omniauth fails
+  # The path used when OmniAuth fails
   # def after_omniauth_failure_path_for(scope)
   #   super(scope)
   # end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -257,7 +257,7 @@ Devise.setup do |config|
   # The router that invoked `devise_for`, in the example above, would be:
   # config.router_name = :my_engine
   #
-  # When using omniauth, Devise cannot automatically set Omniauth path,
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -121,7 +121,7 @@ class OmniauthableIntegrationTest < ActionDispatch::IntegrationTest
     assert_contain 'Could not authenticate you from Facebook because "Access denied".'
   end
 
-  test "handles other exceptions from omniauth" do
+  test "handles other exceptions from OmniAuth" do
     OmniAuth.config.mock_auth[:facebook] = :invalid_credentials
 
     visit "/users/sign_in"


### PR DESCRIPTION
This PR updates the casing in documentation, comments, error messages, and test descriptions when referring to the OmniAuth library. Usage as part of code was not changed.

Different styles of capitalization were used throughout the project, so this is meant to provide consistency.
