### PR TITLE
Update password length validation to 72 characters max

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -10,7 +10,7 @@ module Devise
     # Validatable adds the following options to devise_for:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
-    #   * +password_length+: a range expressing password length. Defaults to 8..128.
+    #   * +password_length+: a range expressing password length. Defaults to 8..72.
     #
     module Validatable
       # All validations used by this module.

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -144,7 +144,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 8..72
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -92,10 +92,10 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too short (minimum is 7 characters)', user.errors[:password].join
   end
 
-  test 'should require a password with maximum of 128 characters long' do
-    user = new_user(password: 'x'*129, password_confirmation: 'x'*129)
+  test 'should require a password with maximum of 72 characters long' do
+    user = new_user(password: 'x'*73, password_confirmation: 'x'*73)
     assert user.invalid?
-    assert_equal 'is too long (maximum is 128 characters)', user.errors[:password].join
+    assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
   end
 
   test 'should not require password length when it\'s not changed' do
@@ -109,10 +109,10 @@ class ValidatableTest < ActiveSupport::TestCase
   end
 
   test 'should complain about length even if password is not required' do
-    user = new_user(password: 'x'*129, password_confirmation: 'x'*129)
+    user = new_user(password: 'x'*73, password_confirmation: 'x'*73)
     user.stubs(:password_required?).returns(false)
     assert user.invalid?
-    assert_equal 'is too long (maximum is 128 characters)', user.errors[:password].join
+    assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
   end
 
   test 'should not be included in objects with invalid API' do

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -90,8 +90,8 @@ Devise.setup do |config|
   # config.extend_remember_period = false
 
   # ==> Configuration for :validatable
-  # Range for password length. Default is 8..128.
-  # config.password_length = 8..128
+  # Range for password length. Default is 8..72.
+  # config.password_length = 8..72
 
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i

--- a/test/rails_app/lib/shared_user.rb
+++ b/test/rails_app/lib/shared_user.rb
@@ -4,7 +4,7 @@ module SharedUser
   included do
     devise :database_authenticatable, :confirmable, :lockable, :recoverable,
            :registerable, :rememberable, :timeoutable,
-           :trackable, :validatable, :omniauthable, password_length: 7..128
+           :trackable, :validatable, :omniauthable, password_length: 7..72
 
     attr_accessor :other_key
 


### PR DESCRIPTION
BCrypt has a limit of 72 characters for the password. Anything beyond 72 characters is truncated:

``` ruby
require 'bcrypt'
password = 'a' * 72 
digest = BCrypt::Password.create(password) 
digest == password # => true
digest == password + 'foobar' # => true
digest == 'a' * 128 # => true
```

This commit updates the validation to limit passwords to less than 72 characters, keeping within the limitation.

For similar discussion, please see rails/rails#14591 and rails/rails#15708 where `has_secure_password`'s validations were updated for this same reason.

I should note that I didn't make the change in [`lib/devise.rb`](https://github.com/plataformatec/devise/blob/e54326c19c68f10df2548fcaaab411e93178b279/lib/devise.rb#L126-L128), as I thought that would introduce a backwards-incompatible change.
