### PR TITLE
Use the new build env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,16 @@ services:
 
 sudo: false
 
+cache: bundler
+
 env:
   matrix:
     - DEVISE_ORM=mongoid
     - DEVISE_ORM=active_record
 
 before_install: "rm ${BUNDLE_GEMFILE}.lock"
+
+before_script: "bundle update"
 
 script: "bundle exec rake test"
 


### PR DESCRIPTION
- use the new build env on Travis (sudo: false) (docs coming soon)
  faster vms, more cpu, more ram, faster vm boot time
- remove the custom caching for now as the new setup has a far better network
- add rails-head to the gemfile list as it wasn't there

Caching is generally not recommended for libs like Devise as you want to test against the latest gem versions. Caching will use the min requirements available on the system instead of retrieving the latest.

Since caching does help halve the bundle install time, I have added Travis caching, but also added `bundle update` to a `before_script` step so that the latest gems are downloaded.

On that note, it is also recommended to remove the Gemfile.lock from the repo. For now I have just 'rm'd it before 'bundle install'
