### PR TITLE
Ability to load modules in specific order

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -363,11 +363,7 @@ module Devise
   def self.add_module(module_name, options = {})
     options.assert_valid_keys(:strategy, :model, :controller, :route, :no_input, :insert_at)
     
-    if insert_at = options[:insert_at]
-      ALL.insert insert_at, module_name
-    else
-      ALL << module_name
-    end
+    ALL.insert (options[:insert_at] || -1), module_name
 
     if strategy = options[:strategy]
       strategy = (strategy == true ? module_name : strategy)


### PR DESCRIPTION
The order in which third party modules are loaded when mixed in with standard devise modules (or modules included from other sources) is important.

Example:

``` ruby
# app/models/user.rb
class User < ActiveRecord::Base
  devise :custom_authenticatable, :confirmable
end
```

``` ruby
# custom_authenticatable.rb
module Devise
  module Models
    module CustomAuthenticatable
      def active_for_authentication?
        true
      end 
    end  
  end
end

# lib/devise/models/confirmable.rb
module Devise
  module Models
    module Confirmable
      def active_for_authentication?
        super && (!confirmation_required? || confirmed? || confirmation_period_valid?)
      end
    end
  end
end
```

You should be able to ensure that :confirmable loads after :custom_authenticatable so that `active_for_authentication?` overrides correctly.

Right now Devise automatically adds confirmable, etc in `lib/devise/modules.rb`, and then includes them in the order in which they were added, leaving no way for someone to mix and match modules without manually calling something similar to:

``` ruby
Devise::ALL.delete :confirmable
Devise::ALL << :confirmable
# Or
Devise.add_module :custom_authenticatable
Devise.add_module :confirmable
# Devise::ALL => [etc, :confirmable, :custom_authenticatable, :confirmable]
```
