### PR TITLE
added test to test comparing sent password reset token and generated tok...

### DIFF
--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -189,6 +189,12 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_equal User.with_reset_password_token(raw), user
   end
 
+  test 'should return the same reset password token as generated' do
+    user = create_user
+    raw  = user.send_reset_password_instructions
+    assert_equal raw, user.reset_password_token
+  end
+
   test 'should return nil if a user based on the raw token is not found' do
     assert_equal User.with_reset_password_token('random-token'), nil
   end


### PR DESCRIPTION
1. Add test to ensure the token that is sent is equal to the reset password token generated in database.
