### PR TITLE
Extract attributes generation for trackable

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -16,22 +16,30 @@ module Devise
       end
 
       def update_tracked_fields(request)
-        old_current, new_current = self.current_sign_in_at, Time.now.utc
-        self.last_sign_in_at     = old_current || new_current
-        self.current_sign_in_at  = new_current
-
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
-        self.last_sign_in_ip     = old_current || new_current
-        self.current_sign_in_ip  = new_current
-
-        self.sign_in_count ||= 0
-        self.sign_in_count += 1
+        assign_attributes(tracked_attributes(request))
       end
 
       def update_tracked_fields!(request)
         update_tracked_fields(request)
         save(validate: false) or raise "Devise trackable could not save #{inspect}." \
           "Please make sure a model using trackable can be saved at sign in."
+      end
+
+      def tracked_attributes(request)
+        attrs = {}
+
+        old_current, new_current = self.current_sign_in_at, Time.now.utc
+        attrs[:last_sign_in_at]     = old_current || new_current
+        attrs[:current_sign_in_at]  = new_current
+
+        old_current, new_current = self.current_sign_in_ip, request.remote_ip
+        attrs[:last_sign_in_ip]     = old_current || new_current
+        attrs[:current_sign_in_ip]  = new_current
+
+        attrs[:sign_in_count] = self.sign_in_count || 0
+        attrs[:sign_in_count] += 1
+
+        attrs
       end
     end
   end


### PR DESCRIPTION
This enabled me to override the update_tracked_fields! method to background the updating of these
attributes. Using something like:

``` ruby
# app/models/user.rb
def update_tracked_fields!(request)
  Resque.enqueue(Jobs::TrackUserSignIn, id, tracked_attributes(request))
end
```

``` ruby
# app/models/jobs/track_user_sign_in.rb
module Jobs
  class TrackUserSignIn
    @queue = :low

    def self.perform(user_id, attributes)
      user = User.find(user_id)
      user.update_attributes! attributes
    end
  end
end
```
