### PR TITLE
If email is case-insensitive, uniqueness should be validated accordingly.

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -27,7 +27,7 @@ module Devise
 
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
-          validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+          validates_uniqueness_of :email, allow_blank: true, if: :email_changed?, case_sensitive: !case_insensitive_keys.include?(:email)
           validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
 
           validates_presence_of     :password, if: :password_required?
@@ -59,7 +59,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(self, :email_regexp, :password_length, :case_insensitive_keys)
       end
     end
   end


### PR DESCRIPTION
The default configuration for Devise is to treat email addresses as case-insensitive. However, when their uniqueness is validated, they are treated case-sensitively. This could lead to confusion.

This patch checks the "case_insensitive_keys" option when creating the validation.
