### PR TITLE
Suppress test.rb configuration warning for Rails 4.2.

### DIFF
--- a/test/rails_app/config/environments/test.rb
+++ b/test/rails_app/config/environments/test.rb
@@ -12,8 +12,13 @@ RailsApp::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets = true
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  if Rails.version >= "4.2.0"
+    config.serve_static_files = true
+  else
+    config.serve_static_assets = true
+  end
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
Suppress following warning due to configuration changes.

```
DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed
to `config.serve_static_files` to clarify its role (it merely enables serving everything
in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets`
alias will be removed in Rails 5.0. Please migrate your configuration files accordingly.
(called from block in <top (required)> at
/Users/Juan/dev/devise/test/rails_app/config/environments/test.rb:20)
```
