### PR TITLE
Added devise.omniauth initializer explicit position requirements.

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -17,7 +17,10 @@ module Devise
       Devise.include_helpers(Devise::Controllers)
     end
 
-    initializer "devise.omniauth" do |app|
+    initializer "devise.omniauth",
+      after: :load_config_initializers,
+      before: :build_middleware_stack do |app|
+
       Devise.omniauth_configs.each do |provider, config|
         app.middleware.use config.strategy_class, *config.args do |strategy|
           config.strategy = strategy

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class DeviseTest < ActiveSupport::TestCase
+  test 'correct initializer position' do
+    initializer = Devise::Engine.initializers.detect {|i| i.name == 'devise.omniauth' }
+    assert_equal  :load_config_initializers, initializer.after
+    assert_equal  :build_middleware_stack, initializer.before
+  end
+end


### PR DESCRIPTION
It is obvious that this initializer should be executed before Rails build_middleware_stack as Omniauth is build on middleware.
Also it is obvious that we need that initializer to be executed after all config/initializers/* files (that is where devise.rb usually is).