### PR TITLE
Update find_message to accept scope

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -167,7 +167,7 @@ MESSAGE
 
   # Get message for given
   def find_message(kind, options = {})
-    options[:scope] = "devise.#{controller_name}" unless options[:scope]
+    options[:scope] ||= "devise.#{controller_name}"
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
     options = devise_i18n_options(options)

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -167,7 +167,7 @@ MESSAGE
 
   # Get message for given
   def find_message(kind, options = {})
-    options[:scope] = "devise.#{controller_name}"
+    options[:scope] = "devise.#{controller_name}" unless options[:scope]
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
     options = devise_i18n_options(options)


### PR DESCRIPTION
This should still keep the devise lookup in the case that a customed scope is not passed as option, but if instead the custom scope is passed, then the find_message method will use it.

This is kind of useful, if i don't want overwrite the devise locale, and use different locale files, but keeping still the fallback of my devise locale.