### PR TITLE
Use Devise translations when inheriting from core controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * `RegistrationsController#new` and `SessionsController#new` now yields the
     current resource (by @mtarnovan, @deivid-rodriguez)
   * Password length validation is now limited to 72 characters for newer apps (by @lleger)
+  * Controllers inheriting from any Devise core controller will now use appropriate translations.
+    The i18n scope can be overridden in `translation_scope`.
 
 ### 3.4.1 - 2014-10-29
 

--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -44,4 +44,8 @@ class Devise::ConfirmationsController < DeviseController
         new_session_path(resource_name)
       end
     end
+
+    def translation_scope
+      'devise.confirmations'
+    end
 end

--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -27,4 +27,8 @@ class Devise::OmniauthCallbacksController < DeviseController
   def after_omniauth_failure_path_for(scope)
     new_session_path(scope)
   end
+
+  def translation_scope
+    'devise.omniauth_callbacks'
+  end
 end

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -68,4 +68,8 @@ class Devise::PasswordsController < DeviseController
         resource.respond_to?(:unlock_strategy_enabled?) &&
         resource.unlock_strategy_enabled?(:email)
     end
+
+    def translation_scope
+      'devise.passwords'
+    end
 end

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -140,4 +140,8 @@ class Devise::RegistrationsController < DeviseController
   def account_update_params
     devise_parameter_sanitizer.sanitize(:account_update)
   end
+
+  def translation_scope
+    'devise.registrations'
+  end
 end

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -46,6 +46,10 @@ class Devise::SessionsController < DeviseController
     { scope: resource_name, recall: "#{controller_path}#new" }
   end
 
+  def translation_scope
+    'devise.sessions'
+  end
+
   private
 
   # Check if there is no signed in user before doing the sign out.

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -43,4 +43,7 @@ class Devise::UnlocksController < DeviseController
       new_session_path(resource)  if is_navigational_format?
     end
 
+    def translation_scope
+      'devise.unlocks'
+    end
 end

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -167,11 +167,18 @@ MESSAGE
 
   # Get message for given
   def find_message(kind, options = {})
-    options[:scope] ||= "devise.#{controller_name}"
+    options[:scope] ||= translation_scope
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
     options = devise_i18n_options(options)
     I18n.t("#{options[:resource_name]}.#{kind}", options)
+  end
+
+  # Controllers inheriting DeviseController are advised to override this
+  # method so that other controllers inheriting from them would use
+  # existing translations.
+  def translation_scope
+    "devise.#{controller_name}"
   end
 
   def clean_up_passwords(object)

--- a/test/controllers/inherited_controller_i18n_messages_test.rb
+++ b/test/controllers/inherited_controller_i18n_messages_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class SessionsInheritedController < Devise::SessionsController
+  def test_i18n_scope
+    set_flash_message(:notice, :signed_in)
+  end
+end
+
+class AnotherInheritedController < SessionsInheritedController
+  protected
+
+  def translation_scope
+    'another'
+  end
+end
+
+class InheritedControllerTest < ActionController::TestCase
+  tests SessionsInheritedController
+
+  def setup
+    @mock_warden = OpenStruct.new
+    @controller.request.env['warden'] = @mock_warden
+    @controller.request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  test 'I18n scope is inherited from Devise::Sessions' do
+    I18n.expects(:t).with do |message, options|
+      message == 'user.signed_in' &&
+        options[:scope] == 'devise.sessions'
+    end
+    @controller.test_i18n_scope
+  end
+end
+
+class AnotherInheritedControllerTest < ActionController::TestCase
+  tests AnotherInheritedController
+
+  def setup
+    @mock_warden = OpenStruct.new
+    @controller.request.env['warden'] = @mock_warden
+    @controller.request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  test 'I18n scope is overridden' do
+    I18n.expects(:t).with do |message, options|
+      message == 'user.signed_in' &&
+        options[:scope] == 'another'
+    end
+    @controller.test_i18n_scope
+  end
+end


### PR DESCRIPTION
closes #3367

I will now start working in the tests but you can already review the changes. I've tested it with my application manually already.