### PR TITLE
Revert "Better error message in case a trackable module can't be saved."

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -30,8 +30,7 @@ module Devise
 
       def update_tracked_fields!(request)
         update_tracked_fields(request)
-        save(validate: false) or raise "Devise trackable could not save #{inspect}." \
-          "Please make sure a model using trackable can be saved at sign in."
+        save(validate: false)
       end
     end
   end


### PR DESCRIPTION
This reverts commit 43d0715238e762e89cc465a441dd1bdffc0529e3.

save() returns false only when validations failed. In this case, validations are not performed. Therefore save() may never return a falsy value. If save() fails, the appropriate exception is raised.

With certain ORMs, such as NoBrainer, save() never returns true/false, but always raise an exception. This commit lift the incompatiblity.

Note: Nowhere in the current codebase, `save(validate: false)` is checked.

Fixes https://github.com/nviennot/devise-nobrainer/issues/2