### PR TITLE
get rid of config.serve_static_assets deprecation warning from production.rb

### DIFF
--- a/test/rails_app/config/environments/production.rb
+++ b/test/rails_app/config/environments/production.rb
@@ -20,7 +20,11 @@ RailsApp::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  if Rails.version >= "4.2.0"
+    config.serve_static_files = false
+  else
+    config.serve_static_assets = false
+  end
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor  = :uglifier


### PR DESCRIPTION
apply the same change to production.rb that was put into test.rb to get rid of the deprecation warning related to the config.serve_static_assets -> config.serve_static_files in Rails 4.2.0