### PR TITLE
Keep used confirmation tokens for more user friendly error message (issue #3429)

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -64,7 +64,6 @@ module Devise
             return false
           end
 
-          self.confirmation_token = nil
           self.confirmed_at = Time.now.utc
 
           saved = if self.class.reconfirmable && unconfirmed_email.present?


### PR DESCRIPTION
Removes line setting token to nil as mentioned in https://github.com/plataformatec/devise/issues/3429.

By saving it, a message (self.errors.add(:email, :already_confirmed)) can be shown to the user. If set to nil, the potentially misleading message "Confirmation token is invalid" is given. In such a case, if the user does not log in, they may never know that their account's email has already been confirmed.

Test cases: 1 added (checks for :already_confirmed error), 1 removed (checks token set to nil), 3 changed.

