### PR TITLE
Only add pepper if needed

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -4,7 +4,10 @@ require 'bcrypt'
 module Devise
   # Digests the password using bcrypt.
   def self.bcrypt(klass, password)
-    ::BCrypt::Password.create("#{password}#{klass.pepper}", cost: klass.stretches).to_s
+    if klass.pepper.present?
+      password = "#{password}#{klass.pepper}"
+    end
+    ::BCrypt::Password.create(password, cost: klass.stretches).to_s
   end
 
   module Models
@@ -46,7 +49,10 @@ module Devise
       def valid_password?(password)
         return false if encrypted_password.blank?
         bcrypt   = ::BCrypt::Password.new(encrypted_password)
-        password = ::BCrypt::Engine.hash_secret("#{password}#{self.class.pepper}", bcrypt.salt)
+        if self.class.pepper.present?
+          password = "#{password}#{self.class.pepper}"
+        end
+        password = ::BCrypt::Engine.hash_secret(password, bcrypt.salt)
         Devise.secure_compare(password, encrypted_password)
       end
 


### PR DESCRIPTION
Due to bug in Ruby 2.2.0; The bug has been acknowledged and fixed in trunk (https://github.com/ruby/ruby/commit/622f3f14b6928ee4fe3afa96db0250eb9da32e7a)

When password comes in FormEncoded the result of `gsub` breaks when peppered with `nil`.
This only adds pepper if defined on the model and works around this bug.

This fixes #3415

To reproduce: https://gist.github.com/davestevens/a9187de713a32cb005b1