### PR TITLE
Added validation check to registrations#create

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -14,22 +14,24 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save
-    yield resource if block_given?
-    if resource.persisted?
-      if resource.active_for_authentication?
-        set_flash_message :notice, :signed_up if is_flashing_format?
-        sign_up(resource_name, resource)
-        respond_with resource, location: after_sign_up_path_for(resource)
+    if resource.valid?
+      resource.save
+      yield resource if block_given?
+      if resource.persisted?
+        if resource.active_for_authentication?
+          set_flash_message :notice, :signed_up if is_flashing_format?
+          sign_up(resource_name, resource)
+          respond_with resource, location: after_sign_up_path_for(resource)
+        else
+          set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
+          expire_data_after_sign_in!
+          respond_with resource, location: after_inactive_sign_up_path_for(resource)
+        end
       else
-        set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
-        expire_data_after_sign_in!
-        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+        clean_up_passwords resource
+        set_minimum_password_length
+        respond_with resource
       end
-    else
-      clean_up_passwords resource
-      set_minimum_password_length
-      respond_with resource
     end
   end
 


### PR DESCRIPTION
I have added a validation check before saving the resource, because in my applications I noticed that there are huge ID gapes that happens regularly because some users not passing the validation checks and the save is called in which it increments the ID but the validation failure rolls back the transaction leaving the incremented ID. Please review that scenario and let me know if my PR can be merged.