### PR TITLE
removing deprecation warning from rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Devise allows you to set up as many Devise models as you want. If you want to ha
 create_table :admins do |t|
   t.string :email
   t.string :encrypted_password
-  t.timestamps, null: false
+  t.timestamps null: false
 end
 
 # Inside your Admin model

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Devise allows you to set up as many Devise models as you want. If you want to ha
 create_table :admins do |t|
   t.string :email
   t.string :encrypted_password
-  t.timestamps
+  t.timestamps, null: false
 end
 
 # Inside your Admin model

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -7,7 +7,7 @@ class DeviseCreate<%= table_name.camelize %> < ActiveRecord::Migration
       t.<%= attribute.type %> :<%= attribute.name %>
 <% end -%>
 
-      t.timestamps
+      t.timestamps, null: false
     end
 
     add_index :<%= table_name %>, :email,                unique: true

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -7,7 +7,7 @@ class DeviseCreate<%= table_name.camelize %> < ActiveRecord::Migration
       t.<%= attribute.type %> :<%= attribute.name %>
 <% end -%>
 
-      t.timestamps, null: false
+      t.timestamps null: false
     end
 
     add_index :<%= table_name %>, :email,                unique: true

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -8,7 +8,7 @@ class AddDeviseTo<%= table_name.camelize %> < ActiveRecord::Migration
 <% end -%>
 
       # Uncomment below if timestamps were not included in your original model.
-      # t.timestamps, null: false
+      # t.timestamps null: false
     end
 
     add_index :<%= table_name %>, :email,                unique: true

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -8,7 +8,7 @@ class AddDeviseTo<%= table_name.camelize %> < ActiveRecord::Migration
 <% end -%>
 
       # Uncomment below if timestamps were not included in your original model.
-      # t.timestamps
+      # t.timestamps, null: false
     end
 
     add_index :<%= table_name %>, :email,                unique: true


### PR DESCRIPTION
removing warning from gererated migrations

```
DEPRECATION WARNING: `#timestamp` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing. (called from block in change at /Users/luciano/Dropbox/projects/Luciano-Sousa/db/migrate/20150203012635_devise_create_users.rb:36)

```