### PR TITLE
Add comments re: secret_key on Rails 4+ apps

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -4,6 +4,8 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`
+  # by default. You can change it below and use your own secret key.
 <% if rails_4? -%>
   # config.secret_key = '<%= SecureRandom.hex(64) %>'
 <% else -%>


### PR DESCRIPTION
Adding a couple comments in initializer that explain that Devise will use `secret_key_base` on Rails 4+ applications as its `secret_key` by default.