### PR TITLE
Fixed bug in config.secret_key code in devise.rb

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -6,11 +6,11 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`
   # by default. You can change it below and use your own secret key.
-<% if rails_4? -%>
-  # config.secret_key = '<%= SecureRandom.hex(64) %>'
-<% else -%>
-  config.secret_key = '<%= SecureRandom.hex(64) %>'
-<% end -%>
+  if Rails::VERSION::MAJOR == 4
+    # config.secret_key = '<%= SecureRandom.hex(64) %>'
+  else
+    config.secret_key = '<%= SecureRandom.hex(64) %>'
+  end
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
The <% tags are not needed, and would cause a bug:

/.rvm/gems/ruby-2.0.0-p247/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load': /Workspace/projectname/config/initializers/devise.rb:9: syntax error, unexpected '<' (SyntaxError)
<% if rails_4? -%>
 ^
/projectname/config/initializers/devise.rb:9: syntax error, unexpected tFID, expecting keyword_end
<% if rails_4? -%>
              ^

Also, rails_4 is in the  `devise/lib/generators/devise/install_generator.rb` file, which is not automatically included in a project when using the latest devise gem. So people will probably not have this file. Therefore it's better to use `Rails::VERSION::MAJOR == 4` directly instead.

PS: I'm on rails 3.2.13 and devise 3.4.1.