### PR TITLE
workaround for mountable Engines with Rails 4.2

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -111,7 +111,10 @@ module Devise
       opts[:format] = request_format unless skip_format?
 
       config = Rails.application.config
-      opts[:script_name] = (config.relative_url_root if config.respond_to?(:relative_url_root))
+
+      if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
+        opts[:script_name] = config.relative_url_root
+      end
 
       context = send(Devise.available_router_name)
 


### PR DESCRIPTION
By Using devise on mountable Engines with Rails 4.2, the scope_url method from FailureApp will return a wrong url/path. Concrete in this line: https://github.com/plataformatec/devise/blob/a93edc72fd9f6cc5839dd74107b215a81c16dc37/lib/devise/failure_app.rb#L119

By setting the script_name option to nil, it overrides the engine's prefix set on the routes.rb from the main_app. Example:

````ruby
Rails.application.routes.draw do
  mount Admin::Engine, at: 'admin'
end
`````

However until Rails 4.1 the returned path was correct. After this commit: https://github.com/rails/rails/commit/33d6e3be623d4dbcec077e62699272cbdcd23f37 by overriding the script_name option (it should be the engine_name), action_dispatch returns the path without the engine prefix and this ist wrong

In FailureApp this condition is always "true", although the option is not set:
**Rails.application.config.respond_to?(:relative_url_root))** # true
````ruby
# (...)
def scope_url
 # (...)
 opts[:script_name] = (config.relative_url_root if config.respond_to?(:relative_url_root))
 #(...)
end
````
