### PR TITLE
Extracted route to separate method to be able to override in child class

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -105,9 +105,13 @@ module Devise
       end
     end
 
+    def route(scope)
+      :"new_#{scope}_session_url"
+    end
+
     def scope_url
       opts  = {}
-      route = :"new_#{scope}_session_url"
+      route = route(scope)
       opts[:format] = request_format unless skip_format?
 
       config = Rails.application.config


### PR DESCRIPTION
I have an app which uses `devise` and `activeadmin` (which uses `devise` too).

I needed to customize `route` depending on the scope - redirecting to `new_user_registration_url` when user accesses the app itself and redirecting to `new_admin_user_session` when accessing admin panel.

Without this change it was even impossible to access login page of admin panel (even having `config.skip_before_filter :authenticate_user!` in `activeadmin` initializer).