### PR TITLE
Fix potential security leak in email reconfirmation flow

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email, required: true, readonly: true, input_html: { value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) } %> 
   </div>
 
   <div class="actions">


### PR DESCRIPTION
Ref. bug/issue: https://github.com/plataformatec/devise/issues/3457

If the user does not click the confirmation link within the confirm_within time period, he is taken to a resend confirmation page. On that page, actually the old email address is shown, and not the new one.

It is a potential security risk, since it will leak the user's old email address to any new user that might have gotten the confirmation email when the original user was trying to change his email (and did a typo).

`:autofocus` removed, and `:readonly` added, since the user shouldn't be able to change the confirmation email address, when asking for a new confirmation email. Allowing the user to change the email address is a another potential security risk:
- A malicious user getting hold of an old confirmation link could change the email to his own, and resend confirmation instructions to that instead.