### PR TITLE
allow Devise::Models::Authenticatable to be loaded before Rails

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -1,3 +1,4 @@
+require 'active_model/version'
 require 'devise/hooks/activatable'
 require 'devise/hooks/csrf_cleaner'
 
@@ -97,7 +98,7 @@ module Devise
 
       array = %w(serializable_hash)
       # to_xml does not call serializable_hash on 3.1
-      array << "to_xml" if Rails::VERSION::STRING[0,3] == "3.1"
+      array << "to_xml" if ActiveModel::VERSION::STRING[0,3] == "3.1"
 
       array.each do |method|
         class_eval <<-RUBY, __FILE__, __LINE__


### PR DESCRIPTION
I am using some Devise modules in a Sinatra app.  Because Devise::Models::Authenticatable expects Rails to be defined, I need to add the following hack:

    require 'active_model'
    module Rails
      VERSION ||= ActiveModel::VERSION # Needed in order to load devise/authenticatable
    end

However, while this solves the immediate problem of making it possible to `include Devise::Models::Authenticatable`, it creates a new set of problems--other gems ([annotate](https://github.com/ctran/annotate_models/blob/v2.6.5/lib/annotate.rb#L130) and recent versions of [paperclip](https://github.com/thoughtbot/paperclip/issues/1739), [delayed_job](https://github.com/collectiveidea/delayed_job/pull/634) and [ActiveRecord](https://github.com/rails/rails/blob/v4.2.0/activerecord/lib/active_record/connection_handling.rb#L3)) use `defined?(Rails)` to determine whether some component of Rails is loaded.

Since the Rails version is being checked to determine whether `serializable_hash` is defined, it would be more appropriate to check the version of ActiveModel anyway, since that is where `serializable_hash` lives.

