### PR TITLE
remove use of hide_action in favor of protected

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -6,11 +6,12 @@ class DeviseController < Devise.parent_controller.constantize
 
   helpers = %w(resource scope_name resource_name signed_in_resource
                resource_class resource_params devise_mapping)
-  hide_action(*helpers)
   helper_method(*helpers)
 
   prepend_before_filter :assert_is_devise_resource!
   respond_to :html if mimes_for_respond_to.empty?
+
+  protected
 
   # Gets the actual resource stored in the instance variable
   def resource
@@ -38,6 +39,7 @@ class DeviseController < Devise.parent_controller.constantize
     @devise_mapping ||= request.env["devise.mapping"]
   end
 
+
   # Override prefixes to consider the scoped view.
   # Notice we need to check for the request due to a bug in
   # Action Controller tests that forces _prefixes to be
@@ -50,9 +52,6 @@ class DeviseController < Devise.parent_controller.constantize
     end
   end
 
-  hide_action :_prefixes
-
-  protected
 
   # Checks whether it's a devise mapped resource or not.
   def assert_is_devise_resource! #:nodoc:

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -13,16 +13,16 @@ class HelpersTest < ActionController::TestCase
   end
 
   test 'get resource name from env' do
-    assert_equal :user, @controller.resource_name
+    assert_equal :user, @controller.send(:resource_name)
   end
 
   test 'get resource class from env' do
-    assert_equal User, @controller.resource_class
+    assert_equal User, @controller.send(:resource_class)
   end
 
   test 'get resource instance variable from env' do
     @controller.instance_variable_set(:@user, user = User.new)
-    assert_equal user, @controller.resource
+    assert_equal user, @controller.send(:resource)
   end
 
   test 'set resource instance variable from env' do
@@ -80,7 +80,7 @@ class HelpersTest < ActionController::TestCase
 
   test 'signed in resource returns signed in resource for current scope' do
     @mock_warden.expects(:authenticate).with(scope: :user).returns(User.new)
-    assert_kind_of User, @controller.signed_in_resource
+    assert_kind_of User, @controller.send(:signed_in_resource)
   end
 
   test 'is a devise controller' do


### PR DESCRIPTION
Rails 5 will [not have `hide_action` any longer](https://github.com/rails/rails/pull/18371/files), as the Rails convention is to not expose private or protected methods as actions, thus obviating the need for `hide_action`.

Presumably, there is code inheriting from `DeviseController` that is calling these helpers, so they cannot be private, so `protected` seems to be the only way to get Devise working with Rails 5.  At least to me :)

I also considered back-porting `hide_action` into this gem, but that felt like the wrong way to go.