### PR TITLE
remove deprecated use of prepend_before_filter

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Devise::OmniauthCallbacksController < DeviseController
-  prepend_before_filter { request.env["devise.skip_timeout"] = true }
+  prepend_before_action { request.env["devise.skip_timeout"] = true }
 
   def passthru
     render status: 404, text: "Not found. Authentication passthru."

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -1,5 +1,5 @@
 class Devise::PasswordsController < DeviseController
-  prepend_before_filter :require_no_authentication
+  prepend_before_action :require_no_authentication
   # Render the #edit only if coming from a reset password email link
   append_before_filter :assert_reset_token_passed, only: :edit
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -1,6 +1,6 @@
 class Devise::RegistrationsController < DeviseController
-  prepend_before_filter :require_no_authentication, only: [ :new, :create, :cancel ]
-  prepend_before_filter :authenticate_scope!, only: [:edit, :update, :destroy]
+  prepend_before_action :require_no_authentication, only: [ :new, :create, :cancel ]
+  prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy]
 
   # GET /resource/sign_up
   def new

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,8 +1,8 @@
 class Devise::SessionsController < DeviseController
-  prepend_before_filter :require_no_authentication, only: [ :new, :create ]
-  prepend_before_filter :allow_params_authentication!, only: :create
-  prepend_before_filter :verify_signed_out_user, only: :destroy
-  prepend_before_filter only: [ :create, :destroy ] { request.env["devise.skip_timeout"] = true }
+  prepend_before_action :require_no_authentication, only: [ :new, :create ]
+  prepend_before_action :allow_params_authentication!, only: :create
+  prepend_before_action :verify_signed_out_user, only: :destroy
+  prepend_before_action only: [ :create, :destroy ] { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -1,5 +1,5 @@
 class Devise::UnlocksController < DeviseController
-  prepend_before_filter :require_no_authentication
+  prepend_before_action :require_no_authentication
 
   # GET /resource/unlock/new
   def new

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -8,7 +8,7 @@ class DeviseController < Devise.parent_controller.constantize
                resource_class resource_params devise_mapping)
   helper_method(*helpers)
 
-  prepend_before_filter :assert_is_devise_resource!
+  prepend_before_action :assert_is_devise_resource!
   respond_to :html if mimes_for_respond_to.empty?
 
   protected

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  prepend_before_filter :current_user, only: :exhibit
+  prepend_before_action :current_user, only: :exhibit
   before_filter :authenticate_user!, except: [:accept, :exhibit]
   respond_to :html, :xml
 


### PR DESCRIPTION
replace all `prepend_before_filter`s with `prepend_before_action`, as `prepend_before_filter` is deprecated in Rails 5 and will be removed in Rails 5.1.

I believe this will make this gem require Rails 4.  If we want this to be compatible with versions of Rails before `prepend_before_action` was added, what is the best way to do that?  Check `Rails.version`?