### PR TITLE
Valid password

### DIFF
--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -108,7 +108,10 @@ module Devise
         params_auth_hash.is_a?(Hash)
       end
 
-      # Check if password is present.
+      # Note: unlike `Model.valid_password?`, this method does not actually
+      # ensure that the password in the params matches the password stored in
+      # the database. It only checks if the password is *present*. Do not rely
+      # on this method for validating that a given password is correct.
       def valid_password?
         password.present?
       end

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -5,7 +5,7 @@ module Devise
     # Default strategy for signing in a user, based on their email and password in the database.
     class DatabaseAuthenticatable < Authenticatable
       def authenticate!
-        resource  = valid_password? && mapping.to.find_for_database_authentication(authentication_hash)
+        resource  = password.present? && mapping.to.find_for_database_authentication(authentication_hash)
         encrypted = false
 
         if validate(resource){ encrypted = true; resource.valid_password?(password) }


### PR DESCRIPTION
In order to be more clear about the expectations of for authenticating, we use `password.present?` so there is no confusion about the role of the `valid_password?` method.

Also, this adds some documentation to the `valid_password?` method clarify its functionality.

More info: #3519