### PR TITLE
Use the currently logged-in resource if available

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -1,7 +1,7 @@
 class Devise::ConfirmationsController < DeviseController
   # GET /resource/confirmation/new
   def new
-    self.resource = resource_class.new
+    self.resource = send(:"current_#{resource_name}") || resource_class.new
   end
 
   # POST /resource/confirmation


### PR DESCRIPTION
When displaying the new confirmation form, if the user is already logged-in and is still in the confirmation time window, why not keeping the resource instead of resetting it to a blank one ?

I've ran the test suite before and after and I didn't break anything.
**But** I don't know devise enough to know how to add a good test for that.

Maybe we should decide if this is a good idea, then figure out how to properly test this.