### PR TITLE
Use router_name from scope if available

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -120,7 +120,8 @@ module Devise
         opts[:script_name] = config.relative_url_root
       end
 
-      context = send(Devise.available_router_name)
+      router_name = Devise.mappings[scope].router_name || Devise.available_router_name
+      context = send(router_name)
 
       if context.respond_to?(route)
         context.send(route, opts)


### PR DESCRIPTION
`Devise.available_router_name` currently returns either
`Devise.router_name` or `:main_app`. As such, any redirecting is done
within either of those contexts. Which leads to undesirable redirects
for scopes that reside in an `isolate_namespace` mounted engine.

This commit makes it possible for FailureApp’s redirect behavior to be
performed in the context of the `router_name` given to `devise_for`.

Test case added to cover undesirable behavior. Without change to
`lib/devise/failure_app.rb`, test case throws exception.