### PR TITLE
Don't error if resource doesn't need confirming

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -201,7 +201,7 @@ module Devise
         #   confirmation_period_expired?  # will always return false
         #
         def confirmation_period_expired?
-          self.class.confirm_within && (Time.now > self.confirmation_sent_at + self.class.confirm_within)
+          self.class.confirm_within && self.confirmation_sent_at && (Time.now > self.confirmation_sent_at + self.class.confirm_within)
         end
 
         # Checks whether the record requires any confirmation.


### PR DESCRIPTION
I've overridden #confirmation_required? in my application so that only certain classes of users require it, and as a result resetting passwords has broken. This small tweak fixes it.