### PR TITLE
Increase default stretches to 12

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -92,15 +92,15 @@ Devise.setup do |config|
   # config.clean_up_csrf_token_on_authentication = true
 
   # ==> Configuration for :database_authenticatable
-  # For bcrypt, this is the cost for hashing the password and defaults to 10. If
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
   # using other encryptors, it sets how many times you want the password re-encrypted.
   #
   # Limiting the stretches to just one in testing will increase the performance of
   # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
-  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # a value less than 12 in other environments. Note that, for bcrypt (the default
   # encryptor), the cost increases exponentially with the number of stretches (e.g.
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  config.stretches = Rails.env.test? ? 1 : 10
+  config.stretches = Rails.env.test? ? 1 : 12
 
   # Setup a pepper to generate the encrypted password.
   # config.pepper = '<%= SecureRandom.hex(64) %>'


### PR DESCRIPTION
The current default number of stretches for devise should probably be increased from 10 to at least 12. While 10 is still the default in many bcrypt libraries, it is no longer slow enough on modern CPUs to provide good protection against brute forcing. As an example, a factor of 12 still only takes a quarter of a second on a several year old laptop:

```
Benchmark.measure do
  BCrypt::Password.create('JGQuufAzwRtxgA8Ph7eqJYgHVJGQ6s4oeLZ7txjj', cost: 12)  
end 
```

Even increasing it to 14 only takes a bit over a second on the same 2.5 year old laptop.

This has been getting some attention recently with the publishing of this post http://chargen.matasano.com/chargen/2015/3/26/enough-with-the-salts-updates-on-secure-password-schemes.html

It should also be noted that this value is stored in the bcrypt digest, and therefore can be updated without breaking any previously computed digests.