### PR TITLE
Added missing require_no_authentication filter in ConfirmationsController

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -1,4 +1,6 @@
 class Devise::ConfirmationsController < DeviseController
+  prepend_before_filter :require_no_authentication
+
   # GET /resource/confirmation/new
   def new
     self.resource = resource_class.new


### PR DESCRIPTION
Hi guys!

I noticed that authenticated user still has a possibility to access confirmations module. :worried:
Should it really be the case? I mean, authenticated user cannot access any other module, e.g. unlocks, passwords.

Here's a missing filter applied