### PR TITLE
Add a replacement for the last character of a confirmation token.

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -466,7 +466,7 @@ module Devise
 
   # Generate a friendly string randomly to be used as token.
   def self.friendly_token
-    SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz')
+    SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz').last.tr('-', '4')
   end
 
   # constant-time comparison algorithm to prevent timing attacks

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -466,7 +466,8 @@ module Devise
 
   # Generate a friendly string randomly to be used as token.
   def self.friendly_token
-    SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz').last.tr('-', '4')
+    token = SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz')
+    (token.last == '-') ? token.chop + '4' : token
   end
 
   # constant-time comparison algorithm to prevent timing attacks

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -466,8 +466,7 @@ module Devise
 
   # Generate a friendly string randomly to be used as token.
   def self.friendly_token
-    token = SecureRandom.urlsafe_base64(15).tr('lIO0', 'sxyz')
-    (token.last == '-') ? token.chop + '4' : token
+    token = SecureRandom.urlsafe_base64(15).tr('lIO0-', 'sxyze')
   end
 
   # constant-time comparison algorithm to prevent timing attacks


### PR DESCRIPTION
A user could not activate his account through confirmable in Devise 3.4.1. He sent me the email and I saw that the URL was probably not recognized by his email client. The hyphen as a last character is not interpreted as belonging to the URL (see image). Therefore, the code was incompletely transmitted to the browser.

I know that this is very, very, very, unlikely to be happen, but I don't want that users resign only because they are not able to confirm their account. (Of course, they could demand a new token, but who will do that..?) So, I simply made a patch which makes sure that the last character of the token is definitely not a hyphen.

This should be sufficient, because the other characters which urlsafe_base64 can generate are correctly detected (by Thunderbird).

![bildschirmfoto 2015-04-17 um 18 10 42](https://cloud.githubusercontent.com/assets/2157768/7205973/7c548970-e52d-11e4-9c94-269b72f1a843.png)
