### PR TITLE
improve error message when using omniauth callbacks under a dynamic segment

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -414,7 +414,7 @@ and you have set #{mapping.fullpath.inspect}. You can work around by passing
 
     match "/users/auth/:action/callback",
       constraints: { action: /google|facebook/ },
-      to: "devise/omniauth_callbacks",
+      to: "devise/omniauth_callbacks#:action",
       as: :omniauth_callback,
       via: [:get, :post]
 ERROR


### PR DESCRIPTION
Documentation only update - Rails 4.2 deprecates specifying controller without an action as 'to' parameter in routes. I just updated the docs to suggest the same thing that code below does. Please see:  #3560