### PR TITLE
Allow save() to be overridden by ORM adapters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   specs:
     devise (3.4.1)
       bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
+      orm_adapter (~> 0.6)
       railties (>= 3.2.6, < 5)
       responders
       thread_safe (~> 0.1)
@@ -113,7 +113,7 @@ GEM
       rack-openid (~> 1.3.1)
     optionable (0.2.0)
     origin (2.1.1)
-    orm_adapter (0.5.0)
+    orm_adapter (0.6.0)
     rack (1.6.0)
     rack-openid (1.3.1)
       rack (>= 1.1.0)

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -14,7 +14,7 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save
+    resource_class.to_adapter.save(resource)
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency("warden", "~> 1.2.3")
-  s.add_dependency("orm_adapter", "~> 0.1")
+  s.add_dependency("orm_adapter", "~> 0.6")
   s.add_dependency("bcrypt", "~> 3.0")
   s.add_dependency("thread_safe", "~> 0.1")
   s.add_dependency("railties", ">= 3.2.6", "< 5")

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -72,9 +72,9 @@ module Devise
             self.unconfirmed_email = nil
 
             # We need to validate in such cases to enforce e-mail uniqueness
-            save(validate: true)
+            self.class.to_adapter.save(self, validate: true)
           else
-            save(validate: args[:ensure_valid] == true)
+            self.class.to_adapter.save(self, validate: args[:ensure_valid] == true)
           end
 
           after_confirmation if saved
@@ -229,7 +229,7 @@ module Devise
         end
 
         def generate_confirmation_token!
-          generate_confirmation_token && save(validate: false)
+          generate_confirmation_token && self.class.to_adapter.save(self, validate: false)
         end
 
         def postpone_email_change_until_confirmation_and_regenerate_confirmation_token

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -43,7 +43,7 @@ module Devise
         if unlock_strategy_enabled?(:email) && opts.fetch(:send_instructions, true)
           send_unlock_instructions
         else
-          save(validate: false)
+          self.class.to_adapter.save(self, validate: false)
         end
       end
 
@@ -52,7 +52,7 @@ module Devise
         self.locked_at = nil
         self.failed_attempts = 0 if respond_to?(:failed_attempts=)
         self.unlock_token = nil  if respond_to?(:unlock_token=)
-        save(validate: false)
+        self.class.to_adapter.save(self, validate: false)
       end
 
       # Verifies whether a user is locked or not.
@@ -64,7 +64,7 @@ module Devise
       def send_unlock_instructions
         raw, enc = Devise.token_generator.generate(self.class, :unlock_token)
         self.unlock_token = enc
-        self.save(validate: false)
+        self.class.to_adapter.save(self, validate: false)
         send_devise_notification(:unlock_instructions, raw, {})
         raw
       end
@@ -104,7 +104,7 @@ module Devise
           if attempts_exceeded?
             lock_access! unless access_locked?
           else
-            save(validate: false)
+            self.class.to_adapter.save(self, validate: false)
           end
           false
         end

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -41,7 +41,7 @@ module Devise
           after_password_reset
         end
 
-        save
+        self.class.to_adapter.save(self)
       end
 
       def reset_password!(new_password, new_password_confirmation)
@@ -108,7 +108,7 @@ module Devise
 
           self.reset_password_token   = enc
           self.reset_password_sent_at = Time.now.utc
-          self.save(validate: false)
+          self.class.to_adapter.save(self, validate: false)
           raw
         end
 

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -50,7 +50,7 @@ module Devise
       def remember_me!(extend_period=false)
         self.remember_token = self.class.remember_token if generate_remember_token?
         self.remember_created_at = Time.now.utc if generate_remember_timestamp?(extend_period)
-        save(validate: false) if self.changed?
+        self.class.to_adapter.save(self, validate: false) if self.changed?
       end
 
       # If the record is persisted, remove the remember token (but only if
@@ -59,7 +59,7 @@ module Devise
         return unless persisted?
         self.remember_token = nil if respond_to?(:remember_token=)
         self.remember_created_at = nil if self.class.expire_all_remember_me_on_sign_out
-        save(validate: false)
+        self.class.to_adapter.save(self, validate: false)
       end
 
       # Remember token should be expired if expiration time not overpass now.

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -30,7 +30,7 @@ module Devise
 
       def update_tracked_fields!(request)
         update_tracked_fields(request)
-        save(validate: false)
+        self.class.to_adapter.save(self, validate: false)
       end
     end
   end

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -105,7 +105,7 @@ class ConfirmationTest < ActionDispatch::IntegrationTest
   test 'already confirmed user should not be able to confirm the account again' do
     user = create_user(confirm: false)
     user.confirmed_at = Time.now
-    user.save
+    user.class.to_adapter.save(user)
     visit_user_confirmation_with_token(user.raw_confirmation_token)
 
     assert_have_selector '#error_explanation'
@@ -115,7 +115,7 @@ class ConfirmationTest < ActionDispatch::IntegrationTest
   test 'already confirmed user should not be able to confirm the account again neither request confirmation' do
     user = create_user(confirm: false)
     user.confirmed_at = Time.now
-    user.save
+    user.class.to_adapter.save(user)
 
     visit_user_confirmation_with_token(user.raw_confirmation_token)
     assert_contain 'already confirmed'

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -91,7 +91,7 @@ class LockTest < ActionDispatch::IntegrationTest
   test "user should not send a new e-mail if already locked" do
     user = create_user(locked: true)
     user.failed_attempts = User.maximum_attempts + 1
-    user.save!
+    user.class.to_adapter.save!(user)
 
     ActionMailer::Base.deliveries.clear
 
@@ -107,7 +107,7 @@ class LockTest < ActionDispatch::IntegrationTest
 
       user = create_user(locked: true)
       user.failed_attempts = User.maximum_attempts + 1
-      user.save!
+      user.class.to_adapter.save!(user)
 
       sign_in_as_user(password: "invalid")
       assert_contain "You are locked!"
@@ -121,7 +121,7 @@ class LockTest < ActionDispatch::IntegrationTest
 
       user = create_user(locked: true)
       user.failed_attempts = User.maximum_attempts + 1
-      user.save!
+      user.class.to_adapter.save!(user)
 
       sign_in_as_user(password: "123456")
       assert_contain "You are locked!"

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -108,7 +108,7 @@ class RememberMeTest < ActionDispatch::IntegrationTest
       user.remember_me!
 
       user.remember_created_at = old = 10.days.ago
-      user.save
+      user.class.to_adapter.save(user)
 
       sign_in_as_user remember_me: true
       user.reload
@@ -159,7 +159,7 @@ class RememberMeTest < ActionDispatch::IntegrationTest
     user = create_user_and_remember
     user.password = "another_password"
     user.password_confirmation = "another_password"
-    user.save!
+    user.class.to_adapter.save!(user)
 
     get users_path
     assert_not warden.authenticated?(:user)

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -67,7 +67,7 @@ class ConfirmableTest < ActiveSupport::TestCase
   test 'should generate errors for a user email if user is already confirmed' do
     user = create_user
     user.confirmed_at = Time.now
-    user.save
+    user.class.to_adapter.save(user)
     confirmed_user = User.confirm_by_token(user.raw_confirmation_token)
     assert confirmed_user.confirmed?
     assert_equal "was already confirmed, please try signing in", confirmed_user.errors[:email].join
@@ -93,7 +93,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert_email_not_sent do
       user = new_user
       user.stubs(:valid?).returns(false)
-      user.save
+      user.class.to_adapter.save(user)
     end
   end
 
@@ -102,7 +102,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     user.skip_confirmation!
 
     assert_email_not_sent do
-      user.save!
+      user.class.to_adapter.save!(user)
       assert_nil user.confirmation_token
       assert_not_nil user.confirmed_at
     end
@@ -113,7 +113,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     user.skip_confirmation_notification!
 
     assert_email_not_sent do
-      user.save!
+      user.class.to_adapter.save!(user)
       assert !user.confirmed?
     end
   end
@@ -122,7 +122,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert_email_not_sent do
       user = new_user
       user.email = ''
-      user.save(validate: false)
+      user.class.to_adapter.save(user, validate: false)
     end
   end
 
@@ -153,7 +153,7 @@ class ConfirmableTest < ActiveSupport::TestCase
   test 'should always have confirmation token when email is sent' do
     user = new_user
     user.instance_eval { def confirmation_required?; false end }
-    user.save
+    user.class.to_adapter.save(user)
     user.send_confirmation_instructions
     assert_not_nil user.reload.confirmation_token
   end
@@ -162,7 +162,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     user = create_user
     user.email = 'new_test@example.com'
     assert_email_not_sent do
-      user.save!
+      user.class.to_adapter.save!(user)
     end
   end
 
@@ -171,7 +171,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     original_token = user.confirmation_token
     user.confirm
     user.email = 'new_test@example.com'
-    user.save!
+    user.class.to_adapter.save!(user)
 
     user.reload
     assert user.confirmed?
@@ -238,7 +238,7 @@ class ConfirmableTest < ActiveSupport::TestCase
   test 'should not be active without confirmation' do
     user = create_user
     user.confirmation_sent_at = nil
-    user.save
+    user.class.to_adapter.save(user)
     assert_not user.reload.active_for_authentication?
   end
 
@@ -246,7 +246,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     user = create_user
     user.instance_eval { def confirmation_required?; false end }
     user.confirmation_sent_at = nil
-    user.save
+    user.class.to_adapter.save(user)
     assert user.reload.active_for_authentication?
   end
 
@@ -393,7 +393,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     assert admin.confirm
     assert_email_not_sent do
       admin.email = ''
-      admin.save(validate: false)
+      admin.class.to_adapter.save(admin, validate: false)
     end
   end
 
@@ -444,7 +444,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
   test 'should find admin with email in unconfirmed_emails' do
     admin = create_admin
     admin.unconfirmed_email = "new_test@email.com"
-    assert admin.save
+    assert admin.class.to_adapter.save(admin)
     admin = Admin.find_by_unconfirmed_email_with_errors(email: "new_test@email.com")
     assert admin.persisted?
   end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -9,7 +9,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = new_user(email: email)
 
     assert_equal email, user.email
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_equal email.downcase, user.email
   end
 
@@ -20,7 +20,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = UserWithVirtualAttributes.new(attributes)
 
     assert_equal confirmation, user.email_confirmation
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_equal confirmation.downcase, user.email_confirmation
   end
 
@@ -29,7 +29,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     original_email = email.dup
     user           = new_user(email: email)
 
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_equal original_email, email
   end
 
@@ -39,7 +39,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = new_user(email: email)
 
     assert_equal email, user.email
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_equal email.strip, user.email
   end
 
@@ -48,7 +48,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     original_email = email.dup
     user           = new_user(email: email)
 
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_equal original_email, email
   end
 
@@ -113,7 +113,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = create_user
     encrypted_password = user.encrypted_password
     user.password = user.password_confirmation = 'new_password'
-    user.save!
+    user.class.to_adapter.save!(user)
     assert_not_equal encrypted_password, user.encrypted_password
   end
 
@@ -164,7 +164,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should run validations even when current password is invalid or blank' do
     user = UserWithValidation.create!(valid_attributes)
-    user.save
+    user.class.to_adapter.save(user)
     assert user.persisted?
     assert_not user.update_with_password(username: "")
     assert_match "usertest", user.reload.username

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -163,7 +163,7 @@ class RecoverableTest < ActiveSupport::TestCase
 
       old_password = user.password
       user.reset_password_sent_at = 2.days.ago
-      user.save!
+      user.class.to_adapter.save!(user)
 
       reset_password_user = User.reset_password_by_token(
         reset_password_token: raw,

--- a/test/models/rememberable_test.rb
+++ b/test/models/rememberable_test.rb
@@ -81,7 +81,7 @@ class RememberableTest < ActiveSupport::TestCase
   test 'forget_me should not try to update resource if it has been destroyed' do
     resource = create_resource
     resource.expects(:remember_created_at).never
-    resource.expects(:save).never
+    resource.class.to_adapter.expects(:save).never
 
     resource.destroy
     resource.forget_me!
@@ -133,7 +133,7 @@ class RememberableTest < ActiveSupport::TestCase
       resource = create_resource
       resource.remember_me!
       resource.remember_created_at = 2.days.ago
-      resource.save
+      resource.class.to_adapter.save(resource)
       assert resource.remember_expired?
     end
   end
@@ -143,7 +143,7 @@ class RememberableTest < ActiveSupport::TestCase
       resource = create_resource
       resource.remember_me!
       resource.remember_created_at = (30.days.ago + 2.minutes)
-      resource.save
+      resource.class.to_adapter.save(resource)
       assert_not resource.remember_expired?
     end
   end
@@ -155,7 +155,7 @@ class RememberableTest < ActiveSupport::TestCase
       assert resource.remember_created_at
 
       resource.remember_created_at = old = 10.minutes.ago
-      resource.save
+      resource.class.to_adapter.save(resource)
 
       resource.remember_me!(false)
       assert_not_equal old.to_i, resource.remember_created_at.to_i
@@ -169,7 +169,7 @@ class RememberableTest < ActiveSupport::TestCase
       assert resource.remember_created_at
 
       resource.remember_created_at = old = 10.minutes.ago.utc
-      resource.save
+      resource.class.to_adapter.save(resource)
 
       resource.remember_me!(false)
       assert_equal old.to_i, resource.remember_created_at.to_i
@@ -183,7 +183,7 @@ class RememberableTest < ActiveSupport::TestCase
       assert resource.remember_created_at
 
       resource.remember_created_at = old = 10.minutes.ago
-      resource.save
+      resource.class.to_adapter.save(resource)
 
       resource.remember_me!(true)
       assert_not_equal old, resource.remember_created_at

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -20,7 +20,7 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.invalid?
     assert_match(/taken/, user.errors[:email].join)
 
-    user.save(validate: false)
+    user.class.to_adapter.save(user, validate: false)
     assert user.valid?
   end
 
@@ -35,7 +35,7 @@ class ValidatableTest < ActiveSupport::TestCase
       assert_equal 'is invalid', user.errors[:email].join
     end
 
-    user.save(validate: false)
+    user.class.to_adapter.save(user, validate: false)
     assert user.valid?
   end
 


### PR DESCRIPTION
Ref. #3412 

Needs https://github.com/ianwhite/orm_adapter/pull/45