### PR TITLE
Split out BCrypt hashing to make it reusable

### DIFF
--- a/lib/devise/encryptor.rb
+++ b/lib/devise/encryptor.rb
@@ -1,0 +1,22 @@
+require 'bcrypt'
+
+module Devise
+  module Encryptor
+    def self.digest(klass, password)
+      if klass.pepper.present?
+        password = "#{password}#{klass.pepper}"
+      end
+      ::BCrypt::Password.create(password, cost: klass.stretches).to_s
+    end
+
+    def self.compare(klass, encrypted_password, password)
+      return false if encrypted_password.blank?
+      bcrypt   = ::BCrypt::Password.new(encrypted_password)
+      if klass.pepper.present?
+        password = "#{password}#{klass.pepper}"
+      end
+      password = ::BCrypt::Engine.hash_secret(password, bcrypt.salt)
+      Devise.secure_compare(password, encrypted_password)
+    end
+  end
+end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -14,11 +14,11 @@ class DeviseTest < ActiveSupport::TestCase
   test 'bcrypt on the class' do
     password = "super secret"
     klass    = Struct.new(:pepper, :stretches).new("blahblah", 2)
-    hash     = Devise.bcrypt(klass, password)
+    hash     = Devise::Encryptor.digest(klass, password)
     assert_equal ::BCrypt::Password.create(hash), hash
 
     klass    = Struct.new(:pepper, :stretches).new("bla", 2)
-    hash     = Devise.bcrypt(klass, password)
+    hash     = Devise::Encryptor.digest(klass, password)
     assert_not_equal ::BCrypt::Password.new(hash), hash
   end
 


### PR DESCRIPTION
This logic is generic and reusable -- hash a secret; and take an unhashed secret and compare it to a hashed secret. This breaks this out to make it reusable in other places. Specifically, we use this in our own token auth at Bonobos that we plan to split out as a Devise extension. This will make that possible without copy & pasting this code.