### PR TITLE
Use `define_method`, not `class_eval`, for url_helpers

### DIFF
--- a/lib/devise/controllers/url_helpers.rb
+++ b/lib/devise/controllers/url_helpers.rb
@@ -42,16 +42,14 @@ module Devise
           [:path, :url].each do |path_or_url|
             actions.each do |action|
               action = action ? "#{action}_" : ""
-              method = "#{action}#{module_name}_#{path_or_url}"
+              method = :"#{action}#{module_name}_#{path_or_url}"
 
-              class_eval <<-URL_HELPERS, __FILE__, __LINE__ + 1
-                def #{method}(resource_or_scope, *args)
-                  scope = Devise::Mapping.find_scope!(resource_or_scope)
-                  router_name = Devise.mappings[scope].router_name
-                  context = router_name ? send(router_name) : _devise_route_context
-                  context.send("#{action}\#{scope}_#{module_name}_#{path_or_url}", *args)
-                end
-              URL_HELPERS
+              define_method method do |resource_or_scope, *args|
+                scope = Devise::Mapping.find_scope!(resource_or_scope)
+                router_name = Devise.mappings[scope].router_name
+                context = router_name ? send(router_name) : _devise_route_context
+                context.send("#{action}#{scope}_#{module_name}_#{path_or_url}", *args)
+              end
             end
           end
         end


### PR DESCRIPTION
I'm not hugely familiar with ruby internals vis-a-vis sclass semantics,
but this *probably* serves as a workaround for the MRI thread-safety
bug mentioned in #3505.
Beyond that, and even if this doesn't fix the thread-safety issue, per
[this blog post][1], `define_method` is recommended over `class_eval`
for performance (and, fwiw, readability) reasons anyway.

[1]: http://tenderlovemaking.com/2013/03/03/dynamic_method_definitions.html