### PR TITLE
fixed typo referring to routes.rb file

### DIFF
--- a/lib/generators/templates/controllers/README
+++ b/lib/generators/templates/controllers/README
@@ -2,7 +2,7 @@
 
 Some setup you must do manually if you haven't yet:
 
-  Ensure you have overridden routes for generated controllers in your route.rb.
+  Ensure you have overridden routes for generated controllers in your routes.rb.
   For example:
 
     Rails.application.routes.draw do


### PR DESCRIPTION
When creating devise controllers there is a message presented:

     Some setup you must do manually if you haven't yet:

      Ensure you have overridden routes for generated controllers in your route.rb.
      For example:

    Rails.application.routes.draw do
      devise_for :users, controllers: {
        sessions: 'users/sessions'
      }
    end


However, the file "Route.rb" should be "Routes.rb"