### PR TITLE
Doesn't send reset password instructions if access_locked? && !unlockable?(resource) 

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -11,6 +11,7 @@ class Devise::PasswordsController < DeviseController
   # POST /resource/password
   def create
     self.resource = resource_class.find_or_initialize_with_errors(resource_class.reset_password_keys, resource_params, :not_found)
+    return respond_with(resource) unless resource.persisted?
 
     yield resource if block_given?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
+      user_locked: "Your account is locked."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."


### PR DESCRIPTION
I think, devise should not send reset password instructions if 'unlock strategy' set as :none and 'access locked' is true for some user.  
The first moment: 
If devise sends the instructions, user goes to the link from email, he fills in a field with a new password, but, after it, he will see "Your account is locked." error message. It is confuses the user. 
The second moment: 
We should not load any email service, if it is not necessary. It is small performance.

What do you think about it ?