### PR TITLE
Validating the presence of password and confirmation in recoverable model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-PATH
-  remote: .
-  specs:
-    devise (3.5.1)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
-      responders
-      thread_safe (~> 0.1)
-      warden (~> 1.2.3)
-
 GIT
   remote: git://github.com/mongoid/mongoid.git
   revision: a4365d7ecfa8221bfcf36a4e7ce7993142fc5940
@@ -19,6 +8,17 @@ GIT
       moped (~> 2.0.0)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
+
+PATH
+  remote: .
+  specs:
+    devise (3.5.1)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 3.2.6, < 5)
+      responders
+      thread_safe (~> 0.1)
+      warden (~> 1.2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,4 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      blank_password: "can't be blank"

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -141,7 +141,11 @@ module Devise
           recoverable = find_or_initialize_with_error_by(:reset_password_token, reset_password_token)
 
           if recoverable.persisted?
-            if recoverable.reset_password_period_valid?
+            if attributes[:password].blank?
+              recoverable.errors.add(:password, :blank_password)
+            elsif attributes[:password_confirmation].blank?
+              recoverable.errors.add(:password_confirmation, :blank_password)
+            elsif recoverable.reset_password_period_valid?
               recoverable.reset_password(attributes[:password], attributes[:password_confirmation])
             else
               recoverable.errors.add(:reset_password_token, :expired)

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -225,4 +225,17 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_equal User.with_reset_password_token('random-token'), nil
   end
 
+  test 'should not reset password and remove token if password confirmation is nil' do
+    user = create_user
+    token = user.send_reset_password_instructions
+    reset_password_user = User.reset_password_by_token(
+        reset_password_token: token,
+        password: 'random_password',
+        password_confirmation: nil
+    )
+    assert_present reset_password_user.reset_password_token
+    assert_not reset_password_user.valid_password?('random_password')
+    assert_match "can't be blank", reset_password_user.errors[:password_confirmation].join
+  end
+
 end


### PR DESCRIPTION
In the process of recovering, though the password_confirmation field was mandatory, it was not properly validating so password was being reset when the password_confirmation was set nil.
It fixes that issue and returns proper validation message when password or confirmation_password are nil or blank.