### PR TITLE
Fixed redirect loop in mounted apps.

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -118,7 +118,7 @@ module Devise
 
       config = Rails.application.config
 
-      if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
+      if config.respond_to?(:relative_url_root)
         opts[:script_name] = config.relative_url_root
       end
 


### PR DESCRIPTION
This is a bug fix and reverses commit af8d38e.
It fixes a redirect loop with mounted apps.
Versions affected by the bug: 3.5.1.

Relative URL root must always be set because it's meaningful even when blank.
It ensures URL helper generates URL based on Rails' root, not any other root.
By "any other root" I mean the base directories of other mounted apps.

If :script_name option is only set when relative_url_root is present,
there'll be a redirect loop within mounted app.
  1. User tries to access /mounted_app
  2. User is redirected to /mounted_app/sign_in (instead of /sign_in)
  3. Route (^/mounted_app) is again forbidden, go back to step 2.

# About test
Unfortunately I couldn't write the proper test. That is, I couldn't make it fail, so an exception is being raised to sinalize that. I've spent some time trying to figure out what was wrong but I couldn't.
In any real app, `ENV['SCRIPT_NAME']` influences in URL generation but even after setting that in the test, #url_options doesn't contain script name (but in any other environment it does).

Hope this helps anyway. I'm sorry I couldn't provide the proper test.