### PR TITLE
Remove rubyforge_project option

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = "Flexible authentication solution for Rails with Warden"
   s.authors     = ['José Valim', 'Carlos Antônio']
 
-  s.rubyforge_project = "devise"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
rubyforge_project option is deprecated.

Thank you!