### PR TITLE
Fix default email_regexp config to disallow trailing non-word characters

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -106,7 +106,7 @@ module Devise
   # an one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   mattr_accessor :email_regexp
-  @@email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
+  @@email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\W]+\z/
 
   # Range validation for password length
   mattr_accessor :password_length

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -95,7 +95,7 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'Devise.email_regexp should match valid email addresses' do
     valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua"]
-    non_valid_emails = ["rex", "test@go,com", "test user@example.com", "test_user@example server.com"]
+    non_valid_emails = ["rex", "test@go,com", "test user@example.com", "test_user@example server.com", "test_user@example.com."]
 
     valid_emails.each do |email|
       assert_match Devise.email_regexp, email


### PR DESCRIPTION
The current email_regexp allows non-word characters at the end: http://rubular.com/r/nzwZ3SXJGo

This small change to the regex will fix that: http://rubular.com/r/jyE5N8FtSM