### PR TITLE
Do not use digests for confirmation tokens

### DIFF
--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -86,7 +86,7 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     host, port = ActionMailer::Base.default_url_options.values_at :host, :port
 
     if mail.body.encoded =~ %r{<a href=\"http://#{host}:#{port}/users/confirmation\?confirmation_token=([^"]+)">}
-      assert_equal Devise.token_generator.digest(user.class, :confirmation_token, $1), user.confirmation_token
+      assert_equal $1, user.confirmation_token
     else
       flunk "expected confirmation url regex to match"
     end

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -291,12 +291,23 @@ class ConfirmableTest < ActiveSupport::TestCase
     end
   end
 
-  test 'always generate a new token on resend' do
+  test 'do not generate a new token on resend' do
     user = create_user
     old  = user.confirmation_token
     user = User.find(user.id)
     user.resend_confirmation_instructions
-    assert_not_equal user.confirmation_token, old
+    assert_equal user.confirmation_token, old
+  end
+
+  test 'generate a new token after first has expired' do
+    swap Devise, confirm_within: 3.days do
+      user = create_user
+      old = user.confirmation_token
+      user.update_attribute(:confirmation_sent_at, 4.days.ago)
+      user = User.find(user.id)
+      user.resend_confirmation_instructions
+      assert_not_equal user.confirmation_token, old
+    end
   end
 
   test 'should call after_confirmation if confirmed' do


### PR DESCRIPTION
Addresses https://github.com/plataformatec/devise/issues/3640.

I did this by changing as little code as possible. It's definitely possible to strip out `raw_confirmation_token` entirely, but you'd have to change a LOT of specs. Please advise if this is up to par for your repository.