### PR TITLE
redirect to after_resetting_password_path always

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -38,11 +38,10 @@ class Devise::PasswordsController < DeviseController
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message(:notice, flash_message) if is_flashing_format?
         sign_in(resource_name, resource)
-        respond_with resource, location: after_resetting_password_path_for(resource)
       else
         set_flash_message(:notice, :updated_not_active) if is_flashing_format?
-        respond_with resource, location: new_session_path(resource_name)
       end
+      respond_with resource, location: after_resetting_password_path_for(resource)
     else
       respond_with resource
     end
@@ -50,7 +49,7 @@ class Devise::PasswordsController < DeviseController
 
   protected
     def after_resetting_password_path_for(resource)
-      after_sign_in_path_for(resource)
+      Devise.sign_in_after_reset_password ? after_sign_in_path_for(resource) : new_session_path(resource_name)
     end
 
     # The path used after sending reset password instructions


### PR DESCRIPTION
As discussed in #3668, this PR makes `after_resetting_password_path_for(resource)` to take effect when `sign_in_after_reset_password` is disabled.