### PR TITLE
Remove obsolete unused `expire_auth_token_on_timeout` config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git://github.com/mongoid/mongoid.git
-  revision: a4365d7ecfa8221bfcf36a4e7ce7993142fc5940
-  branch: master
-  specs:
-    mongoid (4.0.0)
-      activemodel (~> 4.0)
-      moped (~> 2.0.0)
-      origin (~> 2.1)
-      tzinfo (>= 0.3.37)
-
 PATH
   remote: .
   specs:
@@ -60,9 +49,9 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.0)
     bcrypt (3.1.10)
-    bson (2.3.0)
+    bson (3.1.2)
     builder (3.2.2)
-    connection_pool (2.1.3)
+    connection_pool (2.2.0)
     erubis (2.7.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -82,8 +71,13 @@ GEM
     minitest (5.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    moped (2.0.4)
-      bson (~> 2.2)
+    mongoid (4.0.2)
+      activemodel (~> 4.0)
+      moped (~> 2.0.0)
+      origin (~> 2.1)
+      tzinfo (>= 0.3.37)
+    moped (2.0.6)
+      bson (~> 3.0)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     multi_json (1.11.1)
@@ -175,7 +169,7 @@ DEPENDENCIES
   devise!
   jruby-openssl
   mocha (~> 1.1)
-  mongoid!
+  mongoid (~> 4.0)
   omniauth (~> 1.2.0)
   omniauth-facebook
   omniauth-oauth2 (~> 1.1.0)
@@ -184,3 +178,6 @@ DEPENDENCIES
   rdoc
   sqlite3
   webrat (= 0.7.3)
+
+BUNDLED WITH
+   1.10.5

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -146,10 +146,6 @@ module Devise
   mattr_accessor :timeout_in
   @@timeout_in = 30.minutes
 
-  # Authentication token expiration on timeout
-  mattr_accessor :expire_auth_token_on_timeout
-  @@expire_auth_token_on_timeout = false
-
   # Used to encrypt password. Please generate one with rake secret.
   mattr_accessor :pepper
   @@pepper = nil

--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -21,10 +21,6 @@ Warden::Manager.after_set_user do |record, warden, options|
     if record.timedout?(last_request_at) && !env['devise.skip_timeout']
       Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
 
-      if record.respond_to?(:expire_auth_token_on_timeout) && record.expire_auth_token_on_timeout
-        record.reset_authentication_token!
-      end
-
       throw :warden, scope: scope, message: :timeout
     end
 

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -158,9 +158,6 @@ Devise.setup do |config|
   # time the user will be asked for credentials again. Default is 30 minutes.
   # config.timeout_in = 30.minutes
 
-  # If true, expires auth token on session timeout.
-  # config.expire_auth_token_on_timeout = false
-
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -110,23 +110,6 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
     assert_contain 'You are signed in'
   end
 
-  test 'admin does not explode on time out' do
-    admin = sign_in_as_admin
-    get expire_admin_path(admin)
-
-    Admin.send :define_method, :reset_authentication_token! do
-      nil
-    end
-
-    begin
-      get admins_path
-      assert_redirected_to admins_path
-      assert_not warden.authenticated?(:admin)
-    ensure
-      Admin.send(:remove_method, :reset_authentication_token!)
-    end
-  end
-
   test 'user configured timeout limit' do
     swap Devise, timeout_in: 8.minutes do
       user = sign_in_as_user

--- a/test/rails_app/app/controllers/admins_controller.rb
+++ b/test/rails_app/app/controllers/admins_controller.rb
@@ -3,9 +3,4 @@ class AdminsController < ApplicationController
 
   def index
   end
-
-  def expire
-    admin_session['last_request_at'] = 31.minutes.ago.utc
-    render text: 'Admin will be expired on next request'
-  end
 end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -13,9 +13,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :admins, only: [:index] do
-    get :expire, on: :member
-  end
+  resources :admins, only: [:index]
 
   # Users scope
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }


### PR DESCRIPTION
Hi!

I was going to add `timeoutable` to my app so I had a look at the config and saw `expire_auth_token_on_timeout`. So asked myself "what is this?" and "do I need it?". I had a look at the code and saw it calls the `reset_authentication_token!` method that it's not defined anywhere. Then I did a bit of git digging and I think all of this was probably meant to be removed together with dff7891.

Regards and thanks for this gem!