### PR TITLE
allow setting of reset_password_token on an unpersisted record, in a way that matches the functionality of setting the confirmation_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * enhancements
   * Upon setting `Devise.send_password_change_notification = true` a user will receive notification when their password has been changed.
+  * reset_password_token can now be set before saving a new record. (@betesh, #3673)
 
 ### 3.5.2 - 2015-08-10
 

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -31,11 +31,16 @@ module Devise
       end
 
       included do
-        before_save do
+        before_update do
           if email_changed? || encrypted_password_changed?
             clear_reset_password_token
           end
         end
+      end
+
+      def initialize(*args, &block)
+        @raw_reset_password_token = nil
+        super
       end
 
       # Update password saving the record and clearing token. Returns true if
@@ -60,10 +65,15 @@ module Devise
       # Resets reset password token and send reset password instructions by email.
       # Returns the token sent in the e-mail.
       def send_reset_password_instructions
-        token = set_reset_password_token
-        send_reset_password_instructions_notification(token)
+        unless @raw_reset_password_token
+          set_reset_password_token!
+        end
+        send_reset_password_instructions_notification(@raw_reset_password_token)
 
-        token
+        # If there were a simple way to detect whether the return value was being used and log a deprecation warning only if it was,
+        # we would do so and then eventually remove the return value below.  This would match the behavior of #send_confirmation_instructions
+        # However, in the absence of that, we'll simply have to wait for the next major version change.
+        @raw_reset_password_token
       end
 
       # Checks if the reset password token sent is within the limit time.
@@ -90,6 +100,13 @@ module Devise
         reset_password_sent_at && reset_password_sent_at.utc >= self.class.reset_password_within.ago
       end
 
+      def set_reset_password_token
+        raw, enc = Devise.token_generator.generate(self.class, :reset_password_token)
+        @raw_reset_password_token   = raw
+        self.reset_password_token   = enc
+        self.reset_password_sent_at = Time.now.utc
+      end
+
       protected
 
         # Removes reset_password token
@@ -98,13 +115,8 @@ module Devise
           self.reset_password_sent_at = nil
         end
 
-        def set_reset_password_token
-          raw, enc = Devise.token_generator.generate(self.class, :reset_password_token)
-
-          self.reset_password_token   = enc
-          self.reset_password_sent_at = Time.now.utc
-          self.save(validate: false)
-          raw
+        def set_reset_password_token!
+          set_reset_password_token && self.save(validate: false)
         end
 
         def send_reset_password_instructions_notification(token)

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -7,7 +7,8 @@ class PasswordsControllerTest < ActionController::TestCase
   setup do
     request.env["devise.mapping"] = Devise.mappings[:user]
     @user = create_user.tap(&:confirm)
-    @raw  = @user.send_reset_password_instructions
+    @user.send_reset_password_instructions
+    @raw  = @user.instance_variable_get("@raw_reset_password_token")
   end
 
   def put_update_with_params


### PR DESCRIPTION
It's possible to set the confirmation_token before saving the record and then wait until after the record is saved to email the confirmation link.  This PR adds the same functionality for the reset_password_token.

The motivation is a use case where the model is not `devise :registerable`.  Instead, an Administrator creates the user with just the authentication key (email) and the new user immediately receives an email with a link to set his password.

Devise::Models::Validatable adds this validation:

```
validates_presence_of     :password, if: :password_required?
validates_confirmation_of :password, if: :password_required?
```

So there's a built-in way to ignore a missing password when desired, and it would be a shame to have to re-implement all validation when instead I should just be able to override `password_required?`

So I tried overriding it as follows:

```
def password_required?
  reset_password_token.blank? && super
end
```

However, there was no way to set the reset_password_token until the record is saved.  This PR adds the code to make that possible.
