### PR TITLE
Replace all instances of Log in to Sign In

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Log in</h2>
+<h2>Sign in</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
@@ -19,7 +19,7 @@
   <% end -%>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "Sign in" %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Sign in", new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -269,7 +269,7 @@ class FailureTest < ActiveSupport::TestCase
         "warden" => stub_everything
       }
       call_failure(env)
-      assert @response.third.body.include?('<h2>Log in</h2>')
+      assert @response.third.body.include?('<h2>Sign in</h2>')
       assert @response.third.body.include?('Invalid email or password.')
     end
 
@@ -280,7 +280,7 @@ class FailureTest < ActiveSupport::TestCase
         "warden" => stub_everything
       }
       call_failure(env)
-      assert @response.third.body.include?('<h2>Log in</h2>')
+      assert @response.third.body.include?('<h2>Sign in</h2>')
       assert @response.third.body.include?('You have to confirm your email address before continuing.')
     end
 
@@ -291,7 +291,7 @@ class FailureTest < ActiveSupport::TestCase
         "warden" => stub_everything
       }
       call_failure(env)
-      assert @response.third.body.include?('<h2>Log in</h2>')
+      assert @response.third.body.include?('<h2>Sign in</h2>')
       assert @response.third.body.include?('Your account is not activated yet.')
     end
   end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -448,7 +448,7 @@ class AuthenticationOthersTest < ActionDispatch::IntegrationTest
 
   test 'uses the custom controller with the custom controller view' do
     get '/admin_area/sign_in'
-    assert_contain 'Log in'
+    assert_contain 'Sign In'
     assert_contain 'Welcome to "admins/sessions" controller!'
     assert_contain 'Welcome to "sessions/new" view!'
   end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -448,7 +448,7 @@ class AuthenticationOthersTest < ActionDispatch::IntegrationTest
 
   test 'uses the custom controller with the custom controller view' do
     get '/admin_area/sign_in'
-    assert_contain 'Sign In'
+    assert_contain 'Sign in'
     assert_contain 'Welcome to "admins/sessions" controller!'
     assert_contain 'Welcome to "sessions/new" view!'
   end

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -225,11 +225,11 @@ class LockTest < ActionDispatch::IntegrationTest
       visit new_user_session_path
       fill_in 'email', with: user.email
       fill_in 'password', with: "abadpassword"
-      click_button 'Log in'
+      click_button 'Sign in'
 
       fill_in 'email', with: user.email
       fill_in 'password', with: "abadpassword"
-      click_button 'Log in'
+      click_button 'Sign in'
 
       assert_current_url "/users/sign_in"
       assert_not_contain "locked"

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -40,7 +40,7 @@ class ActionDispatch::IntegrationTest
     fill_in 'password', with: options[:password] || '12345678'
     check 'remember me' if options[:remember_me] == true
     yield if block_given?
-    click_button 'Log In'
+    click_button 'Sign in'
     user
   end
 
@@ -50,7 +50,7 @@ class ActionDispatch::IntegrationTest
     fill_in 'email', with: 'admin@test.com'
     fill_in 'password', with: '123456'
     yield if block_given?
-    click_button 'Log In'
+    click_button 'Sign in'
     admin
   end
 


### PR DESCRIPTION
This makes sense as there are no instances of log out on the site. Methods and URL also uses sign_in