### PR TITLE
Token overwrite

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -298,7 +298,6 @@ module Devise
 
           confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_token)
           confirmable.confirm if confirmable.persisted?
-          confirmable.confirmation_token = original_token
           confirmable
         end
 

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -52,6 +52,14 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert user.reload.confirmed?
   end
 
+  test 'should not modify the token when confirming by token' do
+    user = create_user
+    digest_token = user.confirmation_token
+    raw_token  = user.raw_confirmation_token
+    confirmed_user = User.confirm_by_token(raw_token)
+    assert_equal digest_token, confirmed_user.confirmation_token
+  end
+
   test 'should return a new record with errors when a invalid token is given' do
     confirmed_user = User.confirm_by_token('invalid_confirmation_token')
     assert_not confirmed_user.persisted?
@@ -205,7 +213,7 @@ class ConfirmableTest < ActiveSupport::TestCase
       user.confirmation_sent_at = 4.days.ago
       assert user.active_for_authentication?
 
-      user.confirmation_sent_at = 5.days.ago
+      user.confirmation_sent_at = (5.days + 1.second).ago
       assert_not user.active_for_authentication?
     end
   end


### PR DESCRIPTION
This PR changes the behaviour:

- The method `Confirmable#confirm_by_token(non_digested_token)` sets the `confirmation_token` to the non-digested one

to this behaviour:

- The `confirmation_token` is not modified.

Also, an unrelated test was failing on my Windows machine. It tests that the user is not active for authentication when the resource is unconfirmed for exactly the timeout period. I fixed it by pushing the `confirmation_sent_at` date one second further into the past.