### PR TITLE
Basic auth case insensitive pattern match

### DIFF
--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -118,7 +118,7 @@ module Devise
 
       # Helper to decode credentials from HTTP.
       def decode_credentials
-        return [] unless request.authorization && request.authorization =~ /^Basic (.*)/m
+        return [] unless request.authorization && request.authorization =~ /^Basic (.*)/mi
         Base64.decode64($1).split(/:/, 2)
       end
 


### PR DESCRIPTION
Allow basic authentication to be case insensitive as per the HTTP 1.1 spec [RFC 2068](http://www.rfc-base.org/txt/rfc-2068.txt) Section 11
> It uses an extensible, case-insensitive token to identify the authentication scheme, followed by a comma-separated list of attribute-value pairs which carry the parameters necessary for achieving authentication via that scheme.

We have a particular client in production that has basic auth hard-coded as `basic` rather than `Basic` and devise is rejecting perfectly fine credentials. Making this small change has allowed us to authenticate this client with no issues. 

If we can get this accepted upstream then we can stop patching devise whenever we deploy our rails apps.