### PR TITLE
User unconfirmed access should not be extended by re-sending confirmation email

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -198,7 +198,7 @@ module Devise
         #   confirmation_period_valid?   # will always return true
         #
         def confirmation_period_valid?
-          self.class.allow_unconfirmed_access_for.nil? || (confirmation_sent_at && confirmation_sent_at.utc >= self.class.allow_unconfirmed_access_for.ago)
+          self.class.allow_unconfirmed_access_for.nil? || (created_at && created_at.utc >= self.class.allow_unconfirmed_access_for.ago)
         end
 
         # Checks if the user confirmation happens before the token becomes invalid

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -189,7 +189,7 @@ class ConfirmableTest < ActiveSupport::TestCase
   test 'confirm time should fallback to devise confirm in default configuration' do
     swap Devise, allow_unconfirmed_access_for: 1.day do
       user = new_user
-      user.confirmation_sent_at = 2.days.ago
+      user.created_at = 2.days.ago
       assert_not user.active_for_authentication?
 
       Devise.allow_unconfirmed_access_for = 3.days
@@ -202,10 +202,10 @@ class ConfirmableTest < ActiveSupport::TestCase
       Devise.allow_unconfirmed_access_for = 5.days
       user = create_user
 
-      user.confirmation_sent_at = 4.days.ago
+      user.created_at = 4.days.ago
       assert user.active_for_authentication?
 
-      user.confirmation_sent_at = 5.days.ago
+      user.created_at = 5.days.ago
       assert_not user.active_for_authentication?
     end
   end


### PR DESCRIPTION
I think there is an issue with how `confirmable#confirmation_period_valid?` method logic was implemented.

User is able to access website during period specified in `allow_unconfirmed_access_fo` setting, but she can extend this period by just requesting re-sending confirmation email again and again.

I found [discussion](https://groups.google.com/forum/#!topic/plataformatec-devise/4ab91Vr1b9k) in Google Groups, but it seems no one give attention to this problem.

What do you think about?