### PR TITLE
Set minimum version 2.0 to responders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
-      responders
+      responders (~> 2.0)
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
 
@@ -180,4 +180,4 @@ DEPENDENCIES
   webrat (= 0.7.3)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency("bcrypt", "~> 3.0")
   s.add_dependency("thread_safe", "~> 0.1")
   s.add_dependency("railties", ">= 3.2.6", "< 5")
-  s.add_dependency("responders")
+  s.add_dependency("responders", "~> 2.0")
 end


### PR DESCRIPTION
On environment that uses just bundler to manage gems and has installed an old
version of responders (prior 2.0.0) that old version will be installed ,
but Devise will raise errors trying to call methods there exists only on
responders 2.0+

It solves #3685