### PR TITLE
Error on submit

### DIFF
--- a/lib/generators/templates/simple_form_for/confirmations/new.html.erb
+++ b/lib/generators/templates/simple_form_for/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= simple_form_for(resource, as: resource_name, url: user_confirmation_path, html: { method: :post }) do |f| %>
   <%= f.error_notification %>
   <%= f.full_error :confirmation_token %>
 


### PR DESCRIPTION
With the url confirmation_path(resource_name) generates a post on "/confirmation.user" generating the error "No route matches"