### PR TITLE
Improve grammar on lines 189 and 352 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Besides `:stretches`, you can define `:pepper`, `:encryptor`, `:confirm_within`,
 
 When you customize your own views, you may end up adding new attributes to forms. Rails 4 moved the parameter sanitization from the model to the controller, causing Devise to handle this concern at the controller as well.
 
-There are just three actions in Devise that allows any set of parameters to be passed down to the model, therefore requiring sanitization. Their names and the permitted parameters by default are:
+There are just three actions in Devise that allow any set of parameters to be passed down to the model, therefore requiring sanitization. Their names and the permitted parameters by default are:
 
 * `sign_in` (`Devise::SessionsController#create`) - Permits only the authentication keys (like `email`)
 * `sign_up` (`Devise::RegistrationsController#create`) - Permits authentication keys plus `password` and `password_confirmation`
@@ -349,7 +349,7 @@ devise_for :users, path: "auth", path_names: { sign_in: 'login', sign_out: 'logo
 
 Be sure to check `devise_for` documentation for details.
 
-If you have the need for more deep customization, for instance to also allow "/sign_in" besides "/users/sign_in", all you need to do is to create your routes normally and wrap them in a `devise_scope` block in the router:
+If you have the need for more deep customization, for instance to also allow "/sign_in" besides "/users/sign_in", all you need to do is create your routes normally and wrap them in a `devise_scope` block in the router:
 
 ```ruby
 devise_scope :user do


### PR DESCRIPTION
Made minor grammar improvements in the readme file.

1) Line 198: changed the form of the verb `allow` from `allows` to `allow` (plural form instead of singular).

2) Line 352: the unnecessary usage of `to`. While being grammatically correct, the sentence sounds more natural without `to` (besides, the variant without `to` is more frequently used in English). 