### PR TITLE
Remove unnecessary line break on edit password page.

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,8 +7,8 @@
   <div class="field">
     <%= f.label :password, "New password" %><br />
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
   </div>
 


### PR DESCRIPTION
Style fix for https://github.com/plataformatec/devise/issues/3698

Edit password view before (without using the Validatable module): 

<img width="192" alt="screen shot 2015-08-06 at 18 44 45" src="https://cloud.githubusercontent.com/assets/1370570/9118926/a2c8b8ac-3c6b-11e5-8080-665279afd45e.png">

Edit password view after:

<img width="162" alt="screen shot 2015-08-06 at 18 45 19" src="https://cloud.githubusercontent.com/assets/1370570/9118929/a6b67580-3c6b-11e5-9bb1-a5ad9c81d7fc.png">