### PR TITLE
Delete of current password in update_without_password

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -92,6 +92,7 @@ module Devise
       #   end
       #
       def update_without_password(params, *options)
+        params.delete(:current_password)
         params.delete(:password)
         params.delete(:password_confirmation)
 

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -198,6 +198,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_equal 'new@example.com', user.email
   end
 
+  test 'should update the user without password with current_password' do
+    user = create_user
+    user.update_without_password(email: 'new@example.com', current_password: '')
+    assert_equal 'new@example.com', user.email
+  end
+
   test 'should not update password without password' do
     user = create_user
     user.update_without_password(password: 'pass4321', password_confirmation: 'pass4321')


### PR DESCRIPTION
Deletion of current password key when updating without password.
This enables a hybrid model on the form that needs current password
for update specific fields, some with pass and others without.

Signed-off-by: Diogo Rosa <diogo.m.c.rosa@gmail.com>