### PR TITLE
modifys markerb templates to use markdown links, not html ones.

### DIFF
--- a/lib/generators/templates/markerb/confirmation_instructions.markerb
+++ b/lib/generators/templates/markerb/confirmation_instructions.markerb
@@ -2,4 +2,4 @@ Welcome <%= @email %>!
 
 You can confirm your account through the link below:
 
-<%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %>
+[Confirm my account](<%= confirmation_url(@resource, confirmation_token: @token) %>)

--- a/lib/generators/templates/markerb/reset_password_instructions.markerb
+++ b/lib/generators/templates/markerb/reset_password_instructions.markerb
@@ -2,7 +2,7 @@ Hello <%= @resource.email %>!
 
 Someone has requested a link to change your password, and you can do this through the link below.
 
-<%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %>
+[Change my password](<%= edit_password_url(@resource, reset_password_token: @token) %>)
 
 If you didn't request this, please ignore this email.
 Your password won't change until you access the link above and create a new one.

--- a/lib/generators/templates/markerb/unlock_instructions.markerb
+++ b/lib/generators/templates/markerb/unlock_instructions.markerb
@@ -4,4 +4,4 @@ Your account has been locked due to an excessive number of unsuccessful sign in 
 
 Click the link below to unlock your account:
 
-<%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %>
+[Unlock my account](<%= unlock_url(@resource, unlock_token: @token) %>)


### PR DESCRIPTION
Seeing as the point of the markerb templates is to allow markdown templates to be used for both html and text emails, it makes sense that the links used in said template should be markdown links, not html ones.

This will make no difference to HTML viewers of the email, but should make the view better for text viewers of the email.