### PR TITLE
confirmation_sent_at updated when confirmation token is re-sent

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -237,8 +237,8 @@ module Devise
           else
             raw, _ = Devise.token_generator.generate(self.class, :confirmation_token)
             self.confirmation_token = @raw_confirmation_token = raw
-            self.confirmation_sent_at = Time.now.utc
           end
+          self.confirmation_sent_at = Time.now.utc
         end
 
         def generate_confirmation_token!


### PR DESCRIPTION
Since PR #3661 `confirmation_sent_at` is not updated when a non-expired confirmation token is re-sent.
