### PR TITLE
Update comment on Devise.configure_warden

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -433,8 +433,8 @@ module Devise
     Devise::Controllers::UrlHelpers.generate_helpers!
   end
 
-  # A method used internally to setup warden manager from the Rails initialize
-  # block.
+  # A method used internally to complete the setup of warden manager after routes are loaded.
+  # See lib/devise/rails/routes.rb - ActionDispatch::Routing::RouteSet#finalize_with_devise!
   def self.configure_warden! #:nodoc:
     @@warden_configured ||= begin
       warden_config.failure_app   = Devise::Delegator.new


### PR DESCRIPTION
The existing comment seems to be either outdated or obscure. I interpret it as meaning that configure_warden! is invoked by an 'initializer' block in class Devise::Engine, i.e. in lib/devise/rails.rb. However, as far as I can tell the only time the method is invoked is when ActionDispatch::Routing::RouteSet#finalize! is called, and this is aliased by devise to finalize_with_devise!.