### PR TITLE
Use default_url_options from parent_controller

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -22,9 +22,12 @@ module Devise
       @respond.call(env)
     end
 
+    # Try retrieving the URL options from the parent controller (usually 
+    # ApplicationController). Instance methods are not supported at the moment,
+    # so only the class-level attribute is used.
     def self.default_url_options(*args)
-      if defined?(ApplicationController)
-        ApplicationController.default_url_options(*args)
+      if defined?(Devise.parent_controller.constantize)
+        Devise.parent_controller.constantize.try(:default_url_options) || {}
       else
         {}
       end


### PR DESCRIPTION
URLs are now generated using the configured `Devise.parent_controller`, not the hardcoded `ApplicationController`, as in the rest of the library.

Also it now uses the instance method as recommended to implement in the Rails guides, not only the class-level hash. 

Only thing I wasn't sure of is how to test this. I couldn't find a test for the old implementation but when I tried implementing one, I couldn't find a way to modify the environment in a way that changed the parent controller without leaving a big mess behind. Changing `Devise.parent_controller` or modifying `ApplicationWithFakeEngine` has no effect at the time the tests are run as all classes and hierarchy have already been set up.

I don't like contributing code w/o tests so I'm open to suggestions and will amend my code accordingly.
As usual, comments are very welcome.