### PR TITLE
Replace redundant sign_in after creating new session

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -16,7 +16,8 @@ class Devise::SessionsController < DeviseController
   def create
     self.resource = warden.authenticate!(auth_options)
     set_flash_message(:notice, :signed_in) if is_flashing_format?
-    sign_in(resource_name, resource)
+    # remove any previous data stored in the session with keys starting with 'devise.'
+    expire_data_after_sign_in!
     yield resource if block_given?
     respond_with resource, location: after_sign_in_path_for(resource)
   end


### PR DESCRIPTION
The current code calls `sign_in` after authenticating a new user session. This stores the user in the session if it isn't already present. However `warden.authenticate!` already stores the user, so there is no need to do so again. The only other function performed by `sign_in`  that is needed after authentication is to remove old session data by calling `expire_data_after_sign_in!`.