### PR TITLE
Wrap helper_method calls in respond_to?(:helper_method)

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -7,7 +7,9 @@ module Devise
       include Devise::Controllers::StoreLocation
 
       included do
-        helper_method :warden, :signed_in?, :devise_controller?
+        if respond_to?(:helper_method)
+          helper_method :warden, :signed_in?, :devise_controller?
+        end
       end
 
       module ClassMethods
@@ -69,7 +71,9 @@ module Devise
               end.compact
             end
 
-            helper_method "current_#{group_name}", "current_#{group_name.to_s.pluralize}", "#{group_name}_signed_in?"
+            if respond_to?(:helper_method)
+              helper_method "current_#{group_name}", "current_#{group_name.to_s.pluralize}", "#{group_name}_signed_in?"
+            end
           METHODS
         end
 
@@ -126,7 +130,9 @@ module Devise
         METHODS
 
         ActiveSupport.on_load(:action_controller) do
-          helper_method "current_#{mapping}", "#{mapping}_signed_in?", "#{mapping}_session"
+          if respond_to?(:helper_method)
+            helper_method "current_#{mapping}", "#{mapping}_signed_in?", "#{mapping}_session"
+          end
         end
       end
 

--- a/test/controllers/helper_methods_test.rb
+++ b/test/controllers/helper_methods_test.rb
@@ -8,14 +8,14 @@ class HelperMethodsTest < ActionController::TestCase
   tests ApiController
 
   test 'includes Devise::Controllers::Helpers' do
-    assert @controller.class.ancestors.include?(Devise::Controllers::Helpers)
+    assert_includes @controller.class.ancestors, Devise::Controllers::Helpers
   end
 
   test 'does not respond_to helper_method' do
-    refute @controller.respond_to?(:helper_method)
+    refute_respond_to @controller.class, :helper_method
   end
 
   test 'defines methods like current_user' do
-    assert @controller.respond_to?(:current_user)
+    assert_respond_to @controller, :current_user
   end
 end

--- a/test/controllers/helper_methods_test.rb
+++ b/test/controllers/helper_methods_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ApiController < ActionController::Metal
+  include Devise::Controllers::Helpers
+end
+
+class HelperMethodsTest < ActionController::TestCase
+  tests ApiController
+
+  test 'includes Devise::Controllers::Helpers' do
+    assert @controller.class.ancestors.include?(Devise::Controllers::Helpers)
+  end
+
+  test 'does not respond_to helper_method' do
+    refute @controller.respond_to?(:helper_method)
+  end
+
+  test 'defines methods like current_user' do
+    assert @controller.respond_to?(:current_user)
+  end
+end


### PR DESCRIPTION
Currently `Devise::Controllers::Helpers` depends on `#helper_method`, which is defined inside `AbstractController::Helpers`.  This module is included in `ActionController::Base`, but it is not included by default in `ActionController::Metal`.

`#helper_method` is not essential to the functionality of the methods inside `Devise::Controllers::Helpers`, so this PR wraps all Devise `#helper_method` calls with `respond_to?(:helper_method)` checks.