### PR TITLE
disable validates_length_of unless password_required?

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -32,7 +32,7 @@ module Devise
 
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
-          validates_length_of       :password, within: password_length, allow_blank: true
+          validates_length_of       :password, within: password_length, allow_blank: true, if: :password_required?
         end
       end
 


### PR DESCRIPTION
Hi, guys!
My actions:
  1. I created User without password.
  2. Included :validatable module to User.
  3. Want to disable password validation.
  4. Overrode password_reqired? to FALSE.
  5. Got Error 'undefined method `password' for #<User:0x007fa193fe3148>'

This commit will fix it.