### PR TITLE
Check for .message as Omniauth failure message too

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -20,6 +20,7 @@ class Devise::OmniauthCallbacksController < DeviseController
     exception = env["omniauth.error"]
     error   = exception.error_reason if exception.respond_to?(:error_reason)
     error ||= exception.error        if exception.respond_to?(:error)
+    error ||= exception.message      if exception.respond_to?(:message)
     error ||= env["omniauth.error.type"].to_s
     error.to_s.humanize if error
   end


### PR DESCRIPTION
I was working on an [omniauth-saml][1] integration and was getting very generic 'invalid ticket' error messages while trying to get the authentication working. I found that there were more descriptive error messages available, but the way the controller is set up it does not check for the message from `Exception`.

This small addition fixes that, it checks for the `message` and returns that when found. I think this is desirable behaviour, the way [omniauth-saml is set up][2] is that it returns an instance from a class that [inherit from `Exception`][3] and has the actual error in the `message` field.

Not entirely sure if this also works for other omniauth gems, but since the code already uses `exception` as a variable, I think it doesn't do harm to check the message field of `Exception` as it's implemented by default in Ruby.

I couldn't find any tests related to this controller, if additional tests are needed, please let me know.

[1]: https://github.com/PracticallyGreen/omniauth-saml
[2]: https://github.com/PracticallyGreen/omniauth-saml/blob/master/lib/omniauth/strategies/saml.rb#L65-L68
[3]: https://github.com/PracticallyGreen/omniauth-saml/blob/master/lib/omniauth/strategies/saml/validation_error.rb