### PR TITLE
Drop unneeded argument

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -9,7 +9,7 @@ class Devise::ConfirmationsController < DeviseController
     self.resource = resource_class.send_confirmation_instructions(resource_params)
     yield resource if block_given?
 
-    if successfully_sent?(resource)
+    if successfully_sent?
       respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
     else
       respond_with(resource)

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -13,7 +13,7 @@ class Devise::PasswordsController < DeviseController
     self.resource = resource_class.send_reset_password_instructions(resource_params)
     yield resource if block_given?
 
-    if successfully_sent?(resource)
+    if successfully_sent?
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
     else
       respond_with(resource)
@@ -33,7 +33,7 @@ class Devise::PasswordsController < DeviseController
     yield resource if block_given?
 
     if resource.errors.empty?
-      resource.unlock_access! if unlockable?(resource)
+      resource.unlock_access! if unlockable?
       if Devise.sign_in_after_reset_password
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message(:notice, flash_message) if is_flashing_format?
@@ -67,7 +67,7 @@ class Devise::PasswordsController < DeviseController
 
     # Check if proper Lockable module methods are present & unlock strategy
     # allows to unlock resource on password reset
-    def unlockable?(resource)
+    def unlockable?
       resource.respond_to?(:unlock_access!) &&
         resource.respond_to?(:unlock_strategy_enabled?) &&
         resource.unlock_strategy_enabled?(:email)

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -11,7 +11,7 @@ class Devise::UnlocksController < DeviseController
     self.resource = resource_class.send_unlock_instructions(resource_params)
     yield resource if block_given?
 
-    if successfully_sent?(resource)
+    if successfully_sent?
       respond_with({}, location: after_sending_unlock_instructions_path_for(resource))
     else
       respond_with(resource)

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -114,7 +114,7 @@ MESSAGE
   # Helper for use after calling send_*_instructions methods on a resource.
   # If we are in paranoid mode, we always act as if the resource was valid
   # and instructions were sent.
-  def successfully_sent?(resource)
+  def successfully_sent?
     notice = if Devise.paranoid
       resource.errors.clear
       :send_paranoid_instructions


### PR DESCRIPTION
Don't pass attribute values as method arguments.