### PR TITLE
Remove ActionController::RackDelegation for Rails 5 support

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -6,7 +6,9 @@ module Devise
   # page based on current scope and mapping. If no scope is given, redirect
   # to the default_url.
   class FailureApp < ActionController::Metal
-    include ActionController::RackDelegation
+    if Rails::VERSION::MAJOR < 5
+      include ActionController::RackDelegation
+    end
     include ActionController::UrlFor
     include ActionController::Redirecting
 

--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -82,6 +82,10 @@ RUBY
         Rails.version.start_with? '4'
       end
 
+      def rails5?
+        Rails.version.start_with? '5'
+      end
+
       def postgresql?
         config = ActiveRecord::Base.configurations[Rails.env]
         config && config['adapter'] == 'postgresql'

--- a/test/rails_app/config/boot.rb
+++ b/test/rails_app/config/boot.rb
@@ -3,9 +3,13 @@ unless defined?(DEVISE_ORM)
 end
 
 module Devise
-  # Detection for minor differences between Rails 3.2 and 4 in tests.
+  # Detection for minor differences between Rails 3.2, 4 and 5 in tests.
   def self.rails4?
     Rails.version.start_with? '4'
+  end
+
+  def self.rails5?
+    Rails.version.start_with? '5'
   end
 end
 


### PR DESCRIPTION
First fixes for Rails 5 support.