### PR TITLE
Custom Error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Caution: Devise Controllers inherit from ApplicationController. If your app uses
 
 Devise includes some options to customise devise error messages. There are two options -
 
-* `head: false` - to skip from showing error message head part (like `2 errors prohibited this user from being saved:`). default value is true.
+* `head: false` - to skip from showing error message head part (for example `"2 errors prohibited this user from being saved:"`). default value is true.
 * `full_messages: false` - to skip from adding attribute name from starting of error messages. default value is true.
 
 Use code below to skip head part from error message:

--- a/README.md
+++ b/README.md
@@ -401,6 +401,31 @@ https://github.com/plataformatec/devise/wiki/I18n
 
 Caution: Devise Controllers inherit from ApplicationController. If your app uses multiple locales, you should be sure to set I18n.locale in ApplicationController.
 
+### Customise error message
+
+Devise includes some options to customise devise error messages. There are two options -
+
+* `head: false` - to skip from showing error message head part (like `2 errors prohibited this user from being saved:`). default value is true.
+* `full_messages: false` - to skip from adding attribute name from starting of error messages. default value is true.
+
+Use code below to skip head part from error message:
+
+```ruby
+devise_error_messages! head: false
+```
+
+User code below to skip starting attribute name from error messages (show only message from I18n yml files):
+
+```ruby
+devise_error_messages! full_messages: false
+```
+
+User code below to skip both head and starting attribute name from error messages:
+
+```ruby
+devise_error_messages! head: false, full_messages: false
+```
+
 ### Test helpers
 
 Devise includes some test helpers for functional specs. In order to use them, you need to include Devise in your functional tests by adding the following to the bottom of your `test/test_helper.rb` file:

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,24 +1,40 @@
 module DeviseHelper
+  # set { full_messages: false } if you need messages by skipping started attribute name, default value true
+  # set { head: false } if you need to avoid head part of error messages, default value true
+  #
   # A simple way to show error messages for the current devise resource. If you need
   # to customize this method, you can either overwrite it in your application helpers or
   # copy the views to your application.
   #
   # This method is intended to stay simple and it is unlikely that we are going to change
   # it to add more behavior or options.
-  def devise_error_messages!
-    return "" if resource.errors.empty?
+  def devise_error_messages!(**options)
+    return '' if resource.errors.empty?
 
-    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
-    sentence = I18n.t("errors.messages.not_saved",
+    if options.has_key?(:full_messages) && options[:full_messages] == false
+      messages = resource.errors.messages.map {|att, messages| messages.map { |msg| content_tag(:li, msg) }.join }.join
+    else
+      messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    end
+
+    sentence = I18n.t('errors.messages.not_saved',
                       count: resource.errors.count,
                       resource: resource.class.model_name.human.downcase)
 
-    html = <<-HTML
-    <div id="error_explanation">
-      <h2>#{sentence}</h2>
-      <ul>#{messages}</ul>
-    </div>
-    HTML
+    if options.has_key?(:head) && options[:head] == false
+      html = <<-HTML
+      <div id="error_explanation">
+        <ul>#{messages}</ul>
+      </div>
+      HTML
+    else
+      html = <<-HTML
+      <div id="error_explanation">
+        <h2>#{sentence}</h2>
+        <ul>#{messages}</ul>
+      </div>
+      HTML
+    end
 
     html.html_safe
   end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -8,10 +8,12 @@ module DeviseHelper
   #
   # This method is intended to stay simple and it is unlikely that we are going to change
   # it to add more behavior or options.
-  def devise_error_messages!(**options)
+  def devise_error_messages!(*options)
     return '' if resource.errors.empty?
 
-    if options.has_key?(:full_messages) && options[:full_messages] == false
+    params = options[0].present? ? options[0] : {}
+
+    if params.has_key?(:full_messages) && params[:full_messages] == false
       messages = resource.errors.messages.map {|att, messages| messages.map { |msg| content_tag(:li, msg) }.join }.join
     else
       messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
@@ -21,7 +23,7 @@ module DeviseHelper
                       count: resource.errors.count,
                       resource: resource.class.model_name.human.downcase)
 
-    if options.has_key?(:head) && options[:head] == false
+    if params.has_key?(:head) && params[:head] == false
       html = <<-HTML
       <div id="error_explanation">
         <ul>#{messages}</ul>


### PR DESCRIPTION
Most of time developers needed to customize devise error messages. In this case they needed to override helper method. As so I customize the devise_error_messages! helper method.