### PR TITLE
Automatically underscore and pluralize scoped views generator

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -47,7 +47,7 @@ module Devise
       def view_directory(name, _target_path = nil)
         directory name.to_s, _target_path || "#{target_path}/#{name}" do |content|
           if scope
-            content.gsub "devise/shared/links", "#{scope}/shared/links"
+            content.gsub "devise/shared/links", "#{plural_scope}/shared/links"
           else
             content
           end
@@ -55,7 +55,11 @@ module Devise
       end
 
       def target_path
-        @target_path ||= "app/views/#{scope || :devise}"
+        @target_path ||= "app/views/#{plural_scope || :devise}"
+      end
+
+      def plural_scope
+        @plural_scope ||= scope.presence && scope.underscore.pluralize
       end
     end
 
@@ -118,7 +122,7 @@ module Devise
       end
 
       def target_path
-        "app/views/#{scope || :devise}/mailer"
+        "app/views/#{plural_scope || :devise}/mailer"
       end
     end
 


### PR DESCRIPTION
This fixes issue #3790.

Example of previous functionality. This basically just doesn't match up with what Devise expects when rendering the views:
```bash
rails g devise AdminUser
rails g devise:views AdminUser # incorrectly generates the folder name
=>      create    app/views/AdminUser/shared
```

When rendering the scoped views, Devise will always look for the underscored and pluralized folder name, so this trips up a few people.

Fixed version:

```bash
rails g devise AdminUser
rails g devise:views AdminUser # correctly underscores and pluralizes the scope
=>      create    app/views/admin_users/shared
```