### PR TITLE
save in after_create hook breaks devise confirmation

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -254,7 +254,7 @@ module Devise
         end
 
         def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && email_was != "" && !@bypass_confirmation_postpone && self.email.present?
+          postpone = self.class.reconfirmable && email_changed? && email_was.present? && !@bypass_confirmation_postpone && self.email.present?
           @bypass_confirmation_postpone = false
           postpone
         end

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -254,7 +254,7 @@ module Devise
         end
 
         def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && self.email.present?
+          postpone = self.class.reconfirmable && email_changed? && email_was != "" && !@bypass_confirmation_postpone && self.email.present?
           @bypass_confirmation_postpone = false
           postpone
         end


### PR DESCRIPTION
the confirmable.rb module has a before_create method that generates a confirmation token and a before_update method that calls method :postpone_email_change_until_confirmation_and_regenerate_confirmation_token

Apparently, the second method, recognizes that the email changes from empty string to the one specified and triggers true for method email_changed? 