### PR TITLE
Fix infinite redirect fix that broke engine routes

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -22,7 +22,7 @@ module Devise
       @respond.call(env)
     end
 
-    # Try retrieving the URL options from the parent controller (usually 
+    # Try retrieving the URL options from the parent controller (usually
     # ApplicationController). Instance methods are not supported at the moment,
     # so only the class-level attribute is used.
     def self.default_url_options(*args)
@@ -121,17 +121,17 @@ module Devise
 
       config = Rails.application.config
 
-      # Rails 4.2 goes into an infinite loop if opts[:script_name] is unset
-      if (Rails::VERSION::MAJOR >= 4) && (Rails::VERSION::MINOR >= 2)
-        opts[:script_name] = (config.relative_url_root if config.respond_to?(:relative_url_root))
-      else
-        if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
-          opts[:script_name] = config.relative_url_root
-        end
-      end
-
       router_name = Devise.mappings[scope].router_name || Devise.available_router_name
       context = send(router_name)
+
+      if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
+        opts[:script_name] = config.relative_url_root
+      elsif (context_script_name = env["ROUTES_#{context.routes.object_id}_SCRIPT_NAME"])
+        opts[:script_name] = context_script_name
+      elsif (Rails::VERSION::MAJOR >= 4) && (Rails::VERSION::MINOR >= 2)
+        # Rails 4.2 goes into an infinite loop if opts[:script_name] is unset
+        opts[:script_name] = nil
+      end
 
       if context.respond_to?(route)
         context.send(route, opts)


### PR DESCRIPTION
In Rails 4.2 it appears that not setting :script_name causes routes to
be computed within mount points that don’t actually contain a devise
scope (see #3643). Commit aa675f7 unfortunately sets :script_name to
nil for Rails 4.2, preventing routes from being computed in their
correct contexts.

This commit recovers the :script_name from env should the found context
be that of an engine allowing correct route generation, while still
setting :script_name to nil in Rails 4.2 for all other cases.