### PR TITLE
Allow skipping the timeoutable hook

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -7,7 +7,8 @@ Warden::Manager.after_set_user do |record, warden, options|
   scope = options[:scope]
   env   = warden.request.env
 
-  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) && options[:store] != false
+  if record && record.respond_to?(:timedout?) && warden.authenticated?(scope) &&
+     options[:store] != false && !env['devise.skip_timeoutable']
     last_request_at = warden.session(scope)['last_request_at']
 
     if last_request_at.is_a? Integer

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -24,6 +24,18 @@ class SessionTimeoutTest < ActionDispatch::IntegrationTest
     assert_equal old_last_request, last_request_at
   end
 
+  test 'does not set last request at in user session after each request if timeoutable is disabled' do
+    sign_in_as_user
+    old_last_request = last_request_at
+    assert_not_nil last_request_at
+
+    new_time = 2.seconds.from_now
+    Time.stubs(:now).returns(new_time)
+
+    get users_path, {}, 'devise.skip_timeoutable' => true
+    assert_equal old_last_request, last_request_at
+  end
+
   test 'does not time out user session before default limit time' do
     sign_in_as_user
     assert_response :success


### PR DESCRIPTION
I was working on a "session timer" functionality in my current project and making requests without changing `last_request_at` was very useful. What do you think?