### PR TITLE
Allow passwords

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -40,7 +40,7 @@ module Devise
       # Generates password encryption based on the given value.
       def password=(new_password)
         @password = new_password
-        self.encrypted_password = password_digest(@password) if @password.present?
+        self.encrypted_password = password_digest(@password) unless @password.nil? || @password.empty?
       end
 
       # Verifies whether a password (ie from sign in) is the user password.

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -113,6 +113,10 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_blank new_user(password: '').encrypted_password
   end
 
+  test 'should generate encrypted password if password has only whitespaces' do
+    assert_present new_user(password: '      ').encrypted_password
+  end
+
   test 'should encrypt password again if password has changed' do
     user = create_user
     encrypted_password = user.encrypted_password


### PR DESCRIPTION
`.present?` returns `false` for whitespace-only strings.

Since passwords with only whitespaces are also valid, we should allow them.