### PR TITLE
set minimum password length on reset failure

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -43,6 +43,7 @@ class Devise::PasswordsController < DeviseController
       end
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
+      set_minimum_password_length
       respond_with resource
     end
   end


### PR DESCRIPTION
On the reset password form, if the form is invalid, the `@minimum_password_length` variable is not set. This PR fix that by calling `set_minimum_password_length` in the update method. I can add some tests if needed :)