### PR TITLE
Add scoped sessions to TestHelpers module

### DIFF
--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -13,6 +13,16 @@ module Devise
       end
     end
 
+    def self.define_helpers(mapping)
+      mapping ||= :user
+
+      class_eval <<-METHODS, __FILE__, __LINE__ + 1
+        def #{mapping}_session
+          warden.session(:#{mapping})
+        end
+      METHODS
+    end
+
     # Override process to consider warden.
     def process(*)
       # Make sure we always return @response, a la ActionController::TestCase::Behaviour#process, even if warden interrupts
@@ -22,6 +32,7 @@ module Devise
     # We need to setup the environment variables and the response in the controller.
     def setup_controller_for_warden #:nodoc:
       @request.env['action_controller.instance'] = @controller
+      TestHelpers::define_helpers(:user)
     end
 
     # Quick access to Warden::Proxy.

--- a/test/test_helpers_test.rb
+++ b/test/test_helpers_test.rb
@@ -161,6 +161,30 @@ class TestHelpersTest < ActionController::TestCase
     assert_match /User ##{second_user.id}/, @response.body
   end
 
+  test "user_session exposed to signed in test case" do
+    first_user = create_user
+    first_user.confirm
+    sign_in first_user
+
+    user_session['test'] = 'testing'
+    assert_match /testing/, user_session['test'] 
+  end
+
+  test "custom session exposed to signed in test case" do
+    first_admin = create_admin
+    first_admin.confirm
+    sign_in :admin, first_admin
+
+    Devise::TestHelpers::define_helpers(:admin)
+
+    admin_session['test'] = 'testing'
+    assert_match /testing/, admin_session['test'] 
+  end
+
+  test "user_session fails if not logged in" do
+    assert_raises(Warden::NotAuthenticated) { user_session['test'] = 'testing' }
+  end
+
   test "creates a new warden proxy if the request object has changed" do
     old_warden_proxy = warden
     @request = ActionController::TestRequest.new


### PR DESCRIPTION
Hello!

I've added support for scoped sessions to the `TestHelper` module. Many applications use the `user_session` or `admin_session`, and the code in this branch should allow people to cover more of that functionality inside of their tests.

I've included several basic tests in `test_helpers_tests.rb` to demonstrate usage and guarantee scoped sessions can only be used in tests once a `sign_in` has occurred. 

Thanks for the great Gem! Hope my additions are helpful.