### PR TITLE
Don't error if resource doesn't need confirming

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -216,7 +216,7 @@ module Devise
         #   confirmation_period_expired?  # will always return false
         #
         def confirmation_period_expired?
-          self.class.confirm_within && (Time.now > self.confirmation_sent_at + self.class.confirm_within)
+          self.class.confirm_within && self.confirmation_sent_at && (Time.now > self.confirmation_sent_at + self.class.confirm_within)
         end
 
         # Checks whether the record requires any confirmation.

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -250,6 +250,16 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert user.reload.active_for_authentication?
   end
 
+  test 'should not break when a user tries to reset their password in the case where confirmation is not required and confirm_within is set' do
+    swap Devise, confirm_within: 3.days do
+      user = create_user
+      user.instance_eval { def confirmation_required?; false end }
+      user.confirmation_sent_at = nil
+      user.save
+      assert user.reload.confirm!
+    end
+  end
+
   test 'should find a user to send email instructions for the user confirm its email by authentication_keys' do
     swap Devise, authentication_keys: [:username, :email] do
       user = create_user


### PR DESCRIPTION
I've overridden #confirmation_required? in my application so that only certain classes of users require it, and as a result resetting passwords has broken. This small tweak fixes it.
This time with a test.