### PR TITLE
Replaced `alias_method_chain` with `Module.prepend`

### DIFF
--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -1,4 +1,5 @@
 require 'devise/rails/routes'
+require 'devise/rails/route_set'
 require 'devise/rails/warden_compat'
 
 module Devise

--- a/lib/devise/rails/route_set.rb
+++ b/lib/devise/rails/route_set.rb
@@ -1,0 +1,27 @@
+require "active_support/core_ext/object/try"
+
+module ActionDispatch::Routing
+  module RouteSetFinalizeWithDevise
+    def finalize!
+      result = super
+
+      @devise_finalized ||= begin
+        if Devise.router_name.nil? && defined?(@devise_finalized) && self != Rails.application.try(:routes)
+          warn "[DEVISE] We have detected that you are using devise_for inside engine routes. " \
+            "In this case, you probably want to set Devise.router_name = MOUNT_POINT, where "   \
+            "MOUNT_POINT is a symbol representing where this engine will be mounted at. For "   \
+            "now Devise will default the mount point to :main_app. You can explicitly set it"   \
+            " to :main_app as well in case you want to keep the current behavior."
+        end
+
+        Devise.configure_warden!
+        Devise.regenerate_helpers!
+        true
+      end
+
+      result
+    end
+  end
+end
+
+ActionDispatch::Routing::RouteSet.prepend(ActionDispatch::Routing::RouteSetFinalizeWithDevise)

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -2,31 +2,6 @@ require "active_support/core_ext/object/try"
 require "active_support/core_ext/hash/slice"
 
 module ActionDispatch::Routing
-  class RouteSet #:nodoc:
-    # Ensure Devise modules are included only after loading routes, because we
-    # need devise_for mappings already declared to create filters and helpers.
-    def finalize_with_devise!
-      result = finalize_without_devise!
-
-      @devise_finalized ||= begin
-        if Devise.router_name.nil? && defined?(@devise_finalized) && self != Rails.application.try(:routes)
-          warn "[DEVISE] We have detected that you are using devise_for inside engine routes. " \
-            "In this case, you probably want to set Devise.router_name = MOUNT_POINT, where "   \
-            "MOUNT_POINT is a symbol representing where this engine will be mounted at. For "   \
-            "now Devise will default the mount point to :main_app. You can explicitly set it"   \
-            " to :main_app as well in case you want to keep the current behavior."
-        end
-
-        Devise.configure_warden!
-        Devise.regenerate_helpers!
-        true
-      end
-
-      result
-    end
-    alias_method_chain :finalize!, :devise
-  end
-
   class Mapper
     # Includes devise_for method for routes. This method is responsible to
     # generate all needed routes for devise, based on what modules you have


### PR DESCRIPTION
Summary of changes made:

- Removed class `ActionDispatch::Routing::RouteSet` (/lib/devise/rails/routes.rb)

- Created file /lib/devise/rails/route_set.rb and defined module `ActionDispatch::Routing::RouteSetFinalizeWithDevise` and added

`ActionDispatch::Routing::RouteSet.prepend(ActionDispatch::Routing::RouteSetFinalizeWithDevise)`