### PR TITLE
test for save in after_create hook breaks devise confirmation [3787]

### DIFF
--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -476,4 +476,18 @@ class ReconfirmableTest < ActiveSupport::TestCase
       :unconfirmed_email
     ]
   end
+
+  test 'should not require reconfirmation after creating a record' do
+    user = create_admin
+    assert !user.pending_reconfirmation?
+  end
+
+  test 'should not require reconfirmation after creating a record with #save called in callback' do
+    class Admin::WithSaveInCallback < Admin
+      after_create :save
+    end
+
+    user = Admin::WithSaveInCallback.create(valid_attributes.except(:username))
+    assert !user.pending_reconfirmation?
+  end
 end


### PR DESCRIPTION
Hi!

I would like to start contributing to Devise as a thank you for a great project. 
I've noticed [this](https://github.com/plataformatec/devise/pull/3793) PR. It fixes https://github.com/plataformatec/devise/issues/3787, but has [no tests](https://github.com/plataformatec/devise/pull/3793#issuecomment-156698377). I thought that adding this test could be a good start. So there it is.