### PR TITLE
Allow resources with no email field to be recoverable

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -28,7 +28,7 @@ module Devise
 
       included do
         before_save do
-          if email_changed? || encrypted_password_changed?
+          if (respond_to?(:email_changed?) && email_changed?) || encrypted_password_changed?
             clear_reset_password_token
           end
         end

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -65,6 +65,18 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_nil user.reset_password_token
   end
 
+  test 'should clear reset password successfully even if there is no email' do
+    user = create_user_without_email
+    assert_nil user.reset_password_token
+
+    user.send_reset_password_instructions
+    assert_present user.reset_password_token
+    user.password = "123456678"
+    user.password_confirmation = "123456678"
+    user.save!
+    assert_nil user.reset_password_token
+  end
+
   test 'should not clear reset password token if record is invalid' do
     user = create_user
     user.send_reset_password_instructions

--- a/test/rails_app/app/active_record/user_without_email.rb
+++ b/test/rails_app/app/active_record/user_without_email.rb
@@ -1,0 +1,8 @@
+require "shared_user_without_email"
+
+class UserWithoutEmail < ActiveRecord::Base
+  self.table_name = 'users'
+  include Shim
+  include SharedUserWithoutEmail
+end
+

--- a/test/rails_app/app/mongoid/user_without_email.rb
+++ b/test/rails_app/app/mongoid/user_without_email.rb
@@ -1,0 +1,33 @@
+require "shared_user_without_email"
+
+class UserWithoutEmail
+  include Mongoid::Document
+  include Shim
+  include SharedUserWithoutEmail
+
+  field :username, type: String
+  field :facebook_token, type: String
+
+  ## Database authenticatable
+  field :email, type: String, default: ""
+  field :encrypted_password, type: String, default: ""
+
+  ## Recoverable
+  field :reset_password_token, type: String
+  field :reset_password_sent_at, type: Time
+
+  ## Rememberable
+  field :remember_created_at, type: Time
+
+  ## Trackable
+  field :sign_in_count, type: Integer, default: 0
+  field :current_sign_in_at, type: Time
+  field :last_sign_in_at, type: Time
+  field :current_sign_in_ip, type: String
+  field :last_sign_in_ip, type: String
+
+  ## Lockable
+  field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
+  field :unlock_token, type: String # Only if unlock strategy is :email or :both
+  field :locked_at, type: Time
+end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -28,6 +28,11 @@ Rails.application.routes.draw do
     router_name: :fake_engine,
     module: :devise
 
+  devise_for :user_without_email,
+    class_name: 'UserWithoutEmail',
+    router_name: :main_app,
+    module: :devise
+
   as :user do
     get "/as/sign_in", to: "devise/sessions#new"
   end

--- a/test/rails_app/lib/shared_user_without_email.rb
+++ b/test/rails_app/lib/shared_user_without_email.rb
@@ -1,0 +1,26 @@
+module SharedUserWithoutEmail
+  extend ActiveSupport::Concern
+
+  included do
+    # NOTE: This is missing :validatable and :confirmable, as they both require
+    # an email field at the moment. It is also missing :omniauthable because that
+    # adds unnecessary complexity to the setup
+    devise :database_authenticatable, :lockable, :recoverable,
+           :registerable, :rememberable, :timeoutable,
+           :trackable
+  end
+
+  # This test stub is a bit rubbish because it's tied very closely to the
+  # implementation where we care about this one case. However, completely
+  # removing the email field breaks "recoverable" tests completely, so we are
+  # just taking the approach here that "email" is something that is a not an
+  # ActiveRecord field.
+  def email_changed?
+    raise NoMethodError
+  end
+
+  def respond_to?(method_name, include_all=false)
+    return false if method_name.to_sym == :email_changed?
+    super(method_name, include_all)
+  end
+end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -46,6 +46,10 @@ class ActiveSupport::TestCase
     Admin.create!(valid_attributes)
   end
 
+  def create_user_without_email(attributes={})
+    UserWithoutEmail.create!(valid_attributes(attributes))
+  end
+
   # Execute the block setting the given values and restoring old values after
   # the block is executed.
   def swap(object, new_values)


### PR DESCRIPTION
@josevalim - raising this PR folling the discussions on [this commit](https://github.com/plataformatec/devise/commit/e641b4b7b97159054b7d92fb14df557ac18ae6f4)

The current implementation is opinionated in that the resource should have
an "email" column on it if it is to be recoverable, which isn't
necessarily the case.  For example, developers may decide to pull emails
out into their own model or have some other way of communicating
password resets to their users (e.g. text message)

I'm not sure there's an easy test to put together for this case, as
minitest doesn't make it very easy to stub the "email_changed?" to raise
an error. Happy to look into building another model in the
"test/rails_app" if you want to have this properly tested though? Or for
a nice way to get calls to "email_changed?" to raise; minitest isn't
a test framework I'm overly familiar with :).

As a side note, it would be nice if the Validatable module also took
this into account, I may raise another PR for that.