### PR TITLE
Only clear the reset token on an update

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -27,7 +27,7 @@ module Devise
       end
 
       included do
-        before_save do
+        before_update do
           if (respond_to?(:email_changed?) && email_changed?) || encrypted_password_changed?
             clear_reset_password_token
           end

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -42,6 +42,17 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_nil user.reset_password_token
   end
 
+  test 'should not clear reset password token for new user' do
+    user = new_user
+    assert_nil user.reset_password_token
+
+    user.send_reset_password_instructions
+    assert_present user.reset_password_token
+
+    user.save
+    assert_present user.reset_password_token
+  end
+
   test 'should clear reset password token if changing password' do
     user = create_user
     assert_nil user.reset_password_token


### PR DESCRIPTION
This solves the issue where a package might do:

```ruby
user = User.new
user.email = 'test@test.com'
token = user.generate_reset_token
user.save

send_reset_email(token)
```

Since the save clears the reset token, the user will receive a stale token that no longer works.

Closes #3774