### PR TITLE
Comparing times in UTC 

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -83,7 +83,7 @@ module Devise
       #   reset_password_period_valid?   # will always return false
       #
       def reset_password_period_valid?
-        reset_password_sent_at && reset_password_sent_at.utc >= self.class.reset_password_within.ago
+        reset_password_sent_at && reset_password_sent_at.utc >= self.class.reset_password_within.ago.utc
       end
 
       protected


### PR DESCRIPTION
`reset_password_period_valid?` returns false if rails application works in singapore time zone. 

```
# config/initializers/devise.rb
config.reset_password_within = 6.hours
```

```
user.reset_password_sent_at.utc
=> 2015-12-15 06:57:26 UTC
User.reset_password_within.ago
=> Tue, 15 Dec 2015 08:59:57 SGT +08:00

user.reset_password_sent_at.utc >= User.reset_password_within.ago
=> false
```