### PR TITLE
Remove `ParametersSanitizer` inheritance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :username
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
   end
 end
 ```
@@ -212,7 +212,9 @@ To permit simple scalar values for username and email, use this
 
 ```ruby
 def configure_permitted_parameters
-  devise_parameter_sanitizer.for(:sign_in) { |u| u.permit(:username, :email) }
+  devise_parameter_sanitizer.permit(:sign_in) do |user_params|
+    user_params.permit(:username, :email)
+  end
 end
 ```
 
@@ -220,7 +222,9 @@ If you have some checkboxes that express the roles a user may take on registrati
 
 ```ruby
 def configure_permitted_parameters
-  devise_parameter_sanitizer.for(:sign_up) { |u| u.permit({ roles: [] }, :email, :password, :password_confirmation) }
+  devise_parameter_sanitizer.permit(:sign_up) do |user_params|
+    user_params.permit({ roles: [] }, :email, :password, :password_confirmation)
+  end
 end
 ```
 For the list of permitted scalars, and how to declare permitted keys in nested hashes and arrays, see
@@ -231,8 +235,9 @@ If you have multiple Devise models, you may want to set up a different parameter
 
 ```ruby
 class User::ParameterSanitizer < Devise::ParameterSanitizer
-  def sign_in
-    default_params.permit(:username, :email)
+  def initialize(*)
+    super
+    permit(:sign_up, keys: [:username, :email])
   end
 end
 ```

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -12,7 +12,6 @@ module Devise
   autoload :FailureApp,         'devise/failure_app'
   autoload :OmniAuth,           'devise/omniauth'
   autoload :ParameterFilter,    'devise/parameter_filter'
-  autoload :BaseSanitizer,      'devise/parameter_sanitizer'
   autoload :ParameterSanitizer, 'devise/parameter_sanitizer'
   autoload :TestHelpers,        'devise/test_helpers'
   autoload :TimeInflector,      'devise/time_inflector'

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -154,11 +154,7 @@ module Devise
       # lib/devise/parameter_sanitizer.rb for more info. Override this
       # method in your application controller to use your own parameter sanitizer.
       def devise_parameter_sanitizer
-        @devise_parameter_sanitizer ||= if defined?(ActionController::StrongParameters)
-          Devise::ParameterSanitizer.new(resource_class, resource_name, params)
-        else
-          Devise::BaseSanitizer.new(resource_class, resource_name, params)
-        end
+        @devise_parameter_sanitizer ||= Devise::ParameterSanitizer.new(resource_class, resource_name, params)
       end
 
       # Tell warden that params authentication is allowed for that specific page.

--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -1,99 +1,208 @@
 module Devise
-  class BaseSanitizer
-    attr_reader :params, :resource_name, :resource_class
+  # The +ParameterSanitizer+ deals with permitting specific parameters values
+  # for each +Devise+ scope in the application.
+  #
+  # The sanitizer knows about Devise default parameters (like +password+ and
+  # +password_confirmation+ for the `RegistrationsController`), and you can
+  # extend or change the permitted parameters list on your controllers.
+  #
+  # === Permitting new parameters
+  #
+  # You can add new parameters to the permitted list using the +permit+ method
+  # in a +before_action+ method, for instance.
+  #
+  #    class ApplicationController < ActionController::Base
+  #      before_action :configure_permitted_parameters, if: :devise_controller?
+  #
+  #      protected
+  #
+  #      def configure_permitted_parameters
+  #        # Permit the `subscribe_newsletter` parameter along with the other
+  #        # sign up parameters.
+  #        devise_parameter_sanitizer.permit(:sign_up, keys: [:subscribe_newsletter])
+  #      end
+  #    end
+  #
+  # Using a block yields an +ActionController::Parameters+ object so you can
+  # permit nested parameters and have more control over how the parameters are
+  # permitted in your controller.
+  #
+  #    def configure_permitted_parameters
+  #      devise_parameter_sanitizer.permit(:sign_up) do |user|
+  #        user.permit(newsletter_preferences: [])
+  #      end
+  #    end
+  class ParameterSanitizer
+    DEFAULT_PERMITTED_ATTRIBUTES = {
+      sign_in: [:password, :remember_me],
+      sign_up: [:password, :password_confirmation],
+      account_update: [:password, :password_confirmation, :current_password]
+    }
 
     def initialize(resource_class, resource_name, params)
-      @resource_class = resource_class
-      @resource_name  = resource_name
+      @auth_keys      = extract_auth_keys(resource_class)
       @params         = params
-      @blocks         = Hash.new
-    end
+      @resource_name  = resource_name
+      @permitted      = {}
 
-    def for(kind, &block)
-      if block_given?
-        @blocks[kind] = block
-      else
-        default_for(kind)
+      DEFAULT_PERMITTED_ATTRIBUTES.each_pair do |action, keys|
+        permit(action, keys: keys)
       end
     end
 
-    def sanitize(kind)
-      if block = @blocks[kind]
-        block.call(default_params)
+    # Sanitize the parameters for a specific +action+.
+    #
+    # === Arguments
+    #
+    # * +action+ - A +Symbol+ with the action that the controller is
+    #   performing, like +sign_up+, +sign_in+, etc.
+    #
+    # === Examples
+    #
+    #    # Inside the `RegistrationsController#create` action.
+    #    resource = build_resource(devise_parameter_sanitizer.sanitize(:sign_up))
+    #    resource.save
+    #
+    # Returns an +ActiveSupport::HashWithIndifferentAccess+ with the permitted
+    # attributes.
+    def sanitize(action)
+      permissions = @permitted[action]
+
+      # DEPRECATED: Remove this branch on Devise 4.1.
+      if respond_to?(action, true)
+        deprecate_instance_method_sanitization(action)
+        return send(action)
+      end
+
+      if permissions.respond_to?(:call)
+        cast_to_hash permissions.call(default_params)
+      elsif permissions.present?
+        cast_to_hash permit_keys(default_params, permissions)
       else
-        default_sanitize(kind)
+        unknown_action!(action)
+      end
+    end
+
+    # Add or remove new parameters to the permitted list of an +action+.
+    #
+    # === Arguments
+    #
+    # * +action+ - A +Symbol+ with the action that the controller is
+    #   performing, like +sign_up+, +sign_in+, etc.
+    # * +keys:+     - An +Array+ of keys that also should be permitted.
+    # * +except:+   - An +Array+ of keys that shouldn't be permitted.
+    # * +block+     - A block that should be used to permit the action
+    #   parameters instead of the +Array+ based approach. The block will be
+    #   called with an +ActionController::Parameters+ instance.
+    #
+    # === Examples
+    #
+    #   # Adding new parameters to be permitted in the `sign_up` action.
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:subscribe_newsletter])
+    #
+    #   # Removing the `password` parameter from the `account_update` action.
+    #   devise_parameter_sanitizer.permit(:account_update, except: [:password])
+    #
+    #   # Using the block form to completely override how we permit the
+    #   # parameters for the `sign_up` action.
+    #   devise_parameter_sanitizer.permit(:sign_up) do |user|
+    #     user.permit(:email, :password, :password_confirmation)
+    #   end
+    #
+    #
+    # Returns nothing.
+    def permit(action, keys: nil, except: nil, &block)
+      if block_given?
+        @permitted[action] = block
+      end
+
+      if keys.present?
+        @permitted[action] ||= @auth_keys.dup
+        @permitted[action].concat(keys)
+      end
+
+      if except.present?
+        @permitted[action] ||= @auth_keys.dup
+        @permitted[action] = @permitted[action] - except
+      end
+    end
+
+    # DEPRECATED: Remove this method on Devise 4.1.
+    def for(action, &block) # :nodoc:
+      if block_given?
+        deprecate_for_with_block(action)
+        permit(action, &block)
+      else
+        deprecate_for_without_block(action)
+        @permitted[action] or unknown_action!(action)
       end
     end
 
     private
 
-    def default_for(kind)
-      raise ArgumentError, "a block is expected in Devise base sanitizer"
-    end
-
-    def default_sanitize(kind)
-      default_params
+    # Cast a sanitized +ActionController::Parameters+ to a +HashWithIndifferentAccess+
+    # that can be used elsewhere.
+    #
+    # Returns an +ActiveSupport::HashWithIndifferentAccess+.
+    def cast_to_hash(params)
+      # TODO: Remove the `with_indifferent_access` method call when we only support Rails 5+.
+      params && params.to_h.with_indifferent_access
     end
 
     def default_params
-      params.fetch(resource_name, {})
-    end
-  end
-
-  class ParameterSanitizer < BaseSanitizer
-    def initialize(*)
-      super
-      @permitted = Hash.new { |h,k| h[k] = attributes_for(k) }
+      @params.fetch(@resource_name, {})
     end
 
-    def sign_in
-      permit self.for(:sign_in)
+    def permit_keys(parameters, keys)
+      parameters.permit(*keys)
     end
 
-    def sign_up
-      permit self.for(:sign_up)
+    def extract_auth_keys(klass)
+      auth_keys = klass.authentication_keys
+
+      auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys
     end
 
-    def account_update
-      permit self.for(:account_update)
+    def unknown_action!(action)
+      raise NotImplementedError, "Devise doesn't know how to sanitize parameters for #{action}"
     end
 
-    private
+    def deprecate_for_with_block(action)
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+        [Devise] Changing the sanitized parameters through "#{self.class.name}#for(#{action}) is deprecated and it will be removed from Devise 4.1.
+        Please use the `permit` method:
 
-    # TODO: We do need to flatten so it works with strong_parameters
-    # gem. We should drop it once we move to Rails 4 only support.
-    def permit(keys)
-      default_params.permit(*Array(keys))
+          devise_parameter_sanitizer.permit(:#{action}) do |user|
+            # Your block here.
+          end
+      MESSAGE
     end
 
-    # Change for(kind) to return the values in the @permitted
-    # hash, allowing the developer to customize at runtime.
-    def default_for(kind)
-      @permitted[kind] || raise("No sanitizer provided for #{kind}")
+    def deprecate_for_without_block(action)
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+        [Devise] Changing the sanitized parameters through "#{self.class.name}#for(#{action}) is deprecated and it will be removed from Devise 4.1.
+        Please use the `permit` method to add or remove any key:
+
+          To add any new key, use the `keys` keyword argument:
+          devise_parameter_sanitizer.permit(:#{action}, keys: [:key1, key2, key3])
+
+          To remove any existing key, use the `except` keyword argument:
+          devise_parameter_sanitizer.permit(:#{action}, except: [:email])
+      MESSAGE
     end
 
-    def default_sanitize(kind)
-      if respond_to?(kind, true)
-        send(kind)
-      else
-        raise NotImplementedError, "Devise doesn't know how to sanitize parameters for #{kind}"
-      end
-    end
+    def deprecate_instance_method_sanitization(action)
+      ActiveSupport::Deprecation.warn(<<-MESSAGE.strip_heredoc)
+        [Devise] Parameter sanitization through a "#{self.class.name}##{action}" method is deprecated and it will be removed from Devise 4.1.
+        Please use the `permit` method on your sanitizer `initialize` method.
 
-    def attributes_for(kind)
-      case kind
-      when :sign_in
-        auth_keys + [:password, :remember_me]
-      when :sign_up
-        auth_keys + [:password, :password_confirmation]
-      when :account_update
-        auth_keys + [:password, :password_confirmation, :current_password]
-      end
-    end
-
-    def auth_keys
-      @auth_keys ||= @resource_class.authentication_keys.respond_to?(:keys) ?
-                       @resource_class.authentication_keys.keys : @resource_class.authentication_keys
+          class #{self.class.name} < Devise::ParameterSanitizer
+            def initialize(*)
+              super
+              permit(:#{action}, keys: [:key1, :key2, :key3])
+            end
+          end
+      MESSAGE
     end
   end
 end


### PR DESCRIPTION
We no longer need to support the `BaseSanitizer` implementation for apps without
the Strong Parameters API, and this section is lacking a minimal set of
docs to document the expected behavior besides the `README` section.

An important change here is that `sanitize` now returns a `HashWIthIndifferentAccess` instead of an `ActionController::Parameters` as it doesn't inherits from `Hash` anymore, and our internals rely on it being a `Hash` that we can operate on (This is one of the headaches from supporting Rails 5).

I didn't documented the `for` method as I believe its API to be quite confusing at the moment. It can accept a block that is stored in the Sanitizer instance and it can mutate an existing `Array` and return it. I think we should normalize it and add a new method for customizing the sanitizer, and deprecate `for`.
My first sketch would be use `permit` instead (it is currently a private shortcut to `ActionController::Parameters#permit`).

```ruby
devise_parameter_sanitizer.permit(:sign_up, attributes: %i(firstname last name))
# or `keys` instead of `attributes`.
devise_parameter_sanitizer.permit(:sign_up, keys: %i(firstname last name))

# Block form.
devise_parameter_sanitizer.permit(:sign_up) do |user|
  user.permit(nested: [:foo, :bar])
end
```
