### PR TITLE
Explicitly permit rather than using to_unsafe_h

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -253,8 +253,11 @@ module Devise
 
         # Find or initialize a record with group of attributes based on a list of required attributes.
         def find_or_initialize_with_errors(required_attributes, attributes, error=:invalid) #:nodoc:
-          attributes = attributes.to_unsafe_h.with_indifferent_access if attributes.respond_to? :to_unsafe_h
-          attributes = attributes.slice(*required_attributes).with_indifferent_access
+          attributes = if attributes.respond_to? :permit
+            attributes.slice(*required_attributes).permit!.to_h.with_indifferent_access
+          else
+            attributes.with_indifferent_access.slice(*required_attributes)
+          end
           attributes.delete_if { |key, value| value.blank? }
 
           if attributes.size == required_attributes.size

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -314,8 +314,8 @@ module Devise
 
         # Find a record for confirmation by unconfirmed email field
         def find_by_unconfirmed_email_with_errors(attributes = {})
+          attributes = attributes.slice(*confirmation_keys).permit!.to_h if attributes.respond_to? :permit
           unconfirmed_required_attributes = confirmation_keys.map { |k| k == :email ? :unconfirmed_email : k }
-          attributes = attributes.to_unsafe_h if attributes.respond_to? :to_unsafe_h
           unconfirmed_attributes = attributes.symbolize_keys
           unconfirmed_attributes[:unconfirmed_email] = unconfirmed_attributes.delete(:email)
           find_or_initialize_with_errors(unconfirmed_required_attributes, unconfirmed_attributes, :not_found)

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -44,8 +44,7 @@ class HelpersTest < Devise::ControllerTestCase
 
     @controller.stubs(:params).returns(params)
 
-    res_params = @controller.send(:resource_params)
-    res_params = res_params.to_unsafe_h if res_params.respond_to? :to_unsafe_h
+    res_params = @controller.send(:resource_params).permit!.to_h
     assert_equal user_params, res_params
   end
 


### PR DESCRIPTION
When implementing the rails 5 updates I used ActionController::Parameters#to_unsafe_h in some methods. This changes those instances to explicitly permit expected parameters instead.