### PR TITLE
Remove `KeyGenerator` implementation ported from Rails 4.x.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
 
 GEM
@@ -183,4 +182,4 @@ DEPENDENCIES
   webrat (= 0.7.3)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency("warden", "~> 1.2.3")
   s.add_dependency("orm_adapter", "~> 0.1")
   s.add_dependency("bcrypt", "~> 3.0")
-  s.add_dependency("thread_safe", "~> 0.1")
   s.add_dependency("railties", ">= 4.1.0", "< 5.1")
   s.add_dependency("responders")
 end

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -39,7 +39,7 @@ module Devise
       Devise.token_generator ||=
         if secret_key = Devise.secret_key
           Devise::TokenGenerator.new(
-            Devise::CachingKeyGenerator.new(Devise::KeyGenerator.new(secret_key))
+            ActiveSupport::CachingKeyGenerator.new(ActiveSupport::KeyGenerator.new(secret_key))
           )
         end
     end

--- a/lib/devise/token_generator.rb
+++ b/lib/devise/token_generator.rb
@@ -1,11 +1,8 @@
-# Deprecate: Copied verbatim from Rails source, remove once we move to Rails 4 only.
-require 'thread_safe'
 require 'openssl'
-require 'securerandom'
 
 module Devise
   class TokenGenerator
-    def initialize(key_generator, digest="SHA256")
+    def initialize(key_generator, digest = "SHA256")
       @key_generator = key_generator
       @digest = digest
     end
@@ -28,43 +25,6 @@ module Devise
 
     def key_for(column)
       @key_generator.generate_key("Devise #{column}")
-    end
-  end
-
-  # KeyGenerator is a simple wrapper around OpenSSL's implementation of PBKDF2
-  # It can be used to derive a number of keys for various purposes from a given secret.
-  # This lets Rails applications have a single secure secret, but avoid reusing that
-  # key in multiple incompatible contexts.
-  class KeyGenerator
-    def initialize(secret, options = {})
-      @secret = secret
-      # The default iterations are higher than required for our key derivation uses
-      # on the off chance someone uses this for password storage
-      @iterations = options[:iterations] || 2**16
-    end
-
-    # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
-      OpenSSL::PKCS5.pbkdf2_hmac_sha1(@secret, salt, @iterations, key_size)
-    end
-  end
-
-  # CachingKeyGenerator is a wrapper around KeyGenerator which allows users to avoid
-  # re-executing the key generation process when it's called using the same salt and
-  # key_size
-  class CachingKeyGenerator
-    def initialize(key_generator)
-      @key_generator = key_generator
-      @cache_keys = ThreadSafe::Cache.new
-    end
-
-    # Returns a derived key suitable for use.  The default key_size is chosen
-    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
-    def generate_key(salt, key_size=64)
-      @cache_keys["#{salt}#{key_size}"] ||= @key_generator.generate_key(salt, key_size)
     end
   end
 end


### PR DESCRIPTION
We can now use Active Support implementation directly and let it handle the caching dependency `thread_safe` was replaced by `concurrent` for Rails 5).