### PR TITLE
 Send notification to user's old email address on email change

### DIFF
--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -12,6 +12,10 @@ if defined?(ActionMailer)
       devise_mail(record, :reset_password_instructions, opts)
     end
 
+    def reconfirmation_instructions(record,opts={})
+      devise_mail(record, :reconfirmation_instructions,opts)
+    end
+
     def unlock_instructions(record, token, opts={})
       @token = token
       devise_mail(record, :unlock_instructions, opts)

--- a/app/views/devise/mailer/reconfirmation_instructions.html.erb
+++ b/app/views/devise/mailer/reconfirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>Your confirmation instructions for email change has been sent to <%= @resource.unconfirmed_email %></p>
+
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
+      reconfirmation_instructions:
+        subject: "Confirmation instructions"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -111,8 +111,14 @@ module Devise
           generate_confirmation_token!
         end
 
-        opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
-        send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+        opts = {}
+        if pending_reconfirmation?
+          opts = { to: unconfirmed_email }
+          send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+          send_devise_notification(:reconfirmation_instructions)
+        else
+          send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+        end
       end
 
       def send_reconfirmation_instructions

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -267,7 +267,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
     click_link "Didn't receive confirmation instructions?"
 
     fill_in 'email', with: admin.unconfirmed_email
-    assert_difference "ActionMailer::Base.deliveries.size" do
+    assert_difference "ActionMailer::Base.deliveries.size", 2 do
       click_button 'Resend confirmation instructions'
     end
 

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -395,10 +395,12 @@ class ReconfirmableTest < ActiveSupport::TestCase
   test 'should send confirmation instructions by email after changing email' do
     admin = create_admin
     assert admin.confirm
-    assert_email_sent "new_test@example.com" do
+    assert_difference 'ActionMailer::Base.deliveries.size', 2 do
       assert admin.update_attributes(email: 'new_test@example.com')
     end
-    assert_match "new_test@example.com", ActionMailer::Base.deliveries.last.body.encoded
+    assert_equal admin.unconfirmed_email, ActionMailer::Base.deliveries.last(2).first['to'].to_s
+    assert_equal admin.email, ActionMailer::Base.deliveries.last['to'].to_s
+    assert_match admin.email, ActionMailer::Base.deliveries.last.body.encoded
   end
 
   test 'should not send confirmation by email after changing password' do


### PR DESCRIPTION
email notification is sent to user's old  email address when user changes his/her email in the application  
- Issue #3862
