### PR TITLE
Update controller generator templates for new ParameterSanitizer syntax

### DIFF
--- a/lib/generators/templates/controllers/registrations_controller.rb
+++ b/lib/generators/templates/controllers/registrations_controller.rb
@@ -40,12 +40,12 @@ class <%= @scope_prefix %>RegistrationsController < Devise::RegistrationsControl
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
-  #   devise_parameter_sanitizer.for(:sign_up) << :attribute
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
   # end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
-  #   devise_parameter_sanitizer.for(:account_update) << :attribute
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
   # end
 
   # The path used after sign up.

--- a/lib/generators/templates/controllers/sessions_controller.rb
+++ b/lib/generators/templates/controllers/sessions_controller.rb
@@ -20,6 +20,6 @@ class <%= @scope_prefix %>SessionsController < Devise::SessionsController
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
-  #   devise_parameter_sanitizer.for(:sign_in) << :attribute
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
 end


### PR DESCRIPTION
Hi, just playing around on a new project, and having a poke around HEAD on devise (mainly because I had read the README of HEAD and not 3.5.3, so stuck with what I'd learned about).

Not really too familiar with devise, so not sure if I'm missing something here, but think I may have noticed something you've missed, so here's a PR.

Devise::ParameterSanitizer has a new syntax for permitting additional attributes to a model. This commit updates the generated controllers to reflect that.