### PR TITLE
Registrations#create yield before resource save

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -14,8 +14,8 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save
     yield resource if block_given?
+    resource.save
     if resource.persisted?
       if resource.active_for_authentication?
         set_flash_message :notice, :signed_up if is_flashing_format?
@@ -45,8 +45,8 @@ class Devise::RegistrationsController < DeviseController
     self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
     prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
 
-    resource_updated = update_resource(resource, account_update_params)
     yield resource if block_given?
+    resource_updated = update_resource(resource, account_update_params)
     if resource_updated
       if is_flashing_format?
         flash_key = update_needs_confirmation?(resource, prev_unconfirmed_email) ?
@@ -63,10 +63,10 @@ class Devise::RegistrationsController < DeviseController
 
   # DELETE /resource
   def destroy
+    yield resource if block_given?
     resource.destroy
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message :notice, :destroyed if is_flashing_format?
-    yield resource if block_given?
     respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
   end
 


### PR DESCRIPTION
I've run into this issue where I needed to customise the `RegistrationsController` to fire some arbitrary service before saving the `resource` model. 


The problem here was that the resource is `yielded` after the resource gets saved, which in turn fired the model validations.

Example snippet:

```
# RegistrationsController
class RegistrationsController < Devise::RegistrationsController
  def create
     super do |resource|
        # Creates a workspace for a user and sets default_workspace_id
        UserRegistration.new(resource).call     
     end
  end
end

# User model
class User < ActiveRecord::Base
  # Model will not be able to save without the changes 
  # below and overriding the entire registrations#create method
  validates :default_workspace_id, presence: true
end
```

This change allows a developer to extend the registration process without overriding/(copy pasting) the entire `create` method definition.

Please correct me if I'm taking the wrong turn on this and an easier method is available. :tada: 