### PR TITLE
Documentation clarification to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ sign_out @user         # sign_out(resource)
 
 There are two things that are important to keep in mind:
 
-1. `Devise::TestHelpers` is not going to work for integration tests driven by Capybara or Webrat. It is meant to be used with functional tests only. Instead, fill in the form or explicitly set the user in session;
+1. These helpers are not going to work for integration tests driven by Capybara or Webrat. They are meant to be used with functional tests only. It is undesirable even to include `Devise::TestHelpers` during integration tests. Instead, fill in the form or explicitly set the user in session;
 
 2. If you are testing Devise internal controllers or a controller that inherits from Devise's, you need to tell Devise which mapping should be used before a request. This is necessary because Devise gets this information from the router, but since functional tests do not pass through the router, it needs to be stated explicitly. For example, if you are testing the user scope, simply use:
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ If you're using RSpec, you can put the following inside a file named `spec/suppo
 ```ruby
 RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
 end
 ```
 
@@ -438,7 +439,7 @@ sign_out @user         # sign_out(resource)
 
 There are two things that are important to keep in mind:
 
-1. These helpers are not going to work for integration tests driven by Capybara or Webrat. They are meant to be used with functional tests only. Instead, fill in the form or explicitly set the user in session;
+1. `Devise::TestHelpers` is not going to work for integration tests driven by Capybara or Webrat. It is meant to be used with functional tests only. Instead, fill in the form or explicitly set the user in session;
 
 2. If you are testing Devise internal controllers or a controller that inherits from Devise's, you need to tell Devise which mapping should be used before a request. This is necessary because Devise gets this information from the router, but since functional tests do not pass through the router, it needs to be stated explicitly. For example, if you are testing the user scope, simply use:
 


### PR DESCRIPTION
This is a documentation-only change to the testing section of README.md. 

It clarifies how to include Devise::TestHelpers for :view tests.

It also clarifies that including Devise::TestHelpers during integration tests is a mistake.

Here's why I believe these things are true: https://github.com/plataformatec/devise/issues/3881