### PR TITLE
Add parent_mailer to lib/generators/templates/devise.rb

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -17,6 +17,9 @@ Devise.setup do |config|
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be


### PR DESCRIPTION
Most projects I have worked on have had some kind of "BaseMailer" where various shared methods are stored. Most people are not aware of the `parent_mailer` option so have either duplicated code or had modules included. This just adds this option to the default config template so people are aware of it.