### PR TITLE
stop using deprecated method

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -27,7 +27,7 @@ module Devise
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
         return false if remember_exists_and_not_expired?
-        !timeout_in.nil? && last_access && last_access <= timeout_in.ago
+        !timeout_in.nil? && last_access && last_access <= timeout_in.seconds.ago
       end
 
       def timeout_in


### PR DESCRIPTION
Prior to rails 4.2
`60.ago` was equivalent to `60.seconds.ago`

`Numeric#ago` is gone after this commit
rails/rails@f1eddea

Now `60.ago` throws an exception
NoMethodError: undefined method `ago' for 60:Fixnum

