### PR TITLE
Update 'Lazy' strong parameters line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+    devise_parameter_sanitizer.for(:sign_up) << :username
   end
 end
 ```


### PR DESCRIPTION
Within README under the Strong Parameters section, the code example given tries to send `permit` from the context of `ApplicationController`. `permit` is a private method and `ApplicationController` can not call it.

The code block currently is as

```ruby
class ApplicationController < ActionController::Base
  before_action :configure_permitted_parameters, if: :devise_controller?

  protected

  def configure_permitted_parameters
    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
  end
end
```

It should be...

```ruby
class ApplicationController < ActionController::Base
  before_action :configure_permitted_parameters, if: :devise_controller?

  protected

  def configure_permitted_parameters
    devise_parameter_sanitizer.for(:sign_up) << :username
  end
end
```

There are further strong params customisation examples and I'm not sure if this issue also extends to them