### PR TITLE
Make Devise check for Rails >= 4

### DIFF
--- a/lib/generators/devise/install_generator.rb
+++ b/lib/generators/devise/install_generator.rb
@@ -22,7 +22,7 @@ module Devise
       end
 
       def rails_4?
-        Rails::VERSION::MAJOR == 4
+        Rails::VERSION::MAJOR >= 4
       end
     end
   end


### PR DESCRIPTION
Commit `eba91e6` made Devise read `secret_key_base` if it was set but
the method checking for Rails version used `==` making it fail the check
when running Rails 5.