### PR TITLE
Try parsing time in Rememberable before giving up

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -130,6 +130,7 @@ module Devise
 
         def serialize_from_cookie_with_or_without_record(record, args)
           id, token, generated_at = args
+          generated_at = Time.parse(generated_at) rescue nil if generated_at.is_a?(String)
 
           # The token is only valid if:
           # 1. we have a date


### PR DESCRIPTION
I encountered the exception that 048d05a55358a53bbc6d4ea9c78c206f309fcd74 fixes; but the value of `generated_at` (now being discarded) was a serialized time: `"2016-01-26 17:13:52 UTC"`.

After following these steps:
    1. Sign in with **Remember me** checked
    2. Delete the session key (but not `remember_user_token`) from the cookies
    3. Refresh

Using devise `v3.5.5`, my application would crash.

Using 048d05a55358a53bbc6d4ea9c78c206f309fcd74, you'd be signed out.

Using this pull request, you'd be signed in.