### PR TITLE
Change #password_required? implementation

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -51,7 +51,10 @@ module Devise
       # Passwords are always required if it's a new record, or if the password
       # or confirmation are being set somewhere.
       def password_required?
-        !persisted? || !password.nil? || !password_confirmation.nil?
+        if respond_to?(:reset_password_token)
+          return true if reset_password_token.present?
+        end
+        !persisted? || password.present? || password_confirmation.present?
       end
 
       def email_required?

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -64,7 +64,7 @@ class ValidatableTest < ActiveSupport::TestCase
     user = create_user
 
     user.password = ''
-    user.password_confirmation = ''
+    user.password_confirmation = 'x'
 
     assert user.invalid?
     assert_equal 'can\'t be blank', user.errors[:password].join
@@ -88,6 +88,12 @@ class ValidatableTest < ActiveSupport::TestCase
     user = new_user(password: 'x'*73, password_confirmation: 'x'*73)
     assert user.invalid?
     assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
+  end
+
+  test 'should not require password length when it\'s not present' do
+    user = create_user
+    user.password = user.password_confirmation = ''
+    assert_not (user.errors[:password].join =~ /can't be blank/)
   end
 
   test 'should not require password length when it\'s not changed' do


### PR DESCRIPTION
This change will allow updating user with update_attributes containing
blank password and password_confirmation fields (common case for profile
updates).

What do you think?