### PR TITLE
Added DeviseController#set_flash_message!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* enhancements
+  * Introduced `DeviseController#set_flash_message!` for conditional flash messages setting to reduce complexity.
+
 ### 4.0.0.rc1 - 2016-01-02
 
 * Support added to Rails 5 (by @twalpole).

--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -22,7 +22,7 @@ class Devise::ConfirmationsController < DeviseController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message(:notice, :confirmed) if is_flashing_format?
+      set_flash_message!(:notice, :confirmed)
       respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -36,10 +36,10 @@ class Devise::PasswordsController < DeviseController
       resource.unlock_access! if unlockable?(resource)
       if Devise.sign_in_after_reset_password
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
-        set_flash_message(:notice, flash_message) if is_flashing_format?
+        set_flash_message!(:notice, flash_message)
         sign_in(resource_name, resource)
       else
-        set_flash_message(:notice, :updated_not_active) if is_flashing_format?
+        set_flash_message!(:notice, :updated_not_active)
       end
       respond_with resource, location: after_resetting_password_path_for(resource)
     else

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -18,11 +18,11 @@ class Devise::RegistrationsController < DeviseController
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
-        set_flash_message :notice, :signed_up if is_flashing_format?
+        set_flash_message! :notice, :signed_up
         sign_up(resource_name, resource)
         respond_with resource, location: after_sign_up_path_for(resource)
       else
-        set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
         expire_data_after_sign_in!
         respond_with resource, location: after_inactive_sign_up_path_for(resource)
       end
@@ -65,7 +65,7 @@ class Devise::RegistrationsController < DeviseController
   def destroy
     resource.destroy
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-    set_flash_message :notice, :destroyed if is_flashing_format?
+    set_flash_message! :notice, :destroyed
     yield resource if block_given?
     respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
   end

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -15,7 +15,7 @@ class Devise::SessionsController < DeviseController
   # POST /resource/sign_in
   def create
     self.resource = warden.authenticate!(auth_options)
-    set_flash_message(:notice, :signed_in) if is_flashing_format?
+    set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, resource)
     yield resource if block_given?
     respond_with resource, location: after_sign_in_path_for(resource)
@@ -24,7 +24,7 @@ class Devise::SessionsController < DeviseController
   # DELETE /resource/sign_out
   def destroy
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
-    set_flash_message :notice, :signed_out if signed_out && is_flashing_format?
+    set_flash_message! :notice, :signed_out if signed_out
     yield if block_given?
     respond_to_on_destroy
   end
@@ -58,7 +58,7 @@ class Devise::SessionsController < DeviseController
   # to the after_sign_out path.
   def verify_signed_out_user
     if all_signed_out?
-      set_flash_message :notice, :already_signed_out if is_flashing_format?
+      set_flash_message! :notice, :already_signed_out
 
       respond_to_on_destroy
     end

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -24,7 +24,7 @@ class Devise::UnlocksController < DeviseController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message :notice, :unlocked if is_flashing_format?
+      set_flash_message! :notice, :unlocked
       respond_with_navigational(resource){ redirect_to after_unlock_path_for(resource) }
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -127,7 +127,7 @@ MESSAGE
     end
 
     if notice
-      set_flash_message :notice, notice if is_flashing_format?
+      set_flash_message! :notice, notice
       true
     end
   end
@@ -155,6 +155,13 @@ MESSAGE
       flash.now[key] = message if message.present?
     else
       flash[key] = message if message.present?
+    end
+  end
+
+  # Sets flash message if is_flashing_format? equals true
+  def set_flash_message!(key, kind, options = {})
+    if is_flashing_format?
+      set_flash_message(key, kind, options)
     end
   end
 

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -140,11 +140,10 @@ module Devise
 
       config = Rails.application.config
 
-      # Rails 4.2 goes into an infinite loop if opts[:script_name] is unset
-      if (Rails::VERSION::MAJOR >= 4) && (Rails::VERSION::MINOR >= 2)
-        opts[:script_name] = (config.relative_url_root if config.respond_to?(:relative_url_root))
-      else
-        if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
+      if config.respond_to?(:relative_url_root)
+        # Rails 4.2 goes into an infinite loop if opts[:script_name] is unset
+        rails_4_2 = (Rails::VERSION::MAJOR >= 4) && (Rails::VERSION::MINOR >= 2)
+        if config.relative_url_root.present? || rails_4_2
           opts[:script_name] = config.relative_url_root
         end
       end


### PR DESCRIPTION
* Introduced `DeviseController.set_flash_message!` for conditional flash messages setting to reduce method complexity.

* Reduced complexity of `DeviseHelper#devise_error_messages!` and `Devise::FailureApp#scope_url`.

* `DeviseHelper#devise_error_messages_html` not only reduces complexity but also makes error messages easier to override by developers who want to change styling of error message.

* Changed `confirm!` to `confirm` in tests.