### PR TITLE
Spell verb *set up* with a space

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -133,7 +133,7 @@ MESSAGE
   end
 
   # Sets the flash message with :key, using I18n. By default you are able
-  # to setup your messages using specific resource scope, and if no message is
+  # to set up your messages using specific resource scope, and if no message is
   # found we look to the default scope. Set the "now" options key to a true
   # value to populate the flash.now hash in lieu of the default flash hash (so
   # the flash message will be available to the current action instead of the

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -276,7 +276,7 @@ module Devise
   mattr_accessor :token_generator
   @@token_generator = nil
 
-  # Default way to setup Devise. Run rails generate devise_install to create
+  # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup
     yield self

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -150,7 +150,7 @@ module Devise
         is_a?(::DeviseController)
       end
 
-      # Setup a param sanitizer to filter parameters using strong_parameters. See
+      # Set up a param sanitizer to filter parameters using strong_parameters. See
       # lib/devise/parameter_sanitizer.rb for more info. Override this
       # method in your application controller to use your own parameter sanitizer.
       def devise_parameter_sanitizer

--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -64,7 +64,7 @@ module Devise
         template_path
       end
 
-      # Setup a subject doing an I18n lookup. At first, it attempts to set a subject
+      # Set up a subject doing an I18n lookup. At first, it attempts to set a subject
       # based on the current mapping:
       #
       #   en:

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -24,7 +24,7 @@ module Devise
     #     By default allow_unconfirmed_access_for is zero, it means users always have to confirm to sign in.
     #   * +reconfirmable+: requires any email changes to be confirmed (exactly the same way as
     #     initial account confirmation) to be applied. Requires additional unconfirmed_email
-    #     db field to be setup (t.reconfirmable in migrations). Until confirmed, new email is
+    #     db field to be set up (t.reconfirmable in migrations). Until confirmed, new email is
     #     stored in unconfirmed email column, and copied to email column on successful
     #     confirmation.
     #   * +confirm_within+: the time before a sent confirmation token becomes invalid.

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -7,7 +7,7 @@ module Devise
     # blocked: email and time. The former will send an email to the user when
     # the lock happens, containing a link to unlock its account. The second
     # will unlock the user automatically after some configured time (ie 2.hours).
-    # It's also possible to setup lockable to use both email and time strategies.
+    # It's also possible to set up lockable to use both email and time strategies.
     #
     # == Options
     #

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -87,17 +87,17 @@ module ActionDispatch::Routing
     #
     # You can configure your routes with some options:
     #
-    #  * class_name: setup a different class to be looked up by devise, if it cannot be
+    #  * class_name: set up a different class to be looked up by devise, if it cannot be
     #    properly found by the route name.
     #
     #      devise_for :users, class_name: 'Account'
     #
-    #  * path: allows you to setup path name that will be used, as rails routes does.
-    #    The following route configuration would setup your route as /accounts instead of /users:
+    #  * path: allows you to set up path name that will be used, as rails routes does.
+    #    The following route configuration would set up your route as /accounts instead of /users:
     #
     #      devise_for :users, path: 'accounts'
     #
-    #  * singular: setup the singular name for the given resource. This is used as the helper methods
+    #  * singular: set up the singular name for the given resource. This is used as the helper methods
     #    names in controller ("authenticate_#{singular}!", "#{singular}_signed_in?", "current_#{singular}"
     #    and "#{singular}_session"), as the scope name in routes and as the scope given to warden.
     #

--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -22,7 +22,7 @@ module Devise
       @response
     end
 
-    # We need to setup the environment variables and the response in the controller.
+    # We need to set up the environment variables and the response in the controller.
     def setup_controller_for_warden #:nodoc:
       @request.env['action_controller.instance'] = @controller
     end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -101,7 +101,7 @@ Devise.setup do |config|
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
   config.stretches = Rails.env.test? ? 1 : 10
 
-  # Setup a pepper to generate the encrypted password.
+  # Set up a pepper to generate the encrypted password.
   # config.pepper = '<%= SecureRandom.hex(64) %>'
 
   # Send a notification email when the user's password is changed

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -160,7 +160,7 @@ class FailureTest < ActiveSupport::TestCase
       assert_equal 'text/html; charset=utf-8', @response.second['Content-Type']
     end
 
-    test 'setup a default message' do
+    test 'set up a default message' do
       call_failure
       assert_match(/You are being/, @response.last.body)
       assert_match(/redirected/, @response.last.body)

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -37,16 +37,16 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
   end
 
-  test 'setup sender from configuration' do
+  test 'set up sender from configuration' do
     assert_equal ['test@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults' do
+  test 'set up sender from custom mailer defaults' do
     Devise.mailer = 'Users::Mailer'
     assert_equal ['custom@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults with proc' do
+  test 'set up sender from custom mailer defaults with proc' do
     Devise.mailer = 'Users::FromProcMailer'
     assert_equal ['custom@example.com'], mail.from
   end
@@ -56,17 +56,17 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
     assert_present mail.body.encoded
   end
 
-  test 'setup reply to as copy from sender' do
+  test 'set up reply to as copy from sender' do
     assert_equal ['test@example.com'], mail.reply_to
   end
 
-  test 'setup reply to as different if set in defaults' do
+  test 'set up reply to as different if set in defaults' do
     Devise.mailer = 'Users::ReplyToMailer'
     assert_equal ['custom@example.com'], mail.from
     assert_equal ['custom_reply_to@example.com'], mail.reply_to
   end
 
-  test 'setup subject from I18n' do
+  test 'set up subject from I18n' do
     store_translations :en, devise: { mailer: { confirmation_instructions: { subject: 'Account Confirmation' } } } do
       assert_equal 'Account Confirmation', mail.subject
     end

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -39,16 +39,16 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
   end
 
-  test 'setup sender from configuration' do
+  test 'set up sender from configuration' do
     assert_equal ['test@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults' do
+  test 'set up sender from custom mailer defaults' do
     Devise.mailer = 'Users::Mailer'
     assert_equal ['custom@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults with proc' do
+  test 'set up sender from custom mailer defaults with proc' do
     Devise.mailer = 'Users::FromProcMailer'
     assert_equal ['custom@example.com'], mail.from
   end
@@ -58,11 +58,11 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
     assert_present mail.body.encoded
   end
 
-  test 'setup reply to as copy from sender' do
+  test 'set up reply to as copy from sender' do
     assert_equal ['test@example.com'], mail.reply_to
   end
 
-  test 'setup subject from I18n' do
+  test 'set up subject from I18n' do
     store_translations :en, devise: { mailer: { reset_password_instructions: { subject: 'Reset instructions' } } } do
       assert_equal 'Reset instructions', mail.subject
     end

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -40,16 +40,16 @@ class UnlockInstructionsTest < ActionMailer::TestCase
     assert_equal [user.email], mail.to
   end
 
-  test 'setup sender from configuration' do
+  test 'set up sender from configuration' do
     assert_equal ['test@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults' do
+  test 'set up sender from custom mailer defaults' do
     Devise.mailer = 'Users::Mailer'
     assert_equal ['custom@example.com'], mail.from
   end
 
-  test 'setup sender from custom mailer defaults with proc' do
+  test 'set up sender from custom mailer defaults with proc' do
     Devise.mailer = 'Users::FromProcMailer'
     assert_equal ['custom@example.com'], mail.from
   end
@@ -59,11 +59,11 @@ class UnlockInstructionsTest < ActionMailer::TestCase
     assert_present mail.body.encoded
   end
 
-  test 'setup reply to as copy from sender' do
+  test 'set up reply to as copy from sender' do
     assert_equal ['test@example.com'], mail.reply_to
   end
 
-  test 'setup subject from I18n' do
+  test 'set up subject from I18n' do
     store_translations :en, devise: { mailer: { unlock_instructions:  { subject: 'Yo unlock instructions' } } } do
       assert_equal 'Yo unlock instructions', mail.subject
     end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -135,7 +135,7 @@ Devise.setup do |config|
   # reset. Defaults to true, so a user is signed in automatically after a reset.
   # config.sign_in_after_reset_password = true
 
-  # Setup a pepper to generate the encrypted password.
+  # Set up a pepper to generate the encrypted password.
   config.pepper = "d142367154e5beacca404b1a6a4f8bc52c6fdcfa3ccc3cf8eb49f3458a688ee6ac3b9fae488432a3bfca863b8a90008368a9f3a3dfbe5a962e64b6ab8f3a3a1a"
 
   # ==> Scopes configuration


### PR DESCRIPTION
[The verb *set up* is spelled with a space][1].

[1]: http://www.merriam-webster.com/dictionary/set%20up