### PR TITLE
Removes Hakiri, since it thinks Devise is a Rails app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ By [Plataformatec](http://plataformatec.com.br/).
 
 [![Build Status](https://api.travis-ci.org/plataformatec/devise.svg?branch=master)](http://travis-ci.org/plataformatec/devise)
 [![Code Climate](https://codeclimate.com/github/plataformatec/devise.svg)](https://codeclimate.com/github/plataformatec/devise)
-[![Security](https://hakiri.io/github/plataformatec/devise/master.svg)](https://hakiri.io/github/plataformatec/devise/master)
 
 This README is [also available in a friendly navigable format](http://devise.plataformatec.com.br/).
 


### PR DESCRIPTION
I'd like to remove the Hakiri badge from devise's README.

Since we do check in Gemfile and Gemfile.lock for development
and testing purposes (contrary to the popular belief that gems
don't need those files), Hakiri thinks Devise is a Rails app,
instead of a library/gem.

Depending on the Rails version that is locked in Gemfile.lock,
Hakiri will show several CVEs for Rails. But our Travis pipeline
builds against several Rails' branches, all of them updated.

And it is up to the developers using Devise to update
Rails in their apps.

Those warnings (Rails CVEs) don't make sense for devise.