### PR TITLE
Fix request_values to correctly access the request object 

### DIFF
--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -148,7 +148,7 @@ module Devise
 
       def request_values
         keys = request_keys.respond_to?(:keys) ? request_keys.keys : request_keys
-        values = keys.map { |k| self.request.send(k) }
+        values = keys.map { |k| self.request[k] }
         Hash[keys.zip(values)]
       end
 


### PR DESCRIPTION
I was working from the directions located here: 
https://github.com/plataformatec/devise/wiki/How-to:-Scope-login-to-subdomain

and nothing was working until I took a look at how authenticatable was accessing values from the request hash using `request.send(:key)` instead of `self.request[k]` 

At least in Rails 4.2, I have not been able to demonstrate `send` ever working to access an attribute from the `request` object.

The tests that now fail are somewhat suspect to me - but I'm hoping someone with more experience with this code base will be able to confirm - it seems like an invalid request key is expecting NoMethodError - which seems to occur regardless of whether or not the attribute exists or not. 

But the documentation from the above link points out that an error will occur if result_keys are passed by array - but not by hash assuming the values are "false" for "not required"

This seems to be implemented in `parse_authentication_key_values` but false is returned rather than throwing an error.  

It doesn't seem like its possible to use this functionality since request_values comes before parse_authentication_key_values and will always throw an error regardless of how the value_keys are passed (by hash will false values or by array)






