### PR TITLE
fix test helpers for relative_url_root

### DIFF
--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -93,6 +93,7 @@ module Devise
 
     def _process_unauthenticated(env, options = {})
       options[:action] ||= :unauthenticated
+      options[:attempted_path] ||= ::Rack::Request.new(env).fullpath
       proxy = env['warden']
       result = options[:result] || proxy.result
 


### PR DESCRIPTION
BUG:
* in Rails 4.2, Devise goes into an infinite loop if relative_url_root is not set in the Rails config
* when relative_url_root is set, Devise's test_helpers do not pass the attempted_url in the warden options
* this causes an error at `Pathname.new(attempted_path)` in the failure_app

FIX:
* add attempted_path to the warden options in the test_helpers

Versions: 
* Devise 3.5.6
* Rails 4.1.13
* Warden 1.2.6