### PR TITLE
updated email_regexp and added test cases

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -118,13 +118,11 @@ module Devise
   mattr_accessor :http_authentication_realm
   @@http_authentication_realm = "Application"
 
-  # Email regex used to validate email formats. It asserts that there
-  # are no @ symbols or whitespaces in the localpart, that there is a
-  # single @ symbol separating the localpart and the domain, and that
-  # the domain consists of sequences of one or more alphanumeric chars
-  # separated by one or more hyphens or solitary dots.
+  # Email regex used to validate email formats. It asserts that there are no
+  # @ symbols or whitespaces in either the localpart or the domain, and that
+  # there is a single @ symbol separating the localpart and the domain.
   mattr_accessor :email_regexp
-  @@email_regexp = /\A[^@\s]+@[[:alnum:]]+((-+|\.)[[:alnum:]]+)*\z/
+  @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # Range validation for password length
   mattr_accessor :password_length

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -118,22 +118,13 @@ module Devise
   mattr_accessor :http_authentication_realm
   @@http_authentication_realm = "Application"
 
-  # Email regex used to validate email formats. It simply asserts that
-  # an one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
-  # TODO: 4.1 Do: @@email_regexp = [/\A[^@\s]+@[^@\s]+\z/]
-  mattr_reader :email_regexp
-  @@email_regexp = /\A[^@\s]+@([^@\s]+\.)+[^@\W]+\z/
-
-  def self.email_regexp=(email_regexp)
-    app_set_configs << :email_regexp
-    @@email_regexp = email_regexp
-  end
-
-  def email_regexp=(email_regexp)
-    app_set_configs << :email_regexp
-    @@email_regexp = email_regexp
-  end
+  # Email regex used to validate email formats. It asserts that there
+  # are no @ symbols or whitespaces in the localpart, that there is a
+  # single @ symbol separating the localpart and the domain, and that
+  # the domain consists of sequences of one or more alphanumeric chars
+  # separated by one or more hyphens or solitary dots.
+  mattr_accessor :email_regexp
+  @@email_regexp = /\A[^@\s]+@[[:alnum:]]+((-+|\.)[[:alnum:]]+)*\z/
 
   # Range validation for password length
   mattr_accessor :password_length

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -330,7 +330,6 @@ module Devise
   def self.setup
     yield self
 
-    warn_default_config_changed(:email_regexp, '/\A[^@\s]+@([^@\s]+\.)+[^@\W]+\z/', '/\A[^@\s]+@[^@\s]+\z/')
     warn_default_config_changed(:reconfirmable, 'false', 'true')
     warn_default_config_changed(:sign_out_via, ':get', ':delete')
     warn_default_config_changed(:skip_session_storage, '[]', '[:http_auth]')

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -153,7 +153,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@]+@[^@]+\z/
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -122,7 +122,7 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'Devise.email_regexp should match valid email addresses' do
     valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua", "test@tt", "test@valid---domain.com"]
-    non_valid_emails = ["rex", "test@go,com", "test user@example.com", "test_user@example server.com", "test_user@example.com.", "test_user@example..server", "test_user@example-.server"]
+    non_valid_emails = ["rex", "test user@example.com", "test_user@example server.com"]
 
     valid_emails.each do |email|
       assert_match Devise.email_regexp, email

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -37,8 +37,7 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'setup block warns about defaults changing' do
     Devise.app_set_configs = Set.new
-
-    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /email_regexp/ }
+    
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /reconfirmable/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /skip_session_storage/ }
@@ -52,7 +51,6 @@ class DeviseTest < ActiveSupport::TestCase
     ActiveSupport::Deprecation.expects(:warn).never
 
     swap Devise,
-        email_regexp: /@/,
         reconfirmable: false,
         sign_out_via: :get,
         skip_session_storage: [],

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -121,8 +121,8 @@ class DeviseTest < ActiveSupport::TestCase
   end
 
   test 'Devise.email_regexp should match valid email addresses' do
-    valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua"]
-    non_valid_emails = ["rex", "test@go,com", "test user@example.com", "test_user@example server.com", "test_user@example.com."]
+    valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua", "test@tt", "test@valid---domain.com"]
+    non_valid_emails = ["rex", "test@go,com", "test user@example.com", "test_user@example server.com", "test_user@example.com.", "test_user@example..server", "test_user@example-.server"]
 
     valid_emails.each do |email|
       assert_match Devise.email_regexp, email

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -29,7 +29,7 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.invalid?
     assert_not_equal 'is invalid', user.errors[:email].join
 
-    %w{invalid_email_format 123 $$$ () ☃ bla@bla.}.each do |email|
+    %w{invalid_email_format 123 $$$ () ☃}.each do |email|
       user.email = email
       assert user.invalid?, 'should be invalid with email ' << email
       assert_equal 'is invalid', user.errors[:email].join


### PR DESCRIPTION
updated `Devise::email_regexp` to meet existing test cases plus valid emails `"test@tt"` & `"test@valid---domain.com"`, non valid emails `"test_user@example..server"` & `"test_user@example-.server"`.