### PR TITLE
Humanize authentication keys in failure flash message

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -103,7 +103,7 @@ module Devise
         options[:scope] = "devise.failure"
         options[:default] = [message]
         auth_keys = scope_class.authentication_keys
-        keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map(&:to_s).map(&:humanize)
+        keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map { |key| scope_class.human_attribute_name(key) }
         options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
         options = i18n_options(options)
 

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -103,7 +103,7 @@ module Devise
         options[:scope] = "devise.failure"
         options[:default] = [message]
         auth_keys = scope_class.authentication_keys
-        keys = auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys
+        keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map(&:to_s).map(&:humanize)
         options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
         options = i18n_options(options)
 

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -133,14 +133,14 @@ class FailureTest < ActiveSupport::TestCase
 
     test 'uses the proxy failure message as symbol' do
       call_failure('warden' => OpenStruct.new(message: :invalid))
-      assert_equal 'Invalid email or password.', @request.flash[:alert]
+      assert_equal 'Invalid Email or password.', @request.flash[:alert]
       assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
     end
 
     test 'supports authentication_keys as a Hash for the flash message' do
       swap Devise, authentication_keys: { email: true, login: true } do
         call_failure('warden' => OpenStruct.new(message: :invalid))
-        assert_equal 'Invalid email, login or password.', @request.flash[:alert]
+        assert_equal 'Invalid Email, Login or password.', @request.flash[:alert]
       end
     end
 
@@ -226,7 +226,7 @@ class FailureTest < ActiveSupport::TestCase
 
     test 'uses the failure message as response body' do
       call_failure('formats' => Mime[:xml], 'warden' => OpenStruct.new(message: :invalid))
-      assert_match '<error>Invalid email or password.</error>', @response.third.body
+      assert_match '<error>Invalid Email or password.</error>', @response.third.body
     end
 
     context 'on ajax call' do
@@ -275,7 +275,7 @@ class FailureTest < ActiveSupport::TestCase
       }
       call_failure(env)
       assert @response.third.body.include?('<h2>Log in</h2>')
-      assert @response.third.body.include?('Invalid email or password.')
+      assert @response.third.body.include?('Invalid Email or password.')
     end
 
     test 'calls the original controller if not confirmed email' do
@@ -310,7 +310,7 @@ class FailureTest < ActiveSupport::TestCase
           }
           call_failure(env)
           assert @response.third.body.include?('<h2>Log in</h2>')
-          assert @response.third.body.include?('Invalid email or password.')
+          assert @response.third.body.include?('Invalid Email or password.')
           assert_equal @request.env["SCRIPT_NAME"], '/sample'
           assert_equal @request.env["PATH_INFO"], '/users/sign_in'
         end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -580,7 +580,7 @@ class AuthenticationKeysTest < Devise::IntegrationTest
   test 'missing authentication keys cause authentication to abort' do
     swap Devise, authentication_keys: [:subdomain] do
       sign_in_as_user
-      assert_contain "Invalid subdomain or password."
+      assert_contain "Invalid Subdomain or password."
       assert_not warden.authenticated?(:user)
     end
   end
@@ -619,7 +619,7 @@ class AuthenticationRequestKeysTest < Devise::IntegrationTest
 
     swap Devise, request_keys: [:subdomain] do
       sign_in_as_user
-      assert_contain "Invalid email or password."
+      assert_contain "Invalid Email or password."
       assert_not warden.authenticated?(:user)
     end
   end

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -140,7 +140,7 @@ class ConfirmationTest < Devise::IntegrationTest
         fill_in 'password', with: 'invalid'
       end
 
-      assert_contain 'Invalid email or password'
+      assert_contain 'Invalid Email or password'
       assert_not warden.authenticated?(:user)
     end
   end

--- a/test/integration/database_authenticatable_test.rb
+++ b/test/integration/database_authenticatable_test.rb
@@ -68,7 +68,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
       fill_in 'password', with: 'abcdef'
     end
 
-    assert_contain 'Invalid email or password'
+    assert_contain 'Invalid Email or password'
     assert_not warden.authenticated?(:admin)
   end
 

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -42,7 +42,7 @@ class HttpAuthenticationTest < Devise::IntegrationTest
     sign_in_as_new_user_with_http("unknown")
     assert_equal 401, status
     assert_equal "application/xml; charset=utf-8", headers["Content-Type"]
-    assert_match "<error>Invalid email or password.</error>", response.body
+    assert_match "<error>Invalid Email or password.</error>", response.body
   end
 
   test 'returns a custom response with www-authenticate and chosen realm' do


### PR DESCRIPTION
If developer wants to use other authentication keys instead of email and writes in him model
```devise :database_authenticatable, authentication_keys: [:username]authentication_keys: [:user_name]```
and writes in him locale 
```
devise:
  failure:
    invalid: '%{authentication_keys} o contraseña no válidos.'
```
and after that user types wrong user_name or password, flash get message **"user_name  o contraseña no válidos."** instead of **"User name  o contraseña no válidos."**. Changes of this commit fix it. 
PS: sorry for my english