### PR TITLE
Added device type to trackable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 4.2.5"
 gem "omniauth", "~> 1.3"
 gem "omniauth-oauth2", "~> 1.4"
 gem "rdoc"
+gem "mobvious"
 
 group :test do
   gem "omniauth-facebook"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,10 @@ GEM
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    mobileesp_converted (0.2.3)
+    mobvious (0.3.2)
+      mobileesp_converted (~> 0.2.0)
+      rack (>= 1.1.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mongoid (4.0.2)
@@ -168,6 +172,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   devise!
   jruby-openssl
+  mobvious
   mocha (~> 1.1)
   mongoid (~> 4.0)
   omniauth (~> 1.3)

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -57,7 +57,7 @@ module Devise
       BLACKLIST_FOR_SERIALIZATION = [:encrypted_password, :reset_password_token, :reset_password_sent_at,
         :remember_created_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip,
         :last_sign_in_ip, :password_salt, :confirmation_token, :confirmed_at, :confirmation_sent_at,
-        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
+        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at, :device_type]
 
       included do
         class_attribute :devise_modules, instance_writer: false

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -29,7 +29,7 @@ module Devise
         self.sign_in_count += 1
 
         #using mobvious gem--
-        type_of_device = request.['mobvious.device_type']
+        type_of_device = request['mobvious.device_type']
         self.device_type = type_of_device            
       end
 

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -9,16 +9,17 @@ module Devise
     # * last_sign_in_at    - Holds the timestamp of the previous sign in
     # * current_sign_in_ip - The remote ip updated when the user sign in
     # * last_sign_in_ip    - Holds the remote ip of the previous sign in
-    #
+    # * device_type        - Gets device type (mobile, tablet, or desktop)
     module Trackable
       def self.required_fields(klass)
-        [:current_sign_in_at, :current_sign_in_ip, :last_sign_in_at, :last_sign_in_ip, :sign_in_count]
+        [:current_sign_in_at, :current_sign_in_ip, :last_sign_in_at, :last_sign_in_ip, :sign_in_count, :device_type]
       end
 
       def update_tracked_fields(request)
         old_current, new_current = self.current_sign_in_at, Time.now.utc
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
+  
 
         old_current, new_current = self.current_sign_in_ip, request.remote_ip
         self.last_sign_in_ip     = old_current || new_current
@@ -26,6 +27,14 @@ module Devise
 
         self.sign_in_count ||= 0
         self.sign_in_count += 1
+
+        #using mobvious gem--
+        type_of_device = request.env['mobvious.device_type']
+        if type_of_device.nil?
+          self.device_type = "Unknown"
+        else
+          self.device_type = type_of_device            
+        end 
       end
 
       def update_tracked_fields!(request)

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -29,7 +29,7 @@ module Devise
         self.sign_in_count += 1
 
         #using mobvious gem--
-        type_of_device = request.env['mobvious.device_type']
+        type_of_device = request.['mobvious.device_type']
         self.device_type = type_of_device            
       end
 

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -30,11 +30,7 @@ module Devise
 
         #using mobvious gem--
         type_of_device = request.env['mobvious.device_type']
-        if type_of_device.nil?
-          self.device_type = "Unknown"
-        else
-          self.device_type = type_of_device            
-        end 
+        self.device_type = type_of_device            
       end
 
       def update_tracked_fields!(request)

--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -55,6 +55,8 @@ module ActiveRecord
       t.datetime :last_sign_in_at
       t.#{ip_column} :current_sign_in_ip
       t.#{ip_column} :last_sign_in_ip
+      t.string :device_type
+
 
       ## Confirmable
       # t.string   :confirmation_token

--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -37,6 +37,8 @@ module Mongoid
   field :last_sign_in_at,    type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip,    type: String
+  field :device_type,        type: String
+
 
   ## Confirmable
   # field :confirmation_token,   type: String

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -6,6 +6,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     user = create_user
     assert_nil user.current_sign_in_at
     assert_nil user.last_sign_in_at
+    assert_nil user.device_type
 
     sign_in_as_user
     user.reload
@@ -16,7 +17,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     assert_equal user.current_sign_in_at, user.last_sign_in_at
     assert user.current_sign_in_at >= user.created_at
 
-    assert user.device_type == 'desktop'
+    
 
     visit destroy_user_session_path
     new_time = 2.seconds.from_now

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -16,6 +16,8 @@ class TrackableHooksTest < Devise::IntegrationTest
     assert_equal user.current_sign_in_at, user.last_sign_in_at
     assert user.current_sign_in_at >= user.created_at
 
+    assert user.device_type == 'desktop'
+
     visit destroy_user_session_path
     new_time = 2.seconds.from_now
     Time.stubs(:now).returns(new_time)

--- a/test/models/trackable_test.rb
+++ b/test/models/trackable_test.rb
@@ -7,7 +7,8 @@ class TrackableTest < ActiveSupport::TestCase
       :current_sign_in_ip,
       :last_sign_in_at,
       :last_sign_in_ip,
-      :sign_in_count
+      :sign_in_count,
+      :device_type
     ]
   end
 
@@ -21,6 +22,7 @@ class TrackableTest < ActiveSupport::TestCase
     assert_nil user.current_sign_in_at
     assert_nil user.last_sign_in_at
     assert_equal 0, user.sign_in_count
+    assert_nil user.device_type     
 
     user.update_tracked_fields(request)
 
@@ -29,6 +31,7 @@ class TrackableTest < ActiveSupport::TestCase
     assert_not_nil user.current_sign_in_at
     assert_not_nil user.last_sign_in_at
     assert_equal 1, user.sign_in_count
+    assert_not_nil user.device_type
 
     user.reload
 
@@ -37,5 +40,6 @@ class TrackableTest < ActiveSupport::TestCase
     assert_nil user.current_sign_in_at
     assert_nil user.last_sign_in_at
     assert_equal 0, user.sign_in_count
+    assert_nil user.device_type
   end
 end

--- a/test/rails_app/app/mongoid/user.rb
+++ b/test/rails_app/app/mongoid/user.rb
@@ -25,6 +25,7 @@ class User
   field :last_sign_in_at,    type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip,    type: String
+  field :device_type,        type: String
 
   ## Confirmable
   field :confirmation_token,   type: String

--- a/test/rails_app/app/mongoid/user_on_engine.rb
+++ b/test/rails_app/app/mongoid/user_on_engine.rb
@@ -25,6 +25,7 @@ class UserOnEngine
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :device_type, type: String
 
   ## Confirmable
   field :confirmation_token, type: String

--- a/test/rails_app/app/mongoid/user_on_main_app.rb
+++ b/test/rails_app/app/mongoid/user_on_main_app.rb
@@ -25,6 +25,8 @@ class UserOnMainApp
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :device_type, type: String
+
 
   ## Confirmable
   field :confirmation_token, type: String

--- a/test/rails_app/app/mongoid/user_without_email.rb
+++ b/test/rails_app/app/mongoid/user_without_email.rb
@@ -25,6 +25,8 @@ class UserWithoutEmail
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :device_type, type: String
+
 
   ## Lockable
   field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts


### PR DESCRIPTION
I love using devise, I think this will help a lot of people with their logic for mobile and desktop styling if it's built right into devise that way they can use current_user methods for device types making cross platform styling simple. Any question or concerns please let me know!