### PR TITLE
Remove upgrade path for old session format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Remove code supporting old session serialization format (by @fphilipe).
+
 ### 4.0.1 - 2016-04-25
 
 * bug fixes

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -543,10 +543,7 @@ module Devise
           mapping.to.serialize_into_session(record)
         end
 
-        warden_config.serialize_from_session(mapping.name) do |key|
-          # Previous versions contained an additional entry at the beginning of
-          # key with the record's class name.
-          args = key[-2, 2]
+        warden_config.serialize_from_session(mapping.name) do |args|
           mapping.to.serialize_from_session(*args)
         end
       end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -347,37 +347,6 @@ class AuthenticationSessionTest < Devise::IntegrationTest
     assert_equal "Cart", @controller.user_session[:cart]
   end
 
-  test 'does not explode when class name is still stored in session' do
-    # In order to test that old sessions do not break with the new scoped
-    # deserialization, we need to serialize the session the old way. This is
-    # done by removing the newly used scoped serialization method
-    # (#user_serialize) and bringing back the old uncsoped #serialize method
-    # that includes the record's class name in the serialization.
-    begin
-      Warden::SessionSerializer.class_eval do
-        alias_method :original_serialize, :serialize
-        alias_method :original_user_serialize, :user_serialize
-        remove_method :user_serialize
-
-        def serialize(record)
-          klass = record.class
-          array = klass.serialize_into_session(record)
-          array.unshift(klass.name)
-        end
-      end
-
-      sign_in_as_user
-      assert warden.authenticated?(:user)
-    ensure
-      Warden::SessionSerializer.class_eval do
-        alias_method :serialize, :original_serialize
-        remove_method :original_serialize
-        alias_method :user_serialize, :original_user_serialize
-        remove_method :original_user_serialize
-      end
-    end
-  end
-
   test 'session id is changed on sign in' do
     get '/users'
     session_id = request.session["session_id"]


### PR DESCRIPTION
This removes an upgrade path that migrated the old serialization format to the new one introduced. This was introduced in c22d755 (#2300) 3 years ago and should no longer be needed.