### PR TITLE
Add warning about default config change

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -148,12 +148,12 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..72
+  config.password_length = 6..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  # config.email_regexp = /\A[^@]+@[^@]+\z/
+  config.email_regexp = /\A[^@]+@[^@]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -35,6 +35,33 @@ class DeviseTest < ActiveSupport::TestCase
     end
   end
 
+  test 'setup block warns about defaults changing' do
+    Devise.app_set_configs = Set.new
+
+    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /email_regexp/ }
+    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /reconfirmable/ }
+    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
+    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /skip_session_storage/ }
+    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /strip_whitespace_keys/ }
+
+    Devise.setup do
+    end
+  end
+
+  test 'setup block doest not warns when the change is explicit set' do
+    ActiveSupport::Deprecation.expects(:warn).never
+
+    swap Devise,
+        email_regexp: /@/,
+        reconfirmable: false,
+        sign_out_via: :get,
+        skip_session_storage: [],
+        strip_whitespace_keys: [] do
+        Devise.setup do
+        end
+    end
+  end
+
   test 'stores warden configuration' do
     assert_kind_of Devise::Delegator, Devise.warden_config.failure_app
     assert_equal :user, Devise.warden_config.default_scope


### PR DESCRIPTION
This change add warnings for these configurations:

* `strip_whitespace_keys` - It is already explicit on config template, now
it will be the same of the template.
* `email_regexp` - In the new version this regexp will be more
permissive.
* `reconfirmable` - It is already explicit on config template, now
it will be the same of the template.
* `skip_session_storage` - It is already explicit on config template, now
it will be the same of the template.
* `sign_out_via` - It is already explicit on config template, now
it will be the same of the template.

These ones is important to change, since the configuration says current
explicit value are the default. It can lead to misunderstanging if users
remove the explicit configuration.

It also updates the template explicit values:

* Warns the `config.mailer_sender` is nil by default
* Update `config.password_length` to use the current default
* Make the e-mail configuration explicit