### PR TITLE
Fixes issue with devise setting  as an alert message on session expir…

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -78,8 +78,7 @@ module Devise
     def redirect
       store_location!
       if is_flashing_format?
-        if flash[:timedout] && flash[:alert]
-          flash.keep(:timedout)
+        if flash[:alert]
           flash.keep(:alert)
         else
           flash[:alert] = i18n_message
@@ -115,8 +114,6 @@ module Devise
 
     def redirect_url
       if warden_message == :timeout
-        flash[:timedout] = true if is_flashing_format?
-
         path = if request.get?
           attempted_path
         else


### PR DESCRIPTION
…ed with timeoutable.

If a session expires two alerts are shown one with message `true` and another one with `"Your session expired. Please sign in again to continue."`

There is no need to check if it is json format at this time and setup a new flash with `true`. Since that was already taking cared of at: https://github.com/plataformatec/devise/blob/master/lib/devise/failure_app.rb#L78-L89
