### PR TITLE
Fix extented remember me

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -115,7 +115,6 @@ module Devise
   mattr_accessor :remember_for
   @@remember_for = 2.weeks
 
-  # TODO: extend_remember_period is no longer used
   # If true, extends the user's remember period when remembered via cookie.
   mattr_accessor :extend_remember_period
   @@extend_remember_period = false

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -39,7 +39,7 @@ module Devise
     module Rememberable
       extend ActiveSupport::Concern
 
-      attr_accessor :remember_me, :extend_remember_period
+      attr_accessor :remember_me
 
       def self.required_fields(klass)
         [:remember_created_at]
@@ -64,6 +64,10 @@ module Devise
 
       def remember_expires_at
         self.class.remember_for.from_now
+      end
+
+      def extend_remember_period
+        self.class.extend_remember_period
       end
 
       def rememberable_value
@@ -147,9 +151,6 @@ module Devise
           end
         end
 
-        private
-
-        # TODO: extend_remember_period is no longer used
         Devise::Models.config(self, :remember_for, :extend_remember_period, :rememberable_options, :expire_all_remember_me_on_sign_out)
       end
     end

--- a/lib/devise/strategies/rememberable.rb
+++ b/lib/devise/strategies/rememberable.rb
@@ -25,8 +25,7 @@ module Devise
         end
 
         if validate(resource)
-          remember_me(resource)
-          extend_remember_me_period(resource)
+          remember_me(resource) if extend_remember_me?(resource)
           resource.after_remembered
           success!(resource)
         end
@@ -43,10 +42,8 @@ module Devise
 
     private
 
-      def extend_remember_me_period(resource)
-        if resource.respond_to?(:extend_remember_period=)
-          resource.extend_remember_period = mapping.to.extend_remember_period
-        end
+      def extend_remember_me?(resource)
+        resource.respond_to?(:extend_remember_period) && resource.extend_remember_period
       end
 
       def remember_me?


### PR DESCRIPTION
Now the config `extend_remember_period` is used to:

`true` - Every time the user cookie is authenticated, the
cookie expiration is updated.
`false` - Does not update the cookie expiration when the cookie is authenticated.

Closes #3994