### PR TITLE
Send confirmation instructions when a user updates the email address from nil

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -254,13 +254,13 @@ module Devise
         end
 
         def postpone_email_change?
-          postpone = self.class.reconfirmable && email_changed? && email_was.present? && !@bypass_confirmation_postpone && self.email.present?
+          postpone = self.class.reconfirmable && email_changed? && !@bypass_confirmation_postpone && self.email.present?
           @bypass_confirmation_postpone = false
           postpone
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required && self.email.present?
+          self.class.reconfirmable && @reconfirmation_required && (self.email || self.unconfirmed_email)
         end
 
         def send_confirmation_notification?

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -169,6 +169,7 @@ module Devise
         # in models to map to a nice sign up e-mail.
         def send_on_create_confirmation_instructions
           send_confirmation_instructions
+          skip_reconfirmation!
         end
 
         # Callback to overwrite if confirmation is required or not.

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -260,7 +260,7 @@ module Devise
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required && (self.email || self.unconfirmed_email)
+          self.class.reconfirmable && @reconfirmation_required && (self.email.present? || self.unconfirmed_email.present?)
         end
 
         def send_confirmation_notification?

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -488,8 +488,8 @@ class ReconfirmableTest < ActiveSupport::TestCase
   end
 
   test 'should not require reconfirmation after creating a record' do
-    user = create_admin
-    assert !user.pending_reconfirmation?
+    admin = create_admin
+    assert !admin.pending_reconfirmation?
   end
 
   test 'should not require reconfirmation after creating a record with #save called in callback' do
@@ -497,7 +497,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
       after_create :save
     end
 
-    user = Admin::WithSaveInCallback.create(valid_attributes.except(:username))
-    assert !user.pending_reconfirmation?
+    admin = Admin::WithSaveInCallback.create(valid_attributes.except(:username))
+    assert !admin.pending_reconfirmation?
   end
 end

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -114,7 +114,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
     assert_email_not_sent do
       user.save!
-      assert !user.confirmed?
+      assert_not user.confirmed?
     end
   end
 

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -401,6 +401,14 @@ class ReconfirmableTest < ActiveSupport::TestCase
     assert_match "new_test@example.com", ActionMailer::Base.deliveries.last.body.encoded
   end
 
+  test 'should send confirmation instructions by email after changing email from nil' do
+    admin = create_admin(email: nil)
+    assert_email_sent "new_test@example.com" do
+      assert admin.update_attributes(email: 'new_test@example.com')
+    end
+    assert_match "new_test@example.com", ActionMailer::Base.deliveries.last.body.encoded
+  end
+
   test 'should not send confirmation by email after changing password' do
     admin = create_admin
     assert admin.confirm


### PR DESCRIPTION
Send confirmation instructions when a user updates his `email` from `nil`.

Skip reconfirmation in the case that a record is created with #save called in callbacks in a proper way.