### PR TITLE
Make sure attribute_will_change! method exists before calling it

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -41,7 +41,6 @@ module Devise
       # For legacy reasons, we use `encrypted_password` to store
       # the hashed password.
       def password=(new_password)
-        attribute_will_change! 'password'
         @password = new_password
         self.encrypted_password = password_digest(@password) if @password.present?
       end


### PR DESCRIPTION
I'm using the [devise-nobrainer](https://github.com/nviennot/devise-nobrainer) ORM adapter with rails 5. I'm getting this error on the sign-in page: `undefined method 'attribute_will_change!'`. I assume this is because I'm not using ActiveRecord (this seems to be a method related to ActiveRecord ??). When I get rid of this line everything works as expected. So I added a conditional to make sure it exists before running it.