### PR TITLE
Make reloading of routes optional

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -304,6 +304,10 @@ module Devise
   mattr_accessor :clean_up_csrf_token_on_authentication
   @@clean_up_csrf_token_on_authentication = true
 
+  # When false, Devise will not attempt to reload routes on eager load
+  mattr_accessor :reload_routes
+  @@reload_routes = true
+
   # PRIVATE CONFIGURATION
 
   # Store scopes mappings.

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -11,7 +11,9 @@ module Devise
     end
 
     # Force routes to be loaded if we are doing any eager load.
-    config.before_eager_load { |app| app.reload_routes! }
+    config.before_eager_load do |app|
+      app.reload_routes! if Devise.reload_routes
+    end
 
     initializer "devise.url_helpers" do
       Devise.include_helpers(Devise::Controllers)


### PR DESCRIPTION
In #3153 we've seen that some applications require routes to be loaded before the code is eagerly loaded so we can't just remove it. However, this implies that **all** applications using Devise need to have routes reloaded twice (as was mentioned in https://github.com/plataformatec/devise/pull/3241#issuecomment-114038540). Double route reload can incur a slowdown for larger apps that have a lot of routes or a lot of controllers.

This PR strives for compromise, making the route reloading optional.

In our app, enabling this setting shaves off 15-25% of boot time in staging environment (we have more than 1500 routes).