### PR TITLE
Set the new defaults for Devise 4.1

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -88,19 +88,8 @@ module Devise
   @@case_insensitive_keys = [:email]
 
   # Keys that should have whitespace stripped.
-  # TODO: 4.1 Do: @@strip_whitespace_keys = [:email]
-  mattr_reader :strip_whitespace_keys
-  @@strip_whitespace_keys = []
-
-  def self.strip_whitespace_keys=(strip_whitespace_keys)
-    app_set_configs << :strip_whitespace_keys
-    @@strip_whitespace_keys = strip_whitespace_keys
-  end
-
-  def strip_whitespace_keys=(strip_whitespace_keys)
-    app_set_configs << :strip_whitespace_keys
-    @@strip_whitespace_keys = strip_whitespace_keys
-  end
+  mattr_accessor :strip_whitespace_keys
+  @@strip_whitespace_keys = [:email]
 
   # If http authentication is enabled by default.
   mattr_accessor :http_authenticatable
@@ -333,7 +322,6 @@ module Devise
     warn_default_config_changed(:reconfirmable, 'false', 'true')
     warn_default_config_changed(:sign_out_via, ':get', ':delete')
     warn_default_config_changed(:skip_session_storage, '[]', '[:http_auth]')
-    warn_default_config_changed(:strip_whitespace_keys, '[]', '[:email]')
   end
 
   def self.warn_default_config_changed(config, current_default, new_default)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -218,19 +218,8 @@ module Devise
   @@sign_out_all_scopes = true
 
   # The default method used while signing out
-  # TODO: 4.1 Do: @@sign_out_via = :delete
-  mattr_reader :sign_out_via
-  @@sign_out_via = :get
-
-  def self.sign_out_via=(sign_out_via)
-    app_set_configs << :sign_out_via
-    @@sign_out_via = sign_out_via
-  end
-
-  def sign_out_via=(sign_out_via)
-    app_set_configs << :sign_out_via
-    @@sign_out_via = sign_out_via
-  end
+  mattr_accessor :sign_out_via
+  @@sign_out_via = :delete
 
   # The parent controller all Devise controllers inherits from.
   # Defaults to ApplicationController. This should be set early
@@ -295,8 +284,6 @@ module Devise
   # a fresh initializer with all configuration values.
   def self.setup
     yield self
-
-    warn_default_config_changed(:sign_out_via, ':get', ':delete')
   end
 
   def self.warn_default_config_changed(config, current_default, new_default)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -206,19 +206,8 @@ module Devise
   @@mailer_sender = nil
 
   # Skip session storage for the following strategies
-  # TODO: 4.1 Do: @@skip_session_storage = [:http_auth]
-  mattr_reader :skip_session_storage
-  @@skip_session_storage = []
-
-  def self.skip_session_storage=(skip_session_storage)
-    app_set_configs << :skip_session_storage
-    @@skip_session_storage = skip_session_storage
-  end
-
-  def skip_session_storage=(skip_session_storage)
-    app_set_configs << :skip_session_storage
-    @@skip_session_storage = skip_session_storage
-  end
+  mattr_accessor :skip_session_storage
+  @@skip_session_storage = [:http_auth]
 
   # Which formats should be treated as navigational.
   mattr_accessor :navigational_formats
@@ -308,7 +297,6 @@ module Devise
     yield self
 
     warn_default_config_changed(:sign_out_via, ':get', ':delete')
-    warn_default_config_changed(:skip_session_storage, '[]', '[:http_auth]')
   end
 
   def self.warn_default_config_changed(config, current_default, new_default)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -53,12 +53,6 @@ module Devise
   # True values used to check params
   TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE']
 
-  # Track the configs that user explicit changed the default value. It is
-  # helpfull to not warn users about default values changing when they willing
-  # changed.
-  mattr_accessor :app_set_configs
-  @@app_set_configs = Set.new
-
   # Secret key used by the key generator
   mattr_accessor :secret_key
   @@secret_key = nil
@@ -284,26 +278,6 @@ module Devise
   # a fresh initializer with all configuration values.
   def self.setup
     yield self
-  end
-
-  def self.warn_default_config_changed(config, current_default, new_default)
-    unless app_set_configs.include?(config)
-      warn = <<-MESSAGE.strip_heredoc
-        [Devise] config.#{config} will have a new default on Devise 4.1
-        To keep the current behavior please set in your config/initializers/devise.rb the following:
-
-          Devise.setup do |config|
-            config.#{config} = #{current_default}
-          end
-
-        If you want to use the new default:
-
-          Devise.setup do |config|
-            config.#{config} = #{new_default}
-          end
-      MESSAGE
-      ActiveSupport::Deprecation.warn(warn)
-    end
   end
 
   class Getter

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -143,20 +143,8 @@ module Devise
   @@confirmation_keys = [:email]
 
   # Defines if email should be reconfirmable.
-  # False by default for backwards compatibility.
-  # TODO: 4.1 Do: @@reconfirmable = true
-  mattr_reader :reconfirmable
-  @@reconfirmable = false
-
-  def self.reconfirmable=(reconfirmable)
-    app_set_configs << :reconfirmable
-    @@reconfirmable = reconfirmable
-  end
-
-  def reconfirmable=(reconfirmable)
-    app_set_configs << :reconfirmable
-    @@reconfirmable = reconfirmable
-  end
+  mattr_accessor :reconfirmable
+  @@reconfirmable = true
 
   # Time interval to timeout the user session without activity.
   mattr_accessor :timeout_in
@@ -319,7 +307,6 @@ module Devise
   def self.setup
     yield self
 
-    warn_default_config_changed(:reconfirmable, 'false', 'true')
     warn_default_config_changed(:sign_out_via, ':get', ':delete')
     warn_default_config_changed(:skip_session_storage, '[]', '[:http_auth]')
   end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -39,7 +39,6 @@ class DeviseTest < ActiveSupport::TestCase
     Devise.app_set_configs = Set.new
 
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
-    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /skip_session_storage/ }
 
     Devise.setup do
     end
@@ -48,11 +47,9 @@ class DeviseTest < ActiveSupport::TestCase
   test 'setup block doest not warns when the change is explicit set' do
     ActiveSupport::Deprecation.expects(:warn).never
 
-    swap Devise,
-        sign_out_via: :get,
-        skip_session_storage: [] do
-        Devise.setup do
-        end
+    swap Devise, sign_out_via: :get do
+      Devise.setup do
+      end
     end
   end
 

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -35,24 +35,6 @@ class DeviseTest < ActiveSupport::TestCase
     end
   end
 
-  test 'setup block warns about defaults changing' do
-    Devise.app_set_configs = Set.new
-
-    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
-
-    Devise.setup do
-    end
-  end
-
-  test 'setup block doest not warns when the change is explicit set' do
-    ActiveSupport::Deprecation.expects(:warn).never
-
-    swap Devise, sign_out_via: :get do
-      Devise.setup do
-      end
-    end
-  end
-
   test 'stores warden configuration' do
     assert_kind_of Devise::Delegator, Devise.warden_config.failure_app
     assert_equal :user, Devise.warden_config.default_scope

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -37,11 +37,10 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'setup block warns about defaults changing' do
     Devise.app_set_configs = Set.new
-    
+
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /reconfirmable/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /skip_session_storage/ }
-    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /strip_whitespace_keys/ }
 
     Devise.setup do
     end
@@ -53,8 +52,7 @@ class DeviseTest < ActiveSupport::TestCase
     swap Devise,
         reconfirmable: false,
         sign_out_via: :get,
-        skip_session_storage: [],
-        strip_whitespace_keys: [] do
+        skip_session_storage: [] do
         Devise.setup do
         end
     end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -38,7 +38,6 @@ class DeviseTest < ActiveSupport::TestCase
   test 'setup block warns about defaults changing' do
     Devise.app_set_configs = Set.new
 
-    ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /reconfirmable/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /sign_out_via/ }
     ActiveSupport::Deprecation.expects(:warn).with() { |value| value =~ /skip_session_storage/ }
 
@@ -50,7 +49,6 @@ class DeviseTest < ActiveSupport::TestCase
     ActiveSupport::Deprecation.expects(:warn).never
 
     swap Devise,
-        reconfirmable: false,
         sign_out_via: :get,
         skip_session_storage: [] do
         Devise.setup do

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -30,7 +30,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
     swap Devise, sign_out_all_scopes: false do
       sign_in_as_user
       sign_in_as_admin
-      get destroy_user_session_path
+      delete destroy_user_session_path
       assert_not warden.authenticated?(:user)
       assert warden.authenticated?(:admin)
     end
@@ -41,7 +41,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_user
       sign_in_as_admin
 
-      get destroy_admin_session_path
+      delete destroy_admin_session_path
       assert_not warden.authenticated?(:admin)
       assert warden.authenticated?(:user)
     end
@@ -52,7 +52,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_user
       sign_in_as_admin
 
-      get destroy_user_session_path
+      delete destroy_user_session_path
       assert_not warden.authenticated?(:user)
       assert_not warden.authenticated?(:admin)
     end
@@ -63,7 +63,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_user
       sign_in_as_admin
 
-      get destroy_admin_session_path
+      delete destroy_admin_session_path
       assert_not warden.authenticated?(:admin)
       assert_not warden.authenticated?(:user)
     end
@@ -109,7 +109,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
     sign_in_as_admin
     assert warden.authenticated?(:admin)
 
-    get destroy_admin_session_path
+    delete destroy_admin_session_path
     assert_response :redirect
     assert_redirected_to root_path
 
@@ -119,7 +119,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
   end
 
   test 'unauthenticated admin set message on sign out' do
-    get destroy_admin_session_path
+    delete destroy_admin_session_path
     assert_response :redirect
     assert_redirected_to root_path
 
@@ -501,34 +501,34 @@ class AuthenticationOthersTest < Devise::IntegrationTest
 
   test 'sign out with html redirects' do
     sign_in_as_user
-    get destroy_user_session_path
+    delete destroy_user_session_path
     assert_response :redirect
     assert_current_url '/'
 
     sign_in_as_user
-    get destroy_user_session_path(format: 'html')
+    delete destroy_user_session_path(format: 'html')
     assert_response :redirect
     assert_current_url '/'
   end
 
   test 'sign out with xml format returns no content' do
     sign_in_as_user
-    get destroy_user_session_path(format: 'xml')
+    delete destroy_user_session_path(format: 'xml')
     assert_response :no_content
     assert_not warden.authenticated?(:user)
   end
 
   test 'sign out with json format returns no content' do
     sign_in_as_user
-    get destroy_user_session_path(format: 'json')
+    delete destroy_user_session_path(format: 'json')
     assert_response :no_content
     assert_not warden.authenticated?(:user)
   end
 
   test 'sign out with non-navigational format via XHR does not redirect' do
     swap Devise, navigational_formats: ['*/*', :html] do
-      sign_in_as_user
-      get destroy_user_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "application/json,text/javascript,*/*" } # NOTE: Bug is triggered by combination of XHR and */*.
+      sign_in_as_admin
+      get destroy_sign_out_via_get_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "application/json,text/javascript,*/*" } # NOTE: Bug is triggered by combination of XHR and */*.
       assert_response :no_content
       assert_not warden.authenticated?(:user)
     end
@@ -538,7 +538,7 @@ class AuthenticationOthersTest < Devise::IntegrationTest
   test 'sign out with navigational format via XHR does redirect' do
     swap Devise, navigational_formats: ['*/*', :html] do
       sign_in_as_user
-      get destroy_user_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "text/html,*/*" }
+      delete destroy_user_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "text/html,*/*" }
       assert_response :redirect
       assert_not warden.authenticated?(:user)
     end

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -11,13 +11,15 @@ class HttpAuthenticationTest < Devise::IntegrationTest
   end
 
   test 'sign in should authenticate with http' do
-    sign_in_as_new_user_with_http
-    assert_response 200
-    assert_match '<email>user@test.com</email>', response.body
-    assert warden.authenticated?(:user)
+    swap Devise, skip_session_storage: [] do
+      sign_in_as_new_user_with_http
+      assert_response 200
+      assert_match '<email>user@test.com</email>', response.body
+      assert warden.authenticated?(:user)
 
-    get users_path(format: :xml)
-    assert_response 200
+      get users_path(format: :xml)
+      assert_response 200
+    end
   end
 
   test 'sign in should authenticate with http but not emit a cookie if skipping session storage' do

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -182,7 +182,7 @@ class RememberMeTest < Devise::IntegrationTest
     get users_path
     assert warden.authenticated?(:user)
 
-    get destroy_user_session_path
+    delete destroy_user_session_path
     assert_not warden.authenticated?(:user)
     assert_nil warden.cookies['remember_user_token']
 

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -89,7 +89,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
     user = sign_in_as_user
     get expire_user_path(user)
 
-    get destroy_user_session_path
+    delete destroy_user_session_path
 
     assert_response :redirect
     assert_redirected_to root_path

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -16,7 +16,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     assert_equal user.current_sign_in_at, user.last_sign_in_at
     assert user.current_sign_in_at >= user.created_at
 
-    visit destroy_user_session_path
+    delete destroy_user_session_path
     new_time = 2.seconds.from_now
     Time.stubs(:now).returns(new_time)
 
@@ -56,7 +56,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     user.reload
     assert_equal 1, user.sign_in_count
 
-    visit destroy_user_session_path
+    delete destroy_user_session_path
     sign_in_as_user
     user.reload
     assert_equal 2, user.sign_in_count
@@ -80,7 +80,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     end
     user.reload
     assert_equal 0, user.sign_in_count
-    visit destroy_user_session_path
+    delete destroy_user_session_path
 
     sign_in_as_user do
       header 'devise.skip_trackable', false

--- a/test/mapping_test.rb
+++ b/test/mapping_test.rb
@@ -35,8 +35,8 @@ class MappingTest < ActiveSupport::TestCase
     assert_equal [], Devise.mappings[:skip_admin].used_routes
   end
 
-  test 'sign_out_via defaults to :get' do
-    assert_equal :get, Devise.mappings[:user].sign_out_via
+  test 'sign_out_via defaults to :delete' do
+    assert_equal :delete, Devise.mappings[:user].sign_out_via
   end
 
   test 'allows custom sign_out_via to be given' do

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
   namespace :sign_out_via, module: "devise" do
     devise_for :deletes, sign_out_via: :delete, class_name: "Admin"
     devise_for :posts, sign_out_via: :post, class_name: "Admin"
+    devise_for :gets, sign_out_via: :get, class_name: "Admin"
     devise_for :delete_or_posts, sign_out_via: [:delete, :post], class_name: "Admin"
   end
 

--- a/test/rails_app/lib/shared_user.rb
+++ b/test/rails_app/lib/shared_user.rb
@@ -4,7 +4,8 @@ module SharedUser
   included do
     devise :database_authenticatable, :confirmable, :lockable, :recoverable,
            :registerable, :rememberable, :timeoutable,
-           :trackable, :validatable, :omniauthable, password_length: 7..72
+           :trackable, :validatable, :omniauthable, password_length: 7..72,
+           reconfirmable: false
 
     attr_accessor :other_key
 

--- a/test/rails_app/lib/shared_user_without_omniauth.rb
+++ b/test/rails_app/lib/shared_user_without_omniauth.rb
@@ -4,7 +4,7 @@ module SharedUserWithoutOmniauth
   included do
     devise :database_authenticatable, :confirmable, :lockable, :recoverable,
       :registerable, :rememberable, :timeoutable,
-      :trackable, :validatable
+      :trackable, :validatable, reconfirmable: false
   end
 
   def raw_confirmation_token

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -14,7 +14,7 @@ class DefaultRoutingTest < ActionController::TestCase
   end
 
   test 'map destroy user session' do
-    assert_recognizes({controller: 'devise/sessions', action: 'destroy'}, {path: 'users/sign_out', method: :get})
+    assert_recognizes({controller: 'devise/sessions', action: 'destroy'}, {path: 'users/sign_out', method: :delete})
     assert_named_route "/users/sign_out", :destroy_user_session_path
   end
 
@@ -146,7 +146,7 @@ class CustomizedRoutingTest < ActionController::TestCase
   end
 
   test 'map account with custom path name for session sign out' do
-    assert_recognizes({controller: 'devise/sessions', action: 'destroy', locale: 'en'}, '/en/accounts/logout')
+    assert_recognizes({controller: 'devise/sessions', action: 'destroy', locale: 'en'}, {path: '/en/accounts/logout', method: :delete })
   end
 
   test 'map account with custom path name for password' do


### PR DESCRIPTION
In our configuration template we explicit set some configurations as recommended defaults.
Now we are enforcing these configurations to be the defaults.
It also removes all warning code about this change.