### PR TITLE
Send on create confirmation email after commit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
   gem "omniauth-openid", "~> 1.0.1"
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 1.1", require: false
+  gem 'test_after_commit', require: false
 end
 
 platforms :jruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    test_after_commit (1.0.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -173,6 +175,7 @@ DEPENDENCIES
   rails (~> 4.2.6)
   rdoc
   sqlite3
+  test_after_commit
   webrat (= 0.7.3)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.rails-4.1-stable
+++ b/gemfiles/Gemfile.rails-4.1-stable
@@ -12,6 +12,7 @@ group :test do
   gem "omniauth-openid", "~> 1.0.1"
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 1.1", require: false
+  gem 'test_after_commit', require: false
 end
 
 platforms :jruby do

--- a/gemfiles/Gemfile.rails-4.1-stable.lock
+++ b/gemfiles/Gemfile.rails-4.1-stable.lock
@@ -48,7 +48,7 @@ GIT
 PATH
   remote: ..
   specs:
-    devise (4.0.0.rc2)
+    devise (4.0.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -133,6 +133,8 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
+    test_after_commit (1.0.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -161,6 +163,7 @@ DEPENDENCIES
   rails!
   rdoc
   sqlite3
+  test_after_commit
   webrat (= 0.7.3)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.rails-4.2-stable
+++ b/gemfiles/Gemfile.rails-4.2-stable
@@ -12,6 +12,7 @@ group :test do
   gem "omniauth-openid", "~> 1.0.1"
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 1.1", require: false
+  gem 'test_after_commit', require: false
 end
 
 platforms :jruby do

--- a/gemfiles/Gemfile.rails-4.2-stable.lock
+++ b/gemfiles/Gemfile.rails-4.2-stable.lock
@@ -58,7 +58,7 @@ GIT
 PATH
   remote: ..
   specs:
-    devise (4.0.0.rc2)
+    devise (4.0.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -144,7 +144,7 @@ GEM
     rake (11.0.1)
     rdoc (4.2.2)
       json (~> 1.4)
-    responders (2.1.1)
+    responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
     ruby-openid (2.7.0)
     sprockets (3.5.2)
@@ -155,6 +155,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    test_after_commit (1.0.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -183,6 +185,7 @@ DEPENDENCIES
   rails!
   rdoc
   sqlite3
+  test_after_commit
   webrat (= 0.7.3)
 
 BUNDLED WITH

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -5,9 +5,11 @@ ActiveRecord::Base.include_root_in_json = true
 ActiveRecord::Migrator.migrate(File.expand_path("../../rails_app/db/migrate/", __FILE__))
 
 class ActiveSupport::TestCase
-  if Rails.version >= '5.0.0'
+  if Devise.rails5?
     self.use_transactional_tests = true
   else
+    # Let `after_commit` work with transactional fixtures, however this is not needed for Rails 5.
+    require 'test_after_commit'
     self.use_transactional_fixtures = true
   end
 


### PR DESCRIPTION
Fix #4062 

Call `send_on_create_confirmation_instructions` in `after_commit` instead of `after_create`, I think this is no harm in general and it makes things like async job work. 