### PR TITLE
Friendly token

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -235,8 +235,7 @@ module Devise
           if self.confirmation_token && !confirmation_period_expired?
             @raw_confirmation_token = self.confirmation_token
           else
-            raw, _ = Devise.token_generator.generate(self.class, :confirmation_token)
-            self.confirmation_token = @raw_confirmation_token = raw
+            self.confirmation_token = @raw_confirmation_token = Devise.friendly_token
             self.confirmation_sent_at = Time.now.utc
           end
         end

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -64,7 +64,7 @@ module Devise
       def send_unlock_instructions
         raw, enc = Devise.token_generator.generate(self.class, :unlock_token)
         self.unlock_token = enc
-        self.save(validate: false)
+        save(validate: false)
         send_devise_notification(:unlock_instructions, raw, {})
         raw
       end

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -99,7 +99,7 @@ module Devise
 
           self.reset_password_token   = enc
           self.reset_password_sent_at = Time.now.utc
-          self.save(validate: false)
+          save(validate: false)
           raw
         end
 


### PR DESCRIPTION
Use friendly_token over token_generator when only raw value is needed
    
The first value returned by token_generator.generate is
simply the return value of friendly_token so this code should
be equivalent.
    
The use of token_generator here dates back to when the
confirmation_token was stored as a digest, but that is no
longer true.
