### PR TITLE
Fix strategy checking in #unlock_strategy_enabled?

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -181,7 +181,7 @@ module Devise
 
         # Is the unlock enabled for the given unlock strategy?
         def unlock_strategy_enabled?(strategy)
-          [:both, strategy].include?(self.unlock_strategy)
+          [:both, self.unlock_strategy].include?(strategy)
         end
 
         # Is the lock enabled for the given lock strategy?


### PR DESCRIPTION
The argument was used in the wrong spot and caused a bug where all values would return `true` if `self.unlock_strategy` was `:both`

See https://github.com/plataformatec/devise/issues/4072