### PR TITLE
Fix strategy checking in #unlock_strategy_enabled? for :none and undefined strategies

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -181,7 +181,9 @@ module Devise
 
         # Is the unlock enabled for the given unlock strategy?
         def unlock_strategy_enabled?(strategy)
-          [:both, strategy].include?(self.unlock_strategy)
+          self.unlock_strategy == strategy ||
+            # only :time and :email are subsets of the :both strategy
+            (self.unlock_strategy == :both && [:time, :email].include?(strategy))
         end
 
         # Is the lock enabled for the given lock strategy?

--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -155,6 +155,9 @@ module Devise
         end
 
       module ClassMethods
+        # List of strategies that are enabled/supported if :both is used.
+        BOTH_STRATEGIES = [:time, :email]
+
         # Attempt to find a user by its unlock keys. If a record is found, send new
         # unlock instructions to it. If not user is found, returns a new user
         # with an email not found error.
@@ -182,8 +185,7 @@ module Devise
         # Is the unlock enabled for the given unlock strategy?
         def unlock_strategy_enabled?(strategy)
           self.unlock_strategy == strategy ||
-            # only :time and :email are subsets of the :both strategy
-            (self.unlock_strategy == :both && [:time, :email].include?(strategy))
+            (self.unlock_strategy == :both && BOTH_STRATEGIES.include?(strategy))
         end
 
         # Is the lock enabled for the given lock strategy?

--- a/test/models/lockable_test.rb
+++ b/test/models/lockable_test.rb
@@ -325,4 +325,26 @@ class LockableTest < ActiveSupport::TestCase
     user.lock_access!
     assert_equal :locked, user.unauthenticated_message
   end
+
+  test 'unlock_strategy_enabled? should return true for both, email, and time strategies if :both is used' do
+    swap Devise, unlock_strategy: :both do
+      user = create_user
+      assert_equal true, user.unlock_strategy_enabled?(:both)
+      assert_equal true, user.unlock_strategy_enabled?(:time)
+      assert_equal true, user.unlock_strategy_enabled?(:email)
+      assert_equal false, user.unlock_strategy_enabled?(:none)
+      assert_equal false, user.unlock_strategy_enabled?(:an_undefined_strategy)
+    end
+  end
+
+  test 'unlock_strategy_enabled? should return true only for the configured strategy' do
+    swap Devise, unlock_strategy: :email do
+      user = create_user
+      assert_equal false, user.unlock_strategy_enabled?(:both)
+      assert_equal false, user.unlock_strategy_enabled?(:time)
+      assert_equal true, user.unlock_strategy_enabled?(:email)
+      assert_equal false, user.unlock_strategy_enabled?(:none)
+      assert_equal false, user.unlock_strategy_enabled?(:an_undefined_strategy)
+    end
+  end
 end


### PR DESCRIPTION
A bug that if the unlock strategy was set to `:both`, it would return true for all & any inputs

See #4072
PR is an improvement on #4073 