### PR TITLE
Fix Problem with case insentivity comparison(on mysql) when do confirmation

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -301,7 +301,9 @@ module Devise
         # Options must have the confirmation_token
         def confirm_by_token(confirmation_token)
           confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
-          unless confirmable
+          # need `confirmable.confirmation_token != confirmation_token`
+          # because mysql by default is case insensitive
+          if !confirmable || confirmable.confirmation_token != confirmation_token
             confirmation_digest = Devise.token_generator.digest(self, :confirmation_token, confirmation_token)
             confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_digest)
           end


### PR DESCRIPTION
Hi guys,
I found out that when I do confirmation, the token comparison is case insensitive. This downgrades the entropy on the token. After do investigation I found out that by default mysql  comparison is case insensitive. 
![screen shot 2016-05-05 at 12 34 22 pm](https://cloud.githubusercontent.com/assets/4647969/15036767/cdf62fe0-12bd-11e6-812b-1fe40e56f192.png)
![screen shot 2016-05-05 at 12 34 32 pm](https://cloud.githubusercontent.com/assets/4647969/15036768/cdfef9e0-12bd-11e6-8d49-27df9db9b4b9.png)

For case sensitive comparison in mysql there are several choices such as do [binary comparison](http://dev.mysql.com/doc/refman/5.0/en/charset-binary-op.html), or change the collation to `utf8_bin`(CMIIW).

However when developer generate user table migration using devise, the collation is not `utf8_bin`
Therefore, I make it like this

source for case insensitivity comparison in mysql: http://stackoverflow.com/questions/3936967/mysql-case-insensitive-select

I've tried to make test but it's useless since in test environment devise use sqlite(which is case sensitive, I've tried it)

thank you
