### PR TITLE
Fix overwriting the remember_token when a valid one already exists

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -46,7 +46,7 @@ module Devise
       end
 
       def remember_me!
-        self.remember_token = self.class.remember_token if respond_to?(:remember_token)
+        self.remember_token ||= self.class.remember_token if respond_to?(:remember_token)
         self.remember_created_at ||= Time.now.utc
         save(validate: false) if self.changed?
       end

--- a/test/models/rememberable_test.rb
+++ b/test/models/rememberable_test.rb
@@ -16,6 +16,18 @@ class RememberableTest < ActiveSupport::TestCase
     assert user.remember_created_at
   end
 
+  test 'remember_me should not generate a new token if valid token exists' do
+    user = create_user
+    user.singleton_class.send(:attr_accessor, :remember_token)
+    User.to_adapter.expects(:find_first).returns(nil)
+
+    user.remember_me!
+    existing_token = user.remember_token
+
+    user.remember_me!
+    assert_equal existing_token, user.remember_token
+  end
+
   test 'forget_me should not clear remember token if using salt' do
     user = create_user
     user.remember_me!


### PR DESCRIPTION
The remember_token should not get overwritten when a user is
signing in and a valid token already exists.

Fixes #3950.