### PR TITLE
Fix suggested omniauth path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 
 * deprecations
   * omniauth routes are no longer defined with a wildcard `:provider` parameter,
-    and provider specific routes are defined instead, so route helpers like `user_omniauth_authorize_path(:github)` are deprecated in favor of `user_github_authorize_path`.
+    and provider specific routes are defined instead, so route helpers like `user_omniauth_authorize_path(:github)` are deprecated in favor of `user_github_omniauth_authorize_path`.
     You can still use `omniauth_authorize_path(:user, :github)` if you need to
     call the helpers dynamically.
 


### PR DESCRIPTION
The suggested omniauth path noted in the CHANGELOG.md under 4.0.0.rc2 
did not work. It was missing an `_omniauth` in the middle of the 
method name.

user_github_authorize_path => user_github_omniauth_authorize_path