### PR TITLE
Change behavior to skip reconfirmation after creating a record with #save called in callback

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -43,7 +43,7 @@ module Devise
 
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
-        after_create :skip_create_confirmation!, if: :send_confirmation_notification?
+        after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
         if respond_to?(:after_commit) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
@@ -56,7 +56,7 @@ module Devise
 
       def initialize(*args, &block)
         @bypass_confirmation_postpone = false
-        @skip_create_confirmation = false
+        @skip_reconfirmation_in_callback = false
         @reconfirmation_required = false
         @skip_confirmation_notification = false
         @raw_confirmation_token = nil
@@ -168,8 +168,8 @@ module Devise
 
         # To not require reconfirmation after creating with #save called in a
         # callback call skip_create_confirmation!
-        def skip_create_confirmation!
-          @skip_create_confirmation = true
+        def skip_reconfirmation_in_callback!
+          @skip_reconfirmation_in_callback = true
         end
 
         # A callback method used to deliver confirmation
@@ -264,7 +264,7 @@ module Devise
             email_changed? &&
             !@bypass_confirmation_postpone &&
             self.email.present? &&
-            (!@skip_create_confirmation || !self.email_was.nil?)
+            (!@skip_reconfirmation_in_callback || !self.email_was.nil?)
           @bypass_confirmation_postpone = false
           postpone
         end

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -166,7 +166,7 @@ module Devise
 
       protected
 
-        # To not require reoncfirmation after creating with #save called in a
+        # To not require reconfirmation after creating with #save called in a
         # callback call skip_create_confirmation!
         def skip_create_confirmation!
           @skip_create_confirmation = true

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -508,4 +508,12 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin = Admin::WithSaveInCallback.create(valid_attributes.except(:username))
     assert !admin.pending_reconfirmation?
   end
+
+  test 'should require reconfirmation after creating a record and updating the email' do
+    admin = create_admin
+    assert !admin.instance_variable_get(:@bypass_confirmation_postpone)
+    admin.email = "new_test@email.com"
+    admin.save
+    assert admin.pending_reconfirmation?
+  end
 end


### PR DESCRIPTION
The following commit was breaking stuff on our system for a new email confirmation when the email is changed while the object is still in memory:
https://github.com/plataformatec/devise/commit/1d57169c7bd12977a6697a5a06cda265442bb5c8

This is due to `skip_reconfirmation!` in `send_on_create_confirmation_instructions` because it sets `@bypass_confirmation_postpone` to true which lets `postpone_email_change?` return false.

The case was added to the confirmable test case. Basically, the skipping of the reconfirmation as part of an after_create hook needs to be treated differently from a general bypass. To ensure that this is skipped when save is called in an after_create hook but NOT if the email is changed from an existing email, additional checks were added.
