### PR TITLE
Add public_file_server setting for Rails5

### DIFF
--- a/test/rails_app/config/environments/production.rb
+++ b/test/rails_app/config/environments/production.rb
@@ -20,7 +20,9 @@ RailsApp::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  if Rails.version >= "4.2.0"
+  if Rails.version >= "5.0.0"
+    config.public_file_server.enabled = false
+  elsif Rails.version >= "4.2.0"
     config.serve_static_files = false
   else
     config.serve_static_assets = false

--- a/test/rails_app/config/environments/test.rb
+++ b/test/rails_app/config/environments/test.rb
@@ -14,15 +14,14 @@ RailsApp::Application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  if Rails.version >= "4.2.0"
+  if Rails.version >= "5.0.0"
+    config.public_file_server.enabled = true
+    config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
+  elsif Rails.version >= "4.2.0"
     config.serve_static_files = true
+    config.static_cache_control = "public, max-age=3600"
   else
     config.serve_static_assets = true
-  end
-
-  if Rails.version >= "5.0.0"
-    config.public_file_server.headers = {'Cache-Control' => 'public, max-age=3600'}
-  else
     config.static_cache_control = "public, max-age=3600"
   end
 


### PR DESCRIPTION
I added public_file_server setting for Rails5.
Based on the warning "DEPRECATION WARNING: `config.serve_static_files` is deprecated and will be removed in Rails 5.1."