### PR TITLE
Implement Devise::Models::Authenticatable#inspect, re-using #serializable_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
     Devise mappings be loaded during boot time (by @sidonath).
   * Added `Devise::Test::IntegrationHelpers` to bypass the sign in process using
     Warden test API (by @lucasmazza).
+  * Define `inspect` in `Devise::Models::Authenticatable` to help ensure password hashes
+    aren't included in exceptions or otherwise accidentally serialized (by @tkrajcar).
 * deprecations
   * `Devise::TestHelpers` is deprecated in favor of `Devise::Test::ControllerHelpers`
     (by @lucasmazza).

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -114,6 +114,15 @@ module Devise
         super(options)
       end
 
+      # Redefine inspect using serializable_hash, to ensure we don't accidentally
+      # leak passwords into exceptions.
+      def inspect
+        inspection = serializable_hash.collect do |k,v|
+          "#{k}: #{respond_to?(:attribute_for_inspect) ? attribute_for_inspect(k) : v.inspect}"
+        end
+        "#<#{self.class} #{inspection.join(", ")}>"
+      end
+
       protected
 
       def devise_mailer

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -35,6 +35,11 @@ class SerializableTest < ActiveSupport::TestCase
     assert_key "confirmation_token", from_json(force_except: :email)
   end
 
+  test 'should not include unsafe keys in inspect' do
+    assert_match(/email/, @user.inspect)
+    assert_no_match(/confirmation_token/, @user.inspect)
+  end
+
   def assert_key(key, subject)
     assert subject.key?(key), "Expected #{subject.inspect} to have key #{key.inspect}"
   end


### PR DESCRIPTION
Currently, running `inspect()` on any Devise-including model falls back to the default ActiveRecord or Mongoid behavior, which is to generate a string based on all database fields, without any sanitization. `inspect` is commonly used, including [within Devise itself](https://github.com/plataformatec/devise/blob/69bee06ceee6280b54304928bb6e55c5064abad8/lib/devise/mapping.rb#L44), as part of exception messages, and this results in the `encrypted_password` field being included in the exception. When using an external exception tracker, this can create a security disclosure issue.

This change implements `inspect`, using the existing `serializable_hash` implementation to determine which keys to include.

Before (using ActiveRecord):
    
    #<User id: 1, username: "usertest", facebook_token: nil, email: "test45@example.com", encrypted_password: "$2a$04$c/RNbdW8NB07LHGsSAiN6uYyn/GXsxX21cu3LeH1oHa...", reset_password_token: nil, reset_password_sent_at: nil, remember_created_at: nil, sign_in_count: 0, current_sign_in_at: nil, last_sign_in_at: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, confirmation_token: "HRZJCvs8pHJe9QJxrzEW", confirmed_at: nil, confirmation_sent_at: "2016-06-03 22:17:18", failed_attempts: 0, unlock_token: nil, locked_at: nil, created_at: "2016-06-03 22:17:18", updated_at: "2016-06-03 22:17:18">

After:

    #<User id: 1, username: "usertest", facebook_token: nil, email: "test170@example.com", created_at: "2016-06-03 22:19:40", updated_at: "2016-06-03 22:19:40">