### PR TITLE
Add missing support of  Rails.application.config.action_controller.relative_url_root

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -252,5 +252,17 @@ module Devise
     def request_format
       @request_format ||= request.format.try(:ref)
     end
+
+    def relative_url_root
+      @relative_url_root ||= begin
+        config = Rails.application.config
+
+        config.try(:relative_url_root) || config.action_controller.try(:relative_url_root)
+      end
+    end
+
+    def relative_url_root?
+      relative_url_root.present?
+    end
   end
 end

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -50,13 +50,11 @@ module Devise
     end
 
     def recall
-      config = Rails.application.config
-
-      header_info = if config.try(:relative_url_root)
-        base_path = Pathname.new(config.relative_url_root)
+      header_info = if relative_url_root?
+        base_path = Pathname.new(relative_url_root)
         full_path = Pathname.new(attempted_path)
 
-        { "SCRIPT_NAME" => config.relative_url_root,
+        { "SCRIPT_NAME" => relative_url_root,
           "PATH_INFO" => '/' + full_path.relative_path_from(base_path).to_s }
       else
         { "PATH_INFO" => attempted_path }
@@ -144,11 +142,7 @@ module Devise
 
       opts[:format] = request_format unless skip_format?
 
-      config = Rails.application.config
-
-      if config.respond_to?(:relative_url_root) && config.relative_url_root.present?
-        opts[:script_name] = config.relative_url_root
-      end
+      opts[:script_name] = relative_url_root if relative_url_root?
 
       router_name = Devise.mappings[scope].router_name || Devise.available_router_name
       context = send(router_name)


### PR DESCRIPTION
According to Ruby on Rails documentation there are 2 ways deploy your application to a subdirectory.

[doc: ](http://edgeguides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root)
```
class Application < Rails::Application
  ...
  config.relative_url_root = '/my_route'
  ...
end
```

or

[doc: ](http://edgeguides.rubyonrails.org/configuring.html#configuring-action-controller)
```
class Application < Rails::Application
  ...
  config.action_controller.relative_url_root = '/my_route'
  ...
end
```