### PR TITLE
Remove unnecessary 'warden.raw_session.inspect'

### DIFF
--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -74,7 +74,6 @@ module Devise
         scope = Devise::Mapping.find_scope!(resource_or_scope)
         user = warden.user(scope: scope, run_callbacks: false) # If there is no user
 
-        warden.raw_session.inspect # Without this inspect here. The session does not clear.
         warden.logout(scope)
         warden.clear_strategies_cache!(scope: scope)
         instance_variable_set(:"@current_#{scope}", nil)


### PR DESCRIPTION
When looking into performance issues in my company's rails application, I found a lot of time was spent in `Devise::Controllers::SignInOut#sign_out` whenever a user logged out. Upon closer examination, it seems the majority of the time is due to the `warden.raw_session.inspect` line. In my case, we have a very large Rails application (100s of models, 100s of controllers), so the output of that 'inspect' statement seems to take a while to process.

Tests pass despite the "Without this inspect here. The session does not clear" comment. Removing it makes sign-out seem almost instant for my use case. 

Furthermore, [this old commit](https://github.com/plataformatec/devise/commit/b786c384d54a6365bdc6c0cf6068dc5325a301a9#diff-e151dce8935252d1c6bad0356045060aL75) removes the same statement from `Devise::Controllers::SignInOut#sign_out_all_scopes`. So, I'm really wondering if the 'warden.raw_session.inspect' line is really necessary.

Tested my change against master and v3.5.4.