### PR TITLE
Fix Rails 5 env deprecation warning

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -13,14 +13,14 @@ class Devise::OmniauthCallbacksController < DeviseController
   protected
 
   def failed_strategy
-    request.respond_to?(:get_header) ? request.get_header("omniauth.error.strategy") : env["omniauth.error.strategy"]
+    request.respond_to?(:get_header) ? request.get_header("omniauth.error.strategy") : request.env["omniauth.error.strategy"]
   end
 
   def failure_message
-    exception = request.respond_to?(:get_header) ? request.get_header("omniauth.error") : env["omniauth.error"]
+    exception = request.respond_to?(:get_header) ? request.get_header("omniauth.error") : request.env["omniauth.error"]
     error   = exception.error_reason if exception.respond_to?(:error_reason)
     error ||= exception.error        if exception.respond_to?(:error)
-    error ||= (request.respond_to?(:get_header) ? request.get_header("omniauth.error.type") : env["omniauth.error.type"]).to_s
+    error ||= (request.respond_to?(:get_header) ? request.get_header("omniauth.error.type") : request.env["omniauth.error.type"]).to_s
     error.to_s.humanize if error
   end
 

--- a/lib/devise/controllers/rememberable.rb
+++ b/lib/devise/controllers/rememberable.rb
@@ -18,7 +18,7 @@ module Devise
 
       # Remembers the given resource by setting up a cookie
       def remember_me(resource)
-        return if env["devise.skip_storage"]
+        return if request.env["devise.skip_storage"]
         scope = Devise::Mapping.find_scope!(resource)
         resource.remember_me!
         cookies.signed[remember_key(resource, scope)] = remember_cookie_values(resource)

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -64,7 +64,7 @@ module Devise
         if request.respond_to?(:set_header)
           request.set_header(var, value)
         else
-          env[var]  = value
+          request.env[var]  = value
         end
       end
 
@@ -202,11 +202,11 @@ module Devise
     end
 
     def warden
-      request.respond_to?(:get_header) ? request.get_header("warden") : env["warden"]
+      request.respond_to?(:get_header) ? request.get_header("warden") : request.env["warden"]
     end
 
     def warden_options
-      request.respond_to?(:get_header) ? request.get_header("warden.options") : env["warden.options"]
+      request.respond_to?(:get_header) ? request.get_header("warden.options") : request.env["warden.options"]
     end
 
     def warden_message

--- a/lib/devise/hooks/proxy.rb
+++ b/lib/devise/hooks/proxy.rb
@@ -7,7 +7,7 @@ module Devise
       include Devise::Controllers::SignInOut
 
       attr_reader :warden
-      delegate :cookies, :env, to: :warden
+      delegate :cookies, :request, to: :warden
 
       def initialize(warden)
         @warden = warden

--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -121,7 +121,7 @@ module Devise
 
       def _process_unauthenticated(env, options = {})
         options[:action] ||= :unauthenticated
-        proxy = env['warden']
+        proxy = request.env['warden']
         result = options[:result] || proxy.result
 
         ret = case result
@@ -131,8 +131,8 @@ module Devise
         when :custom
           proxy.custom_response
         else
-          env["PATH_INFO"] = "/#{options[:action]}"
-          env["warden.options"] = options
+          request.env["PATH_INFO"] = "/#{options[:action]}"
+          request.env["warden.options"] = options
           Warden::Manager._run_callbacks(:before_failure, env, options)
 
           status, headers, response = Devise.warden_config[:failure_app].call(env).to_a

--- a/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
-    data = request.respond_to?(:get_header) ? request.get_header("omniauth.auth") : env["omniauth.auth"]
+    data = request.respond_to?(:get_header) ? request.get_header("omniauth.auth") : request.env["omniauth.auth"]
     session["devise.facebook_data"] = data["extra"]["user_hash"]
     render json: data
   end


### PR DESCRIPTION
Using Rails 5.0.0.rc1 and the remember_me controller method from Devise::Controllers::Rememberable I was getting this warning a lot in my tests ```DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1```