### PR TITLE
Fixed: changing email from nil updates email but not unconfirmed_email

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -43,20 +43,30 @@ module Devise
 
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
-        after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
+        before_update :postpone_email_change_until_confirmation_and_regenerate_confirmation_token, if: :postpone_email_change?
         if respond_to?(:after_commit) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
-          after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
+          after_commit on: :update do
+            if previous_changes.include?(:email) && send_confirmation_notification?
+              send_confirmation_instructions
+            elsif reconfirmation_required?
+              send_reconfirmation_instructions
+            end
+          end
         else # Mongoid
           after_create :send_on_create_confirmation_instructions, if: :send_confirmation_notification?
-          after_update :send_reconfirmation_instructions, if: :reconfirmation_required?
+          after_update on: :update do
+            if email_changed? && send_confirmation_notification?
+              send_confirmation_instructions
+            elsif reconfirmation_required?
+              send_reconfirmation_instructions
+            end
+          end
         end
-        before_update :postpone_email_change_until_confirmation_and_regenerate_confirmation_token, if: :postpone_email_change?
       end
 
       def initialize(*args, &block)
         @bypass_confirmation_postpone = false
-        @skip_reconfirmation_in_callback = false
         @reconfirmation_required = false
         @skip_confirmation_notification = false
         @raw_confirmation_token = nil
@@ -166,12 +176,6 @@ module Devise
 
       protected
 
-        # To not require reconfirmation after creating with #save called in a
-        # callback call skip_create_confirmation!
-        def skip_reconfirmation_in_callback!
-          @skip_reconfirmation_in_callback = true
-        end
-
         # A callback method used to deliver confirmation
         # instructions on creation. This can be overridden
         # in models to map to a nice sign up e-mail.
@@ -261,20 +265,18 @@ module Devise
 
         def postpone_email_change?
           postpone = self.class.reconfirmable &&
-            email_changed? &&
             !@bypass_confirmation_postpone &&
-            self.email.present? &&
-            (!@skip_reconfirmation_in_callback || !self.email_was.nil?)
+            email_changed? && email.present? && !email_was.nil?
           @bypass_confirmation_postpone = false
           postpone
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required && (self.email.present? || self.unconfirmed_email.present?)
+          self.class.reconfirmable && @reconfirmation_required && email.present?
         end
 
         def send_confirmation_notification?
-          confirmation_required? && !@skip_confirmation_notification && self.email.present?
+          confirmation_required? && !@skip_confirmation_notification && email.present?
         end
 
         # A callback initiated after successfully confirming. This can be

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -442,6 +442,13 @@ class ReconfirmableTest < ActiveSupport::TestCase
     assert_equal 'new_test@example.com', admin.email
   end
 
+  test 'should update email when updating from nil' do
+    admin = create_admin(email: nil)
+    new_email = 'new_test@example.com'
+    assert admin.update_attributes(email: new_email)
+    assert_equal new_email, admin.email
+  end
+
   test 'should not allow admin to get past confirmation email by resubmitting their new address' do
     admin = create_admin
     assert admin.confirm


### PR DESCRIPTION
https://github.com/plataformatec/devise/pull/4043#discussion_r64995026

@ulissesalmeida here is failing test: https://github.com/plataformatec/devise/blob/ac702843ddaa5652fde7a0050ff2378e7368149e/test/models/confirmable_test.rb#L161
I can change PR to make it pass, but why it doesn't send confirmation mail to new email?

I've found https://github.com/plataformatec/devise/commit/8c1bab4951eaabc11d942a334b9ac620e54a53a8, its related to #14, but I can't understand the decision from conversation.
