### PR TITLE
fixed : ActiveRecord check

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -44,7 +44,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if respond_to?(:after_commit) # ActiveRecord
+        if defined?(ActiveRecord::Base) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid


### PR DESCRIPTION
Seems like "send_reconfirmation_instructions" (line 49) was triggered because Mongoid 5 now implements :after_commit callbacks.

Just changed the active record check based on the ActiveRecord::Base definition.
