### PR TITLE
add block passthrough to devise_mail

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -11,9 +11,9 @@ module Devise
       protected
 
       # Configure default email options
-      def devise_mail(record, action, opts={})
+      def devise_mail(record, action, opts = {}, &block)
         initialize_from_record(record)
-        mail headers_for(action, opts)
+        mail headers_for(action, opts), &block
       end
 
       def initialize_from_record(record)

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class MailerTest < ActionMailer::TestCase
+  test "pass given block to #mail call" do
+    class TestMailer < Devise::Mailer
+      def confirmation_instructions(record, token, opts = {})
+        @token = token
+        devise_mail(record, :confirmation_instructions, opts) do |format|
+          format.html(content_transfer_encoding: "7bit")
+        end
+      end
+    end
+
+    Devise.mailer = TestMailer
+    create_user
+    mail = ActionMailer::Base.deliveries.first
+
+    assert mail.content_transfer_encoding, "7bit"
+  end
+end

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -11,8 +11,7 @@ class MailerTest < ActionMailer::TestCase
       end
     end
 
-    Devise.mailer = TestMailer
-    create_user
+    TestMailer.confirmation_instructions(create_user, "confirmation-token").deliver_now
     mail = ActionMailer::Base.deliveries.first
 
     assert mail.content_transfer_encoding, "7bit"

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -11,8 +11,7 @@ class MailerTest < ActionMailer::TestCase
       end
     end
 
-    TestMailer.confirmation_instructions(create_user, "confirmation-token").deliver_now
-    mail = ActionMailer::Base.deliveries.first
+    mail = TestMailer.confirmation_instructions(create_user, "confirmation-token")
 
     assert mail.content_transfer_encoding, "7bit"
   end


### PR DESCRIPTION
ActionMailer's ``mail`` method may receive a block for customizing the mails
format
``devise_mail`` now has the same functionality by just passing the block to ``mail`` call.

fixes plataformatec/devise#2341