### PR TITLE
Reduce ORM API surface

### DIFF
--- a/lib/devise/hooks/lockable.rb
+++ b/lib/devise/hooks/lockable.rb
@@ -2,6 +2,9 @@
 # This is only triggered when the user is explicitly set (with set_user)
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
   if record.respond_to?(:failed_attempts) && warden.authenticated?(options[:scope])
-    record.update_attribute(:failed_attempts, 0) unless record.failed_attempts.to_i.zero?
+    unless record.failed_attempts.to_i.zero?
+      record.failed_attempts = 0
+      record.save(validate: false)
+    end
   end
 end


### PR DESCRIPTION
The benefit of this commit is twofold:

1) In the Devise codebase, `update_attribute()` is only used once, while the pattern `record.attribute = value; save(validate: false)` is used in all other cases. The codebase will be more consistent.

2) This reduces the API surface an ORM must expose to support Devise. The less methods an ORM must provide to Devise, the better. For example, NoBrainer (RethinkDB ORM) does not implement such `update_attribute()` method (and probably never will due to spooky no validation feature). This would allow NoBrainer to support Devise.

Thanks :)
Nico.