### PR TITLE
[Minor] Fix indentation in generators

### DIFF
--- a/lib/generators/templates/controllers/registrations_controller.rb
+++ b/lib/generators/templates/controllers/registrations_controller.rb
@@ -1,6 +1,6 @@
 class <%= @scope_prefix %>RegistrationsController < Devise::RegistrationsController
-# before_action :configure_sign_up_params, only: [:create]
-# before_action :configure_account_update_params, only: [:update]
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new

--- a/lib/generators/templates/controllers/sessions_controller.rb
+++ b/lib/generators/templates/controllers/sessions_controller.rb
@@ -1,5 +1,5 @@
 class <%= @scope_prefix %>SessionsController < Devise::SessionsController
-# before_action :configure_sign_in_params, only: [:create]
+  # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
   # def new


### PR DESCRIPTION
Some generators produce incorrect indentations E.g.

Actual
------

```ruby
class Users::RegistrationsController < Devise::RegistrationsController
# before_action :configure_sign_up_params, only: [:create]
# before_action :configure_account_update_params, only: [:update]

  # GET /resource/sign_up
...
```

Expected
---------

```ruby
class Users::RegistrationsController < Devise::RegistrationsController
  # before_action :configure_sign_up_params, only: [:create]
  # before_action :configure_account_update_params, only: [:update]

  # GET /resource/sign_up
...
```

This would result in configured linters screaming about improper code. Thought i'd fix it for everyone.