### PR TITLE
Add respond_to? to controller_helpers

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -25,7 +25,7 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        setup :setup_controller_for_warden, :warden
+        setup :setup_controller_for_warden, :warden if respond_to?(:setup)
       end
 
       # Override process to consider warden.


### PR DESCRIPTION
As @viamin says, In some case setup method isn't available.
So, I add respond_to? when call setup method.

But I don't know how to write test case. If you could point right direction, i would very pleased.

fixes plataformatec/devise#4189