### PR TITLE
[WIP] Issue #4209 - Add deliver_later option in send_devise_notification

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -287,8 +287,8 @@ module Devise
   @@token_generator = nil
 
   # Store devise notification delivery method, default is deliver now
-  mattr_accessor :delivery_method
-  @@delivery_method = :deliver_now
+  mattr_accessor :deliver_later_option
+  @@deliver_later_option = false
 
   # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -286,6 +286,10 @@ module Devise
   mattr_accessor :token_generator
   @@token_generator = nil
 
+  # Store devise notification delivery method, default is deliver now
+  mattr_accessor :delivery_method
+  @@delivery_method = :deliver_now
+
   # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -129,6 +129,10 @@ module Devise
         Devise.mailer
       end
 
+      def delivery_method
+        Devise.delivery_method
+      end
+
       # This is an internal method called every time Devise needs
       # to send a notification/mail. This can be overridden if you
       # need to customize the e-mail delivery logic. For instance,
@@ -187,8 +191,9 @@ module Devise
       def send_devise_notification(notification, *args)
         message = devise_mailer.send(notification, self, *args)
         # Remove once we move to Rails 4.2+ only.
-        if message.respond_to?(:deliver_now)
-          message.deliver_now
+
+        if delivery_method == :deliver_now || delivery_method == :deliver_later
+          message.send(delivery_method)
         else
           message.deliver
         end

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -130,7 +130,7 @@ module Devise
       end
 
       def delivery_method
-        Devise.delivery_method
+        Devise.deliver_later_option ? :deliver_later : :deliver_now
       end
 
       # This is an internal method called every time Devise needs
@@ -192,7 +192,7 @@ module Devise
         message = devise_mailer.send(notification, self, *args)
         # Remove once we move to Rails 4.2+ only.
 
-        if delivery_method == :deliver_now || delivery_method == :deliver_later
+        if message.respond_to?(:deliver_now)
           message.send(delivery_method)
         else
           message.deliver

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -271,4 +271,9 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ===> ActiveJob configuration
+  # If you want to use ActiveJob to diliver ActionMailer messages in the backgound,
+  # you can config deliver_later_option to true. Default is false
+  # config.deliver_later_option = true
 end

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -15,4 +15,12 @@ class MailerTest < ActionMailer::TestCase
 
     assert mail.content_transfer_encoding, "7bit"
   end
+
+  test "devise mailer should use deliver_later if deliver_later_option is true" do
+    swap Devise, deliver_later_option: true do
+      user = create_user
+      deliver_method = user.send(:delivery_method).to_s
+      assert_equal deliver_method, "deliver_later"
+    end
+  end
 end


### PR DESCRIPTION
#4209

Add a class variable `deliver_later_option` and modify the method `send_devise_notification` 

Now you can just add `config.deliver_later_option = true` in your `config/initailizers/devise.rb`, and devise mailer will use `deliver_later` to send every letter.

Hope to get some feedback. 😄 
