### PR TITLE
ActiveSupport deprecation warning fix on calling #ago on a Fixnum

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -26,7 +26,7 @@ module Devise
 
       # Checks whether the user session has expired based on configured time.
       def timedout?(last_access)
-        !timeout_in.nil? && last_access && last_access <= timeout_in.ago
+        !timeout_in.nil? && last_access && last_access <= timeout_in.seconds.ago
       end
 
       def timeout_in


### PR DESCRIPTION
In `Timeoutable` there is a call to #ago on a Fixnum class.  `timeout_in` returns a Fixnum from (3.days, 15.minutes, etc. as suggested values from Devise documentation / wiki) -- and so when #ago is called you get a deprecation warning from ActiveSupport that calling #ago on a number is not going to be supported.

```
DEPRECATION WARNING: Calling #ago or #until on a number (e.g. 5.ago) is deprecated and will be removed in the future, use 5.seconds.ago instead.`
```

I updated the code per ActiveSupport's recommendation for the future.  It also works with existing ActiveSupport libraries.  Specs still run green.