### PR TITLE
Fix omniauth provider generated URL in links partial

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", send("user_#{provider}_omniauth_authorize_path") %><br />
   <% end -%>
 <% end -%>


### PR DESCRIPTION
The omniauth_authorize_path(resource_name, provider) does not work any more, and a correct URL is eg. for facebook:  user_facebook_omniauth_authorize_path
