### PR TITLE
Use `strip_heredoc` for deprecation warnings

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -65,7 +65,7 @@ module Devise
           scope = resource
           resource = deprecated
 
-          ActiveSupport::Deprecation.warn <<-DEPRECATION
+          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
             [Devise] sign_in(:#{scope}, resource) on controller tests is deprecated and will be removed from Devise.
             Please use sign_in(resource, scope: :#{scope}) instead.
           DEPRECATION

--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -2,7 +2,7 @@ module Devise
   module TestHelpers
     def self.included(base)
       base.class_eval do
-        ActiveSupport::Deprecation.warn <<-DEPRECATION
+        ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
           For controller tests, please include `Devise::Test::ControllerHelpers` instead.
         DEPRECATION


### PR DESCRIPTION
I think these deprecation warning messages should use `strip_heredoc` like others.