### PR TITLE
Change the way to detect ActiveRecord vs Mongoid

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -44,7 +44,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if respond_to?(:after_commit) # ActiveRecord
+        if defined?(ActiveRecord) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -44,7 +44,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if defined?(ActiveRecord) # ActiveRecord
+        if defined?(ActiveRecord) && self.is_a?(ActiveRecord::Base) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid


### PR DESCRIPTION
Cause of **mongoid-paperclip** declaring _after_commit_ callback while **mongoid** (and MongoDB) does not support it.
