### PR TITLE
Single quotes in template README

### DIFF
--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -13,7 +13,7 @@ Some setup you must do manually if you haven't yet:
   2. Ensure you have defined root_url to *something* in your config/routes.rb.
      For example:
 
-       root to: "home#index"
+       root to: 'home#index'
 
   3. Ensure you have flash messages in app/views/layouts/application.html.erb.
      For example:


### PR DESCRIPTION
Use single quotes in template, like it is used in [/lib/generators/templates/README#L9](https://github.com/plataformatec/devise/blob/master/lib/generators/templates/README#L9)
