### PR TITLE
Update README - Decrease stretches to 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ member_session
 The Devise method in your models also accepts some options to configure its modules. For example, you can choose the cost of the hashing algorithm with:
 
 ```ruby
-devise :database_authenticatable, :registerable, :confirmable, :recoverable, stretches: 20
+devise :database_authenticatable, :registerable, :confirmable, :recoverable, stretches: 12
 ```
 
 Besides `:stretches`, you can define `:pepper`, `:encryptor`, `:confirm_within`, `:remember_for`, `:timeout_in`, `:unlock_in` among other options. For more details, see the initializer file that was created when you invoked the "devise:install" generator described above. This file is usually located at `/config/initializers/devise.rb`.


### PR DESCRIPTION
An example value of `:stretches` is `20`, which is quite slow.
For instance, take 1 minute to create an user.
When a developer set this value, it takes time to resolve the issue.

This value is set `11` [by default](https://github.com/plataformatec/devise/blob/9a11586a724487dc98dddea0ab9c8afcc0e9439d/lib/devise.rb#L71), so I think `12` is an appropriate value.