### PR TITLE
Add ActiveSupport::Notification instruments

### DIFF
--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -83,7 +83,7 @@ module Devise
 
       devise_modules_hook! do
         include Devise::Models::Authenticatable
-        include Devise::Models::Notifiable
+        include Devise::Models::Instrumentation
 
         selected_modules.each do |m|
           mod = Devise::Models.const_get(m.to_s.classify)
@@ -118,4 +118,4 @@ module Devise
 end
 
 require 'devise/models/authenticatable'
-require 'devise/models/notifiable'
+require 'devise/models/instrumentation'

--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -83,6 +83,7 @@ module Devise
 
       devise_modules_hook! do
         include Devise::Models::Authenticatable
+        include Devise::Models::Notifiable
 
         selected_modules.each do |m|
           mod = Devise::Models.const_get(m.to_s.classify)
@@ -117,3 +118,4 @@ module Devise
 end
 
 require 'devise/models/authenticatable'
+require 'devise/models/notifiable'

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -185,7 +185,7 @@ module Devise
       #     end
       #
       def send_devise_notification(notification, *args)
-        instrument "send.#{notification}.notification.devise", default_instrument_payload do
+        instrument "send.#{notification}.notification.devise" do
           message = devise_mailer.send(notification, self, *args)
           # Remove once we move to Rails 4.2+ only.
           if message.respond_to?(:deliver_now)

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -185,12 +185,14 @@ module Devise
       #     end
       #
       def send_devise_notification(notification, *args)
-        message = devise_mailer.send(notification, self, *args)
-        # Remove once we move to Rails 4.2+ only.
-        if message.respond_to?(:deliver_now)
-          message.deliver_now
-        else
-          message.deliver
+        instrument "send.#{notification}.notification.devise", default_instrument_payload do
+          message = devise_mailer.send(notification, self, *args)
+          # Remove once we move to Rails 4.2+ only.
+          if message.respond_to?(:deliver_now)
+            message.deliver_now
+          else
+            message.deliver
+          end
         end
       end
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -118,7 +118,7 @@ module Devise
         end
 
         opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
-        instrument 'send_confirmation_instructions.confirmable.devise', default_instrument_payload.merge(opts)
+        instrument 'send_confirmation_instructions.confirmable.devise', opts
         send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
       end
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -257,7 +257,9 @@ module Devise
         end
 
         def generate_confirmation_token!
-          generate_confirmation_token && save(validate: false)
+          instrument 'generate_confirmation_token.confirmable.devise' do
+            generate_confirmation_token && save(validate: false)
+          end
         end
 
         def postpone_email_change_until_confirmation_and_regenerate_confirmation_token

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -93,7 +93,11 @@ module Devise
             save(validate: args[:ensure_valid] == true)
           end
 
-          after_confirmation if saved
+          if saved
+            instrument 'confirm!.confirmable.devise'
+            after_confirmation
+          end
+
           saved
         end
       end

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -118,6 +118,7 @@ module Devise
         end
 
         opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
+        instrument 'send_confirmation_instructions.confirmable.devise', default_instrument_payload.merge(opts)
         send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
       end
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -94,7 +94,7 @@ module Devise
           end
 
           if saved
-            instrument 'confirm!.confirmable.devise'
+            instrument 'confirm.confirmable.devise'
             after_confirmation
           end
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -157,6 +157,7 @@ module Devise
       # If you don't want confirmation to be sent on create, neither a code
       # to be generated, call skip_confirmation!
       def skip_confirmation!
+        instrument 'skip_confirmation!.confirmable.devise'
         self.confirmed_at = Time.now.utc
       end
 

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -123,6 +123,8 @@ module Devise
       end
 
       def send_reconfirmation_instructions
+        instrument 'send_reconfirmation_instructions.confirmable.devise'
+
         @reconfirmation_required = false
 
         unless @skip_confirmation_notification

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -136,6 +136,7 @@ module Devise
       # Regenerates the token if the period is expired.
       def resend_confirmation_instructions
         pending_any_confirmation do
+          instrument 'resend_confirmation_instructions.confirmable.devise'
           send_confirmation_instructions
         end
       end

--- a/lib/devise/models/instrumentation.rb
+++ b/lib/devise/models/instrumentation.rb
@@ -1,7 +1,7 @@
 module Devise
   module Models
     # Gather methods used for blasting ActiveSupport::Notifications
-    module Notifiable
+    module Instrumentation
 
       protected
 

--- a/lib/devise/models/instrumentation.rb
+++ b/lib/devise/models/instrumentation.rb
@@ -5,8 +5,8 @@ module Devise
 
       protected
 
-        def instrument name, payload = nil, &block
-          payload ||= default_instrument_payload
+        def instrument name, payload = {}, &block
+          payload.reverse_merge! default_instrument_payload
           ActiveSupport::Notifications.instrument name, payload, &block
         end
 

--- a/lib/devise/models/notifiable.rb
+++ b/lib/devise/models/notifiable.rb
@@ -1,0 +1,21 @@
+module Devise
+  module Models
+    # Gather methods used for blasting ActiveSupport::Notifications
+    module Notifiable
+
+      protected
+
+        def instrument name, payload = nil, &block
+          payload ||= default_instrument_payload
+          ActiveSupport::Notifications.instrument name, payload, &block
+        end
+
+      private
+
+        def default_instrument_payload
+          { "#{ self.class.model_name.element }_id" => self.id }
+        end
+
+    end
+  end
+end

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -33,6 +33,8 @@ module Devise
       # Update password saving the record and clearing token. Returns true if
       # the passwords are valid and the record was saved, false otherwise.
       def reset_password(new_password, new_password_confirmation)
+        instrument 'reset_password.recoverable.devise'
+
         self.password = new_password
         self.password_confirmation = new_password_confirmation
 
@@ -42,10 +44,12 @@ module Devise
       # Resets reset password token and send reset password instructions by email.
       # Returns the token sent in the e-mail.
       def send_reset_password_instructions
-        token = set_reset_password_token
-        send_reset_password_instructions_notification(token)
+        instrument 'send_reset_password_instructions.recoverable.devise' do
+          token = set_reset_password_token
+          send_reset_password_instructions_notification(token)
 
-        token
+          token
+        end
       end
 
       # Checks if the reset password token sent is within the limit time.

--- a/test/models/instrumentation_test.rb
+++ b/test/models/instrumentation_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+class ConfirmableInstrumentationTest < ActiveSupport::TestCase
+  test 'should send ActiveSupport::Notification when confirmation token is generated' do
+    user = new_user
+    with_subscription_to 'generate_confirmation_token.confirmable.devise' do
+      user.send :generate_confirmation_token!
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when confirmation instructions are sent' do
+    user = new_user
+    with_subscription_to 'send_confirmation_instructions.confirmable.devise' do
+      user.save!
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when confirmation instructions are resent' do
+    user = new_user
+    with_subscription_to 'resend_confirmation_instructions.confirmable.devise' do
+      user.resend_confirmation_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when re-confirmation instructions are sent' do
+    user = new_user
+    with_subscription_to 'send_reconfirmation_instructions.confirmable.devise' do
+      user.send_reconfirmation_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when the user confirms their account' do
+    user = new_user
+    with_subscription_to 'confirm!.confirmable.devise' do
+      user.confirm!
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when confirmation is skipped' do
+    user = new_user
+    with_subscription_to 'skip_confirmation!.confirmable.devise' do
+      user.skip_confirmation!
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+end
+
+class MailerInstrumentationTest < ActiveSupport::TestCase
+  test 'should send ActiveSupport::Notification when confirmation instructions are sent' do
+    user = new_user
+    with_subscription_to 'send.confirmation_instructions.notification.devise' do
+      user.save!
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when confirmation instructions are resent' do
+    user = create_user
+    with_subscription_to 'send.confirmation_instructions.notification.devise' do
+      user.resend_confirmation_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when re-confirmation instructions are sent' do
+    user = create_user
+    with_subscription_to 'send.confirmation_instructions.notification.devise' do
+      user.send_reconfirmation_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when password reset instructions are sent' do
+    user = create_user
+    with_subscription_to 'send.reset_password_instructions.notification.devise' do
+      user.send_reset_password_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+end
+
+class RecoverableInstrumentationTest < ActiveSupport::TestCase
+  test 'should send ActiveSupport::Notification when password reset instructions are sent' do
+    user = create_user
+    with_subscription_to 'send_reset_password_instructions.recoverable.devise' do
+      user.send_reset_password_instructions
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+
+  test 'should send ActiveSupport::Notification when password is reset' do
+    user = create_user
+    with_subscription_to 'reset_password.recoverable.devise' do
+      user.reset_password! 'a_new_password', 'a_new_password'
+      assert_equal @sent_notifications.size, 1
+    end
+  end
+end

--- a/test/models/instrumentation_test.rb
+++ b/test/models/instrumentation_test.rb
@@ -35,8 +35,8 @@ class ConfirmableInstrumentationTest < ActiveSupport::TestCase
 
   test 'should send ActiveSupport::Notification when the user confirms their account' do
     user = new_user
-    with_subscription_to 'confirm!.confirmable.devise' do
-      user.confirm!
+    with_subscription_to 'confirm.confirmable.devise' do
+      user.confirm
       assert_equal @sent_notifications.size, 1
     end
   end
@@ -96,7 +96,7 @@ class RecoverableInstrumentationTest < ActiveSupport::TestCase
   test 'should send ActiveSupport::Notification when password is reset' do
     user = create_user
     with_subscription_to 'reset_password.recoverable.devise' do
-      user.reset_password! 'a_new_password', 'a_new_password'
+      user.reset_password 'a_new_password', 'a_new_password'
       assert_equal @sent_notifications.size, 1
     end
   end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -74,4 +74,17 @@ class ActiveSupport::TestCase
       end
     end
   end
+
+  def with_subscription_to notification_name, &block
+    @sent_notifications = []
+
+    subscription = ActiveSupport::Notifications.subscribe(notification_name) do |*args|
+      @sent_notifications << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    yield
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+    @sent_notifications = nil
+  end
 end


### PR DESCRIPTION
My original PR #3304 got closed by some overzealous repo reorganization on my part. This PR is the same code, rebased against the current devise master branch.
