### PR TITLE
CI against 2.1.10, 2.2.6 and 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - ruby-head
 
 gemfile:
@@ -13,7 +13,7 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 2.1.9
+    - rvm: 2.1.10
       gemfile: Gemfile
     - env: DEVISE_ORM=mongoid
       gemfile: Gemfile


### PR DESCRIPTION
The Ruby versions in .travis.yml was old.

Ruby versions:

- 2.1.9 to [2.1.10](https://www.ruby-lang.org/ja/news/2016/04/01/ruby-2-1-10-released/)
- 2.2.5 to [2.2.6](https://www.ruby-lang.org/ja/news/2016/11/15/ruby-2-2-6-released/)
- 2.3.2 to [2.3.3](https://www.ruby-lang.org/ja/news/2016/11/21/ruby-2-3-3-released/)

These are supported at Travis CI.
http://rubies.travis-ci.org

Thanks.