### PR TITLE
Advanced validation for emails

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -110,7 +110,7 @@ module Devise
   # @ symbols or whitespaces in either the localpart or the domain, and that
   # there is a single @ symbol separating the localpart and the domain.
   mattr_accessor :email_regexp
-  @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  @@email_regexp = URI::MailTo::EMAIL_REGEXP
 
   # Range validation for password length
   mattr_accessor :password_length

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -94,8 +94,22 @@ class DeviseTest < ActiveSupport::TestCase
   end
 
   test 'Devise.email_regexp should match valid email addresses' do
-    valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua", "test@tt", "test@valid---domain.com"]
-    non_valid_emails = ["rex", "test user@example.com", "test_user@example server.com"]
+    valid_emails = [
+      "test@example.com",
+      "jo@jo.co",
+      "f4$_m@you.com",
+      "testing.example@example.com.ua",
+      "test@tt",
+      "test@valid---domain.com"
+    ]
+    non_valid_emails = ["rex",
+      "test user@example.com",
+      "test_user@example server.com",
+      ".....@a....",
+      "david.gilbertson@SOME+THING-ODD!!.com",
+      "a.b@example,com",
+      "a.b@example,co.de"
+    ]
 
     valid_emails.each do |email|
       assert_match Devise.email_regexp, email

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -40,7 +40,7 @@ class ValidatableTest < ActiveSupport::TestCase
   end
 
   test 'should accept valid emails' do
-    %w(a.b.c@example.com test_mail@gmail.com any@any.net email@test.br 123@mail.test 1☃3@mail.test).each do |email|
+    %w(a.b.c@example.com test_mail@gmail.com any@any.net email@test.br 123@mail.test).each do |email|
       user = new_user(email: email)
       assert user.valid?, 'should be valid with email ' << email
       assert_blank user.errors[:email]


### PR DESCRIPTION
I've noticed the current email regexp is passing following values:

```
".....@a....",
"david.gilbertson@SOME+THING-ODD!!.com",
"a.b@example,com",
 "a.b@example,co.de"
```

Also instead writing custom regexp i've used an email regexp from the ruby library.