### PR TITLE
Replace log_process_action to append_info_to_payload

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -10,6 +10,11 @@ module Devise
         if respond_to?(:helper_method)
           helper_method :warden, :signed_in?, :devise_controller?
         end
+
+        def append_info_to_payload(payload)
+          super
+          payload[:status] ||= 401 unless payload[:exception]
+        end
       end
 
       module ClassMethods
@@ -75,11 +80,6 @@ module Devise
               helper_method "current_#{group_name}", "current_#{group_name.to_s.pluralize}", "#{group_name}_signed_in?"
             end
           METHODS
-        end
-
-        def log_process_action(payload)
-          payload[:status] ||= 401 unless payload[:exception]
-          super
         end
       end
 

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -543,6 +543,18 @@ class AuthenticationOthersTest < Devise::IntegrationTest
       refute warden.authenticated?(:user)
     end
   end
+
+  test 'not signed in should returns notification payload with 401 status' do
+    begin
+      subscriber = ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |_name, _start, _finish, _id, payload|
+        assert_equal 401, payload[:status]
+      end
+
+      get admins_path
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+  end
 end
 
 class AuthenticationKeysTest < Devise::IntegrationTest

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -544,7 +544,7 @@ class AuthenticationOthersTest < Devise::IntegrationTest
     end
   end
 
-  test 'not signed in should returns notification payload with 401 status' do
+  test 'not signed in should return notification payload with 401 status' do
     begin
       subscriber = ActiveSupport::Notifications.subscribe /process_action.action_controller/ do |_name, _start, _finish, _id, payload|
         assert_equal 401, payload[:status]


### PR DESCRIPTION
This implementation replace `log_process_action` to `append_info_to_payload`  that way the status should be present in ActiveSupport::Notifications's payload and at the log

It's based on what AR is doing:
https://github.com/rails/rails/blob/92703a9ea5d8b96f30e0b706b801c9185ef14f0e/activerecord/lib/active_record/railties/controller_runtime.rb#L35

No test change was needed but one test was include.