### PR TITLE
remove warnings about default value with new thor

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -139,7 +139,11 @@ module Devise
                               default: defined?(SimpleForm) ? "simple_form_for" : "form_for"
 
       hook_for :markerb,  desc: "Generate markerb instead of erb mail views",
-                          default: defined?(Markerb) ? :markerb : :erb,
+                          default: defined?(Markerb),
+                          type: :boolean
+
+      hook_for :erb,      desc: "Generate erb mail views",
+                          default: !defined?(Markerb),
                           type: :boolean
     end
   end


### PR DESCRIPTION
Removes warning "Expected boolean default value for '--markerb'; got :erb (string)" for thor >= 0.19.2