### PR TITLE
update devise.rb to encourage use of the Rails 4.1 secrets convention

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -2,11 +2,11 @@
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
-  # random tokens. Changing this key will render invalid all existing
-  # confirmation, reset password and unlock tokens in the database.
-  # Devise will use the `secret_key_base` as its `secret_key`
-  # by default. You can change it below and use your own secret key.
-  # config.secret_key = '<%= SecureRandom.hex(64) %>'
+  # random tokens. Changing this key will render invalid for all existing
+  # confirmation, reset password, and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key` by default
+  # You may change it below and use your own secret key.
+  # config.secret_key = Rails.application.secrets.devise_secret_key
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -108,7 +108,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '<%= SecureRandom.hex(64) %>'
+  # config.pepper = Rails.application.secrets.devise_pepper_key
 
   # Send a notification email when the user's password is changed
   # config.send_password_change_notification = false


### PR DESCRIPTION
Quite often, when I setup a new Rails application, the second and third keys that enter the secrets.yml (just after the secret_key_base) is the `devise_secret_key` and the `devise_pepper_key`. Whenever I come onto older projects, I notice that some people haven't yet switched over to using the secrets convention that has been around since Rails 4.1. Secrets will also be getting a boost in Rails 5.1 as encryption is introduced.

I've also updated the docs. Added a missing "for" and an Oxford comma. Switch "can" to "may".

If a user doesn't put in a secret or a pepper, we could default it in the app to load up the `secrets.devise_*_key` instead. This would save some people some configuration time.