### PR TITLE
Fix warnings: `Use assert_nil if expecting nil`

### DIFF
--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -164,8 +164,8 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
     @controller.instance_variable_set(:@current_user, user)
     @controller.instance_variable_set(:@current_admin, user)
     @controller.sign_out
-    assert_equal nil, @controller.instance_variable_get(:@current_user)
-    assert_equal nil, @controller.instance_variable_get(:@current_admin)
+    assert_nil @controller.instance_variable_get(:@current_user)
+    assert_nil @controller.instance_variable_get(:@current_admin)
   end
 
   test 'sign out logs out and clears up any signed in user by scope' do
@@ -175,7 +175,7 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
     @mock_warden.expects(:clear_strategies_cache!).with(scope: :user).returns(true)
     @controller.instance_variable_set(:@current_user, user)
     @controller.sign_out(:user)
-    assert_equal nil, @controller.instance_variable_get(:@current_user)
+    assert_nil @controller.instance_variable_get(:@current_user)
   end
 
   test 'sign out accepts a resource as argument' do

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -245,7 +245,7 @@ class RecoverableTest < ActiveSupport::TestCase
   end
 
   test 'should return nil if a user based on the raw token is not found' do
-    assert_equal User.with_reset_password_token('random-token'), nil
+    assert_nil User.with_reset_password_token('random-token')
   end
 
 end


### PR DESCRIPTION
Fix a following deprecated warnings.

"`Use assert_nil if expecting nil`"

Thanks.
