### PR TITLE
Clarify how store_location_for modifies URIs

### DIFF
--- a/lib/devise/controllers/store_location.rb
+++ b/lib/devise/controllers/store_location.rb
@@ -33,12 +33,9 @@ module Devise
       #
       def store_location_for(resource_or_scope, location)
         session_key = stored_location_key_for(resource_or_scope)
-        uri = parse_uri(location)
-        if uri
-          path = [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
-          path = [path, uri.fragment].compact.join('#')
-          session[session_key] = path
-        end
+        
+        path = extract_path_from_location(location)
+        session[session_key] = path if path
       end
 
       private
@@ -52,6 +49,25 @@ module Devise
       def stored_location_key_for(resource_or_scope)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
         "#{scope}_return_to"
+      end
+
+      def extract_path_from_location(location)
+        uri = parse_uri(location)
+
+        if uri 
+          path = remove_domain_from_uri(uri)
+          path = add_fragment_back_to_path(uri, path)
+
+          path
+        end
+      end
+
+      def remove_domain_from_uri(uri)
+        [uri.path.sub(/\A\/+/, '/'), uri.query].compact.join('?')
+      end
+
+      def add_fragment_back_to_path(uri, path)
+        [path, uri.fragment].compact.join('#')
       end
     end
   end


### PR DESCRIPTION
This fairly straightforward refactor extracts the most obtuse portions of `store_location_for` into the following discrete private methods:
- `extract_path_from_location`
- `remove_domain_from_uri`
- `add_fragment_back_to_path`

This may seem like indirection but it was very unclear what operation was being performed on the location sent to store_location_for prior to this change.

I considered documenting the behavior but the code seemed like a prime candidate for method extraction.