### PR TITLE
fix name of the module in the docs

### DIFF
--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -12,7 +12,7 @@ module Devise
 
     # Creates configuration values for Devise and for the given module.
     #
-    #   Devise::Models.config(Devise::DatabaseAuthenticatable, :stretches)
+    #   Devise::Models.config(Devise::Models::DatabaseAuthenticatable, :stretches)
     #
     # The line above creates:
     #


### PR DESCRIPTION
Docs say `Devise::DatabaseAuthenticatable`. 
The correct name is `Devise::Models::DatabaseAuthenticatable`.

