### PR TITLE
Validate password_confirmation when password is set, even if password_required? is false

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -31,7 +31,7 @@ module Devise
           validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
 
           validates_presence_of     :password, if: :password_required?
-          validates_confirmation_of :password, if: :password_required?
+          validates_confirmation_of :password
           validates_length_of       :password, within: password_length, allow_blank: true
         end
       end

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -107,6 +107,18 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
   end
 
+  test 'should complain about confirmation even if password is not required' do
+    user = new_user(password: 'x'*15, password_confirmation: 'x'*16)
+    user.stubs(:password_required?).returns(false)
+    assert user.invalid?
+  end
+
+  test 'should not complain about confirmation if password and confirmation are blank' do
+    user = new_user(password: '', password_confirmation: '')
+    user.stubs(:password_required?).returns(false)
+    assert user.valid?
+  end
+
   test 'should not be included in objects with invalid API' do
     assert_raise RuntimeError do
       Class.new.send :include, Devise::Models::Validatable


### PR DESCRIPTION
Expected:
Even if i overwrite `password_required?` to return `false`, IF I add a password, the password should be validated against its confirmation
Current:
The validation of the confirmation is skipped.

Background: In some cases, you might want to allow to create new users without password, but still have the ability to set a password (say: allow to login regularly with a password, and via sms/magic link). Even if a password is not required, if you add one, it should be valid.

The tests I added check that if password and confirmation are `blank?` the validatable is `valid`. From my point of view that should be `invalid`, and be `valid` only if `password` and `confirmation_password` are `nil`, but that might change the current behaviour.