### PR TITLE
Primary key type in migration template

### DIFF
--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -6,6 +6,8 @@ module ActiveRecord
     class DeviseGenerator < ActiveRecord::Generators::Base
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 
+      class_option :primary_key_type, type: :string, desc: "The type for primary key"
+
       include Devise::Generators::OrmHelpers
       source_root File.expand_path("../templates", __FILE__)
 
@@ -91,6 +93,15 @@ RUBY
        if rails5?
          "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
        end
+     end
+
+     def primary_key_type
+       primary_key_string if rails5?
+     end
+
+     def primary_key_string
+       key_string = options[:primary_key_type]
+       ", id: :#{key_string}" if key_string
      end
     end
   end

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,6 +1,6 @@
 class DeviseCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    create_table :<%= table_name %> do |t|
+    create_table :<%= table_name %><%= primary_key_type %> do |t|
 <%= migration_data -%>
 
 <% attributes.each do |attribute| -%>

--- a/test/generators/active_record_generator_test.rb
+++ b/test/generators/active_record_generator_test.rb
@@ -43,6 +43,20 @@ if DEVISE_ORM == :active_record
       assert_migration "db/migrate/devise_create_monsters.rb", /t.string   :current_sign_in_ip/
       assert_migration "db/migrate/devise_create_monsters.rb", /t.string   :last_sign_in_ip/
     end
+
+    test "do NOT add primary key type when NOT specified in rails generator" do
+      run_generator %w(monster)
+      assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters do/
+    end
+
+    test "add primary key type with rails 5 when specified in rails generator" do
+      run_generator ["monster", "--primary_key_type=uuid"]
+      if Devise.rails5?
+        assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters, id: :uuid do/
+      else
+        assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters do/
+      end
+    end
   end
 
   module RailsEngine

--- a/test/generators/active_record_generator_test.rb
+++ b/test/generators/active_record_generator_test.rb
@@ -51,7 +51,7 @@ if DEVISE_ORM == :active_record
 
     test "add primary key type with rails 5 when specified in rails generator" do
       run_generator ["monster", "--primary_key_type=uuid"]
-      if Devise.rails5?
+      if Rails.version.start_with? '5'
         assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters, id: :uuid do/
       else
         assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters do/


### PR DESCRIPTION
Adds primary key type to migration creating template in Rails 5. It uses the configuration set in Rails generator as below:
```
config.generators do |g|
  g.orm :active_record, primary_key_type: :uuid
end
```
Resolves #4413 