### PR TITLE
Fix sending confirmation emails

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -44,7 +44,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if respond_to?(:after_commit) # ActiveRecord
+        if is_a?(ActiveRecord::Base)
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid
@@ -270,7 +270,9 @@ module Devise
         end
 
         def reconfirmation_required?
-          self.class.reconfirmable && @reconfirmation_required && (self.email.present? || self.unconfirmed_email.present?)
+          result = self.class.reconfirmable && @reconfirmation_required && self.unconfirmed_email.present? && !@skip_reconfirmation_in_callback
+          @skip_reconfirmation_in_callback = false
+          result
         end
 
         def send_confirmation_notification?


### PR DESCRIPTION
Hello, Devise team!

First let me thank you for a great product!!

I was trying to use :confirmable for my User model, which is inheriting from an abstract class (and this abstract class - from ActiveRecord::Base) and haven't got any confirmation emails to be automatically sent by devise. So, I started to investigate and debug:

Changed checking for ActiveRecord with is_a?(ActiveRecord::Base) and not with respond_to?(:after_commit) - the latter doesn't work and confirmation mails were not sent with Devise 4.2.0 (at least in Rails 5.0.1). The cause was [this commit](https://github.com/plataformatec/devise/commit/78bbf6dcc4d0a63ab68c31d31d8905dbf8f9c1bb)

After fixing AR check, I realized that the confirmation emails are now sent 2 times. After much debugging I found the cause - reconfirmation_required? method wasn't taking into account @skip_reconfirmation_in_callback. Also, after checking, it should set @skip_reconfirmation_in_callback to false for further correct operation.

Sorry for missing test, but I don't know how to catch that 2 emails were sent prior to my commit.
Though I have written a test, but it is showing a normal 1 email:

```
test 'should send only 1 email after creating the user' do
  class User::WithSaveInCallback < User
    after_create :save
  end

  assert_emails 2 do
    @user = User::WithSaveInCallback.create!(email: 'mynewuser@example.com', password: 'some_password', password_confirmation: 'some_password')
  end
end
```

That's why I haven't included the test in the PR.

So everything's working fine now in my app and also, this PR doesn't break existing tests.