### PR TITLE
Fix absent password params from Password#update

### DIFF
--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -33,10 +33,14 @@ module Devise
       # Update password saving the record and clearing token. Returns true if
       # the passwords are valid and the record was saved, false otherwise.
       def reset_password(new_password, new_password_confirmation)
-        self.password = new_password
-        self.password_confirmation = new_password_confirmation
-
-        save
+        if new_password.present?
+          self.password = new_password
+          self.password_confirmation = new_password_confirmation
+          save
+        else
+          errors.add(:password, :blank)
+          false
+        end
       end
 
       # Resets reset password token and send reset password instructions by email.

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -184,6 +184,16 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_equal raw, reset_password_user.reset_password_token
   end
 
+  test 'should return a new record with errors if password is not provided' do
+    user = create_user
+    raw  = user.send_reset_password_instructions
+
+    reset_password_user = User.reset_password_by_token(reset_password_token: raw)
+    refute reset_password_user.errors.empty?
+    assert_match "can't be blank", reset_password_user.errors[:password].join
+    assert_equal raw, reset_password_user.reset_password_token
+  end
+
   test 'should reset successfully user password given the new password and confirmation' do
     user = create_user
     old_password = user.password


### PR DESCRIPTION
Related to issue #4397 

This hotfix adds a string coercion to new_password paramenters when
trying to reset an user's password.

Before that, when a user submitted a password recovery form with the
new_password and new_password_confirmation params as nil, Devise would
sign in the user with a success notice but without actually changing the
password.