### PR TITLE
Fix bug: `ParameterFilter` should not add keys (#3431)

### DIFF
--- a/lib/devise/parameter_filter.rb
+++ b/lib/devise/parameter_filter.rb
@@ -16,6 +16,8 @@ module Devise
 
     def filtered_hash_by_method_for_given_keys(conditions, method, condition_keys)
       condition_keys.each do |k|
+        next unless conditions.key?(k)
+
         value = conditions[k]
         conditions[k] = value.send(method) if value.respond_to?(method)
       end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -86,6 +86,13 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_equal( {'strip_whitespace' => 'strip_whitespace_val', 'do_not_strip_whitespace' => ' do_not_strip_whitespace_val '}, conditions )
   end
 
+  test 'param filter should not add keys to filtered hash' do
+    conditions = { 'present' => 'present_val' }
+    conditions.default = ''
+    conditions = Devise::ParameterFilter.new(['not_present'], []).filter(conditions)
+    assert_equal({ 'present' => 'present_val' }, conditions)
+  end
+
   test 'should respond to password and password confirmation' do
     user = new_user
     assert user.respond_to?(:password)


### PR DESCRIPTION
If called with a hash that has a `default` / `default_proc` configured, `Devise::ParameterFilter` can add in missing keys it was due to attempt to sanitise the values for. (This can also occur if `NilClass` has been augmented with definitions for `strip` or `downcase`.)

A side effect of this is that reset tokens were preventing from being used; the workaround in place was to set `config.authentication_keys = config.strip_whitespace_keys = []`, as described in issue #3431.

This patch prevents this from happening, whilst also clarifying the filtering intent of `ParamaterFilter`.

_Current behaviour, before patch:_
```ruby
conditions = { 'present' => 'present_val' }
conditions.default = ''

Devise::ParameterFilter.new(['not_present'], []).filter(conditions)
  # => { 'present' => 'present_val', 'not_present' => '' }
```

_New behaviour, with patch:_
```ruby
conditions = { 'present' => 'present_val' }
conditions.default = ''

Devise::ParameterFilter.new(['not_present'], []).filter(conditions)
  # => { 'present' => 'present_val' }
```

Thanks, Josh

Fixes #3431.