### PR TITLE
Fixing README Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ If you're using RSpec, you can put the following inside a file named
 
 ```ruby
 RSpec.configure do |config|
-  config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::TestHelpers, type: :view
 end
 ```
 


### PR DESCRIPTION
README instructions contain incorrect config statements
for rspec users.