### PR TITLE
Fix Timeoutable timeouts flash hash keys

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -76,8 +76,7 @@ module Devise
     def redirect
       store_location!
       if is_flashing_format?
-        if flash[:timedout] && flash[:alert]
-          flash.keep(:timedout)
+        if flash[:alert]
           flash.keep(:alert)
         else
           flash[:alert] = i18n_message
@@ -113,7 +112,6 @@ module Devise
 
     def redirect_url
       if warden_message == :timeout
-        flash[:timedout] = true if is_flashing_format?
 
         path = if request.get?
           attempted_path

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -155,6 +155,13 @@ class FailureTest < ActiveSupport::TestCase
       assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
     end
 
+    test 'does not set timedout key on flash hash' do
+      call_failure('warden' => OpenStruct.new(message: :timeout))
+      assert_nil @request.flash[:timedout]
+      assert_equal 'Your session expired. Please sign in again to continue.', @request.flash[:alert]
+      assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
+    end
+
     test 'supports authentication_keys as a Hash for the flash message' do
       swap Devise, authentication_keys: { email: true, login: true } do
         call_failure('warden' => OpenStruct.new(message: :invalid))


### PR DESCRIPTION
See https://github.com/plataformatec/devise/issues/1777 for an in-depth discussion of the unexpected behaviour.

See https://github.com/plataformatec/devise/pull/4038 for the fix, but awaiting tests.

The behaviour still works as expected for redirects, see

```
test 'error message with i18n'
test 'error message with i18n with double redirect'
```

in https://github.com/plataformatec/devise/blob/master/test/integration/timeoutable_test.rb#L141-L166.