### PR TITLE
update rake reference to rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $ rails generate devise MODEL
 
 Next, check the MODEL for any additional configuration options you might want to add, such as confirmable or lockable. If you add an option, be sure to inspect the migration file (created by the generator if your ORM supports them) and uncomment the appropriate section.  For example, if you add the confirmable option in the model, you'll need to uncomment the Confirmable section in the migration. 
 
-Then run `rake db:migrate`
+Then run `rails db:migrate`
 
 You should restart your application after changing Devise's configuration options. Otherwise, you will run into strange errors, for example, users being unable to login and route helpers being undefined.
 


### PR DESCRIPTION
Update `rake db:migrate` reference to `rails db:migrate` in keeping with Rail 5 semantics. 