### PR TITLE
Separate Devise test methods from Devise

### DIFF
--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -10,9 +10,9 @@ class RememberMeTest < Devise::IntegrationTest
   end
 
   def generate_signed_cookie(raw_cookie)
-    request = if Devise.rails51?
+    request = if Devise::Test.rails51?
       ActionController::TestRequest.create(Class.new) # needs a "controller class"
-    elsif Devise.rails5?
+    elsif Devise::Test.rails5?
       ActionController::TestRequest.create
     else
       ActionController::TestRequest.new

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -5,7 +5,7 @@ ActiveRecord::Base.include_root_in_json = true
 ActiveRecord::Migrator.migrate(File.expand_path("../../rails_app/db/migrate/", __FILE__))
 
 class ActiveSupport::TestCase
-  if Devise.rails5?
+  if Devise::Test.rails5?
     self.use_transactional_tests = true
   else
     # Let `after_commit` work with transactional fixtures, however this is not needed for Rails 5.

--- a/test/rails_app/app/active_record/user.rb
+++ b/test/rails_app/app/active_record/user.rb
@@ -3,5 +3,5 @@ require 'shared_user'
 class User < ActiveRecord::Base
   include Shim
   include SharedUser
-  include ActiveModel::Serializers::Xml if Devise.rails5?
+  include ActiveModel::Serializers::Xml if Devise::Test.rails5?
 end

--- a/test/rails_app/app/controllers/home_controller.rb
+++ b/test/rails_app/app/controllers/home_controller.rb
@@ -20,7 +20,7 @@ class HomeController < ApplicationController
   end
 
   def unauthenticated
-    if Devise.rails5?
+    if Devise::Test.rails5?
       render body: "unauthenticated", status: :unauthorized
     else
       render text: "unauthenticated", status: :unauthorized

--- a/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/test/rails_app/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,6 +9,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = User.to_adapter.find_first(email: 'user@test.com')
     user.remember_me = true
     sign_in user
-    render (Devise.rails5? ? :body : :text) => ""
+    render (Devise::Test.rails5? ? :body : :text) => ""
   end
 end

--- a/test/rails_app/app/controllers/users_controller.rb
+++ b/test/rails_app/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   end
 
   def update_form
-    render (Devise.rails5? ? :body : :text) => 'Update'
+    render (Devise::Test.rails5? ? :body : :text) => 'Update'
   end
 
   def accept
@@ -21,11 +21,11 @@ class UsersController < ApplicationController
   end
 
   def exhibit
-    render (Devise.rails5? ? :body : :text) => current_user ? "User is authenticated" : "User is not authenticated"
+    render (Devise::Test.rails5? ? :body : :text) => current_user ? "User is authenticated" : "User is not authenticated"
   end
 
   def expire
     user_session['last_request_at'] = 31.minutes.ago.utc
-    render (Devise.rails5? ? :body : :text) => 'User will be expired on next request'
+    render (Devise::Test.rails5? ? :body : :text) => 'User will be expired on next request'
   end
 end

--- a/test/rails_app/config/boot.rb
+++ b/test/rails_app/config/boot.rb
@@ -3,9 +3,15 @@ unless defined?(DEVISE_ORM)
 end
 
 module Devise
-  # Detection for minor differences between Rails 4 and 5, and 5.1 in tests.
-  def self.rails5?
-    Rails.version.start_with? '5'
+  module Test
+    # Detection for minor differences between Rails 4 and 5, and 5.1 in tests.
+    def self.rails51?
+      Rails.version.start_with? '5.1'
+    end
+
+    def self.rails5?
+      Rails.version.start_with? '5'
+    end
   end
 end
 

--- a/test/rails_app/lib/shared_admin.rb
+++ b/test/rails_app/lib/shared_admin.rb
@@ -8,7 +8,7 @@ module SharedAdmin
            allow_unconfirmed_access_for: 2.weeks, reconfirmable: true
 
     validates_length_of     :reset_password_token, minimum: 3, allow_blank: true
-    if Devise.rails51?
+    if Devise::Test.rails51?
       validates_uniqueness_of :email, allow_blank: true, if: :will_save_change_to_email?
     else
       validates_uniqueness_of :email, allow_blank: true, if: :email_changed?

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -203,7 +203,7 @@ class CustomizedRoutingTest < ActionController::TestCase
 
   test 'map with format false for sessions' do
     expected_params = {controller: 'devise/sessions', action: 'new'}
-    expected_params[:format] = false if Devise.rails5?
+    expected_params[:format] = false if Devise::Test.rails5?
 
     assert_recognizes(expected_params, {path: '/htmlonly_admin/sign_in', method: :get})
     assert_raise ExpectedRoutingError do
@@ -213,7 +213,7 @@ class CustomizedRoutingTest < ActionController::TestCase
 
   test 'map with format false for passwords' do
     expected_params = {controller: 'devise/passwords', action: 'create'}
-    expected_params[:format] = false if Devise.rails5?
+    expected_params[:format] = false if Devise::Test.rails5?
 
     assert_recognizes(expected_params, {path: '/htmlonly_admin/password', method: :post})
     assert_raise ExpectedRoutingError do
@@ -223,7 +223,7 @@ class CustomizedRoutingTest < ActionController::TestCase
 
   test 'map with format false for registrations' do
     expected_params = {controller: 'devise/registrations', action: 'new'}
-    expected_params[:format] = false if Devise.rails5?
+    expected_params[:format] = false if Devise::Test.rails5?
 
     assert_recognizes(expected_params, {path: '/htmlonly_admin/sign_up', method: :get})
     assert_raise ExpectedRoutingError do
@@ -233,7 +233,7 @@ class CustomizedRoutingTest < ActionController::TestCase
 
   test 'map with format false for confirmations' do
     expected_params = {controller: 'devise/confirmations', action: 'show'}
-    expected_params[:format] = false if Devise.rails5?
+    expected_params[:format] = false if Devise::Test.rails5?
 
     assert_recognizes(expected_params, {path: '/htmlonly_users/confirmation', method: :get})
     assert_raise ExpectedRoutingError do
@@ -243,7 +243,7 @@ class CustomizedRoutingTest < ActionController::TestCase
 
   test 'map with format false for unlocks' do
     expected_params = {controller: 'devise/unlocks', action: 'show'}
-    expected_params[:format] = false if Devise.rails5?
+    expected_params[:format] = false if Devise::Test.rails5?
 
     assert_recognizes(expected_params, {path: '/htmlonly_users/unlock', method: :get})
     assert_raise ExpectedRoutingError do

--- a/test/test/controller_helpers_test.rb
+++ b/test/test/controller_helpers_test.rb
@@ -164,9 +164,9 @@ class TestControllerHelpersTest < Devise::ControllerTestCase
   test "creates a new warden proxy if the request object has changed" do
     old_warden_proxy = warden
 
-    @request = if Devise.rails51?
+    @request = if Devise::Test.rails51?
       ActionController::TestRequest.create(Class.new) # needs a "controller class"
-    elsif Devise.rails5?
+    elsif Devise::Test.rails5?
       ActionController::TestRequest.create
     else
       ActionController::TestRequest.new


### PR DESCRIPTION
~This PR does two things:~

1. I didn't like the way test specific methods are polluting the `Devise` module, so I've moved those to `Devise::Test`. This will prevent issues like #4514 from happening.

~2. Refactored the `rails51?` changes so we keep the codebase DRY.~