### PR TITLE
Rails 5.1 fix: Replaced render :text 404 with :plain in omniauth

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -2,7 +2,7 @@ class Devise::OmniauthCallbacksController < DeviseController
   prepend_before_action { request.env["devise.skip_timeout"] = true }
 
   def passthru
-    render status: 404, text: "Not found. Authentication passthru."
+    render status: 404, plain: "Not found. Authentication passthru."
   end
 
   def failure


### PR DESCRIPTION
Rails 5.1 has deprecated render :text, and HEAD requests on the omniauth callbacks passthru method is causing errors because the render :text is non-existant, and there's no template to fall back to.

Replacing :text with :plain, adds a content-type type of text/plain and also returns the previous message.

render :plain was supported back in rails 4.1.0
http://api.rubyonrails.org/v4.1.0/classes/ActionView/Helpers/RenderingHelper.html#method-i-render
