### PR TITLE
Consistent status code on confirmation error

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -25,7 +25,7 @@ class Devise::ConfirmationsController < DeviseController
       set_flash_message!(:notice, :confirmed)
       respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new, status: :unprocessable_entity }
     end
   end
 

--- a/test/controllers/confirmations_controller_test.rb
+++ b/test/controllers/confirmations_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class ConfirmationsControllerTest < Devise::ControllerTestCase
+  tests Devise::ConfirmationsController
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    @user = create_user
+  end
+
+  test 'respond with unprocessable entity response if already confirmed' do
+    get :show, params: { confirmation_token: @user.confirmation_token }
+    assert_redirected_to 'http://test.host/users/sign_in'
+
+    get :show, params: { format: :json, confirmation_token: @user.confirmation_token }
+    assert_response :unprocessable_entity
+
+    get :show, params: { confirmation_token: @user.confirmation_token }
+    assert_response :unprocessable_entity
+  end
+end


### PR DESCRIPTION
Before this fix if trying to confirm already confirmed account you will
get 200 status code for some formats (html and js) and 422 status code
for other formats (json, xml, ...).

At first I wanted to fix this in `responders` gem but after looking at source code and documentation https://github.com/plataformatec/responders/blob/master/lib/action_controller/responder.rb#L25 I saw that `respond_with` doesn't use same status code for `html` and other formats by design. So I just did it here for devise cause I think it should always return 422 status code if you try to confirm same account multiple times.