### PR TITLE
Generate a valid fixture by default

### DIFF
--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -18,7 +18,8 @@ module ActiveRecord
       end
 
       def generate_model
-        invoke "active_record:model", [name], migration: false unless model_exists? && behavior == :invoke
+        invoke "active_record:model", [name], migration: false, fixture: false unless model_exists? && behavior == :invoke
+        template "fixtures.yml", File.join("test/fixtures", class_path, "#{name.pluralize}.yml")
       end
 
       def inject_devise_content

--- a/lib/generators/active_record/templates/fixtures.yml
+++ b/lib/generators/active_record/templates/fixtures.yml
@@ -1,0 +1,8 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value


### PR DESCRIPTION
This reduces the default fixture generated by devise creating only one instance of User (or whatever the name of the model is) instead of two, since that breaks the tests by default.
This fixes #4475