### PR TITLE
Ensure string literals can be frozen.

### DIFF
--- a/lib/generators/devise/devise_generator.rb
+++ b/lib/generators/devise/devise_generator.rb
@@ -8,7 +8,7 @@ module Devise
       namespace "devise"
       source_root File.expand_path("../templates", __FILE__)
 
-      desc "Generates a model with the given NAME (if one does not exist) with devise " <<
+      desc "Generates a model with the given NAME (if one does not exist) with devise " \
            "configuration plus a migration file and devise routes."
 
       hook_for :orm
@@ -16,7 +16,7 @@ module Devise
       class_option :routes, desc: "Generate routes", type: :boolean, default: true
 
       def add_devise_routes
-        devise_route  = "devise_for :#{plural_name}"
+        devise_route  = "devise_for :#{plural_name}".dup
         devise_route << %Q(, class_name: "#{class_name}") if class_name.include?("::")
         devise_route << %Q(, skip: :all) unless options.routes?
         route devise_route

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -31,7 +31,7 @@ class ValidatableTest < ActiveSupport::TestCase
 
     %w{invalid_email_format 123 $$$ () ☃}.each do |email|
       user.email = email
-      assert user.invalid?, 'should be invalid with email ' << email
+      assert user.invalid?, "should be invalid with email #{email}"
       assert_equal 'is invalid', user.errors[:email].join
     end
 
@@ -42,7 +42,7 @@ class ValidatableTest < ActiveSupport::TestCase
   test 'should accept valid emails' do
     %w(a.b.c@example.com test_mail@gmail.com any@any.net email@test.br 123@mail.test 1☃3@mail.test).each do |email|
       user = new_user(email: email)
-      assert user.valid?, 'should be valid with email ' << email
+      assert user.valid?, "should be valid with email #{email}"
       assert_blank user.errors[:email]
     end
   end


### PR DESCRIPTION
These minor changes will allow Devise to work when MRI's string literals are frozen by default. This feature of Ruby is documented here: https://wyeworks.com/blog/2015/12/1/immutable-strings-in-ruby-2-dot-3

Will over a second patch in a moment for testing this to ensure regressions are avoided.