### PR TITLE
Test frozen string literals on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ env:
 
 before_install: "rm ${BUNDLE_GEMFILE}.lock"
 
-before_script: "bundle update"
+before_script:
+  - "bundle update"
+  - ./bin/literals
 
 script: "bin/test"
 

--- a/bin/literals
+++ b/bin/literals
@@ -1,0 +1,10 @@
+if (ruby -e "exit RUBY_VERSION.to_f >= 2.4")
+then
+  echo "Automatic frozen string literals are supported"
+  gem install pragmater -v 4.0.0
+  pragmater --add app --comments "# frozen_string_literal: true" --whitelist "**/*.rb"
+  pragmater --add lib --comments "# frozen_string_literal: true" --whitelist "**/*.rb"
+  pragmater --add test --comments "# frozen_string_literal: true" --whitelist "**/*.rb"
+else
+  echo "Automatic frozen string literals are not supported."
+fi


### PR DESCRIPTION
This PR adds a script `bin/literals` which will add the pragma setting `frozen_string_literal: true` to the top of all Ruby files in `app`, `lib`, and `test`. Errors in the test suite will then be raised if any string literals in these files are modified.

This script will only add the pragma comment if MRI 2.4 or newer is being used. Previous versions of Ruby either do not support this feature (MRI <= 2.2), or do not work with pragmater (MRI 2.3).

Related to #4565.