### PR TITLE
Fix capitalization of "Invalid Email or password"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,10 +9,10 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
+      invalid: "%{authentication_keys} or password is invalid."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
+      not_found_in_database: "%{authentication_keys} or password is invalid."
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."


### PR DESCRIPTION
Currently, `authentication_keys` is humanized which causes its first character to be capitalized. This causes awkward looking messages such as "Invalid Email or password." By moving `authentication_keys`, we can create a correct sentence for the english local without disrupting the behavior of the other locales.