### PR TITLE
Fix wrong arity in AM defaults procs

### DIFF
--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -15,4 +15,24 @@ class MailerTest < ActionMailer::TestCase
 
     assert mail.content_transfer_encoding, "7bit"
   end
+
+  test "calls default procs with the proper arity" do
+    class TestMailerWithDefault < Devise::Mailer
+      default from: ->() { computed_from }
+
+      def confirmation_instructions(record, token, opts = {})
+        @token = token
+        devise_mail(record, :confirmation_instructions, opts)
+      end
+
+      private
+
+      def computed_from
+        "from@example.com"
+      end
+    end
+
+    mail = TestMailerWithDefault.confirmation_instructions(create_user, "confirmation-token")
+    assert mail.from, "from@example.com"
+  end
 end


### PR DESCRIPTION
Support Rails 5.1 + 5.0 by using the right arity for the proc.
Rails 5.1 changed the arity from 0 to 1.

See rails/rails#30391 and #4604 for details.