### PR TITLE
Allow frozen options in as_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * bug fixes
   * Validations were being ignored on singup in the `Trackable#update_tracked_fields!` method. (by @AshleyFoster)
+  * Do not modify options for `#serializable_hash`. (by @guigs)
  
 ### 4.3.0 - 2017-05-14
 

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -102,7 +102,7 @@ module Devise
       # and passing a new list of attributes you want to exempt. All attributes
       # given to :except will simply add names to exempt to Devise internal list.
       def serializable_hash(options = nil)
-        options ||= {}
+        options = options.try(:dup) || {}
         options[:except] = Array(options[:except])
 
         if options[:force_except]

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -40,6 +40,10 @@ class SerializableTest < ActiveSupport::TestCase
     assert_no_match(/confirmation_token/, @user.inspect)
   end
 
+  test 'should accept frozen options' do
+    assert_key "username", @user.as_json({only: :username}.freeze)["user"]
+  end
+
   def assert_key(key, subject)
     assert subject.key?(key), "Expected #{subject.inspect} to have key #{key.inspect}"
   end


### PR DESCRIPTION
The test uses `as_json` instead of `to_json` because `to_json` does `#dup` on `options` before it reaches `#serializable_hash` and the test would pass without the fix.

See also this related change in Rails: https://github.com/rails/rails/pull/27945