### PR TITLE
MongoDB is not required anymore to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ We hope that you will consider contributing to Devise. Please read this short ov
 
 https://github.com/plataformatec/devise/wiki/Contributing
 
-You will usually want to write tests for your changes.  To run the test suite, go into Devise's top-level directory and run "bundle install" and "rake".  For the tests to pass, you will need to have a MongoDB server (version 2.0 or newer) running on your system.
+You will usually want to write tests for your changes.  To run the test suite, go into Devise's top-level directory and run "bundle install" and "rake".
 
 ## Starting with Rails?
 


### PR DESCRIPTION
I was able to run tests without having MongoDB server running in my system. So I guess it is not required anymore. Or am I missing something?