### PR TITLE
Fix syntax for MRI 2.5.0-preview1.

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -2,7 +2,7 @@ class Devise::SessionsController < DeviseController
   prepend_before_action :require_no_authentication, only: [:new, :create]
   prepend_before_action :allow_params_authentication!, only: :create
   prepend_before_action :verify_signed_out_user, only: :destroy
-  prepend_before_action only: [:create, :destroy] { request.env["devise.skip_timeout"] = true }
+  prepend_before_action(only: [:create, :destroy]) { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new


### PR DESCRIPTION
This ensures the tests are green when run on MRI 2.5.0-preview1 :)