### PR TITLE
Include Turbolinks if it is installed

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -260,5 +260,7 @@ module Devise
     def relative_url_root?
       relative_url_root.present?
     end
+
+    ActiveSupport.run_load_hooks(:devise_failure_app, self)
   end
 end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -284,7 +284,7 @@ Devise.setup do |config|
   # ==> Turbolinks configuration
   # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
   #
-  # ActiveSupport.on_load(:devise_failure_app)
+  # ActiveSupport.on_load(:devise_failure_app) do
   #   include Turbolinks::Controller
   # end
 end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -280,4 +280,11 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app)
+  #   include Turbolinks::Controller
+  # end
 end

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -337,4 +337,10 @@ class FailureTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "Lazy loading" do
+    test "loads" do
+      assert_equal Devise::FailureApp.new.lazy_loading_works?, "yes it does"
+    end
+  end
 end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -179,4 +179,9 @@ Devise.setup do |config|
   #   manager.failure_app = AnotherApp
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+
+  ActiveSupport.on_load(:devise_failure_app) do
+    require "lazy_load_test_module"
+    include LazyLoadTestModule
+  end
 end

--- a/test/rails_app/lib/lazy_load_test_module.rb
+++ b/test/rails_app/lib/lazy_load_test_module.rb
@@ -1,0 +1,5 @@
+module LazyLoadTestModule
+  def lazy_loading_works?
+    "yes it does"
+  end
+end


### PR DESCRIPTION
Turbolinks is overwriting the redirect_to method of ActionController::Redirecting.

Devise only includes ActionController::Redirecting

So, if turbolinks is installed, it doesn't work will with devise.

This should fix it.