### PR TITLE
Provide config info into the translation files

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -176,11 +176,20 @@ MESSAGE
     options
   end
 
+  def devise_config_options(options)
+    Devise.class_variables.each do |k|
+      key_name = k.to_s.sub('@@', '')
+      options[:"resource_#{key_name}"] = Devise.class_variable_get(k)
+    end
+    options
+  end
+
   # Get message for given
   def find_message(kind, options = {})
     options[:scope] ||= translation_scope
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
+    options = devise_config_options(options)
     options = devise_i18n_options(options)
     I18n.t("#{options[:resource_name]}.#{kind}", options)
   end

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -92,6 +92,14 @@ module Devise
       options
     end
 
+    def config_options(options)
+      Devise.class_variables.each do |k|
+        key_name = k.to_s.sub('@@', '')
+        options[:"resource_#{key_name}"] = Devise.class_variable_get(k)
+      end
+      options
+    end
+
     def i18n_message(default = nil)
       message = warden_message || default || :unauthenticated
 
@@ -103,6 +111,7 @@ module Devise
         auth_keys = scope_class.authentication_keys
         keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map { |key| scope_class.human_attribute_name(key) }
         options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
+        options = config_options(options)
         options = i18n_options(options)
 
         I18n.t(:"#{scope}.#{message}", options)

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -167,6 +167,12 @@ class FailureTest < ActiveSupport::TestCase
       assert_equal 'User Steve does not exist', @request.flash[:alert]
     end
 
+    test 'uses devise config options' do
+      call_failure('warden' => OpenStruct.new(message: :locked))
+      assert_equal 'Your account is locked. Maximum amount of failed attempts(20) was reached.', @request.flash[:alert]
+      assert_equal 'http://test.host/users/sign_in', @response.second["Location"]
+    end
+
     test 'uses the proxy failure message as string' do
       call_failure('warden' => OpenStruct.new(message: 'Hello world'))
       assert_equal 'Hello world', @request.flash[:alert]

--- a/test/support/locale/en.yml
+++ b/test/support/locale/en.yml
@@ -1,6 +1,7 @@
 en:
   devise:
     failure:
+      locked: "Your account is locked. Maximum amount of failed attempts(%{resource_maximum_attempts}) was reached."
       user:
         does_not_exist: "User %{name} does not exist"
   errors:


### PR DESCRIPTION
Enable to reference config info from the translation files.

For example, if the paremeter `maximum_attempts` value is default(20), and the translation file is like this.

```yml
en:
  devise:
    failure:
      locked: "Your account is locked. Maximum amount of failed attempts(%{resource_maximum_attempts}) was reached."
```

Then, the result is translated would be the following.

```
Your account is locked. Maximum amount of failed attempts(20) was reached.
```

To inform the detail reason why user failed to log in. It might be a good idea to specify the config values as part of error message. In that case, it will be easy to change the code.