### PR TITLE
Removed gem minitest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ gem "rails-controller-testing"
 
 gem "responders", "~> 2.1"
 
-# TODO: Remove this line when Rails 5.1.1 is released
-gem "minitest", "< 5.10.2"
-
 group :test do
   gem "omniauth-facebook"
   gem "omniauth-openid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   devise!
   jruby-openssl
-  minitest (< 5.10.2)
   mocha (~> 1.1)
   oauth2
   omniauth (~> 1.3)


### PR DESCRIPTION
I removed `gem "minitest", "< 5.10.2"` from Gemfile, because Rails 5.1.1 has already been released