### PR TITLE
Remove unnecessary hide! method definition

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -21,13 +21,6 @@ module Devise
         public_task :copy_views
       end
 
-      # TODO: Add this to Rails itself
-      module ClassMethods
-        def hide!
-          Rails::Generators.hide_namespace self.namespace
-        end
-      end
-
       def copy_views
         if options[:views]
           options[:views].each do |directory|


### PR DESCRIPTION
It is no longer necessary to define `hide!` in `Devise::Generators::ViewPathTemplates`.
This method has already been added to `Rails:: Generators::Base` since Rails v4.0.0.beta1.

https://github.com/rails/rails/blob/master/railties/lib/rails/generators/base.rb#L55
https://github.com/rails/rails/commit/c6ef45d6c4e718b306ba8309e15ee5c1fb532878
