### PR TITLE
Fix mongoid test failed problem

### DIFF
--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -8,6 +8,6 @@ end
 
 class ActiveSupport::TestCase
   setup do
-    Mongoid.purge!
+    Mongoid.default_session.drop
   end
 end


### PR DESCRIPTION
The problem is mongoid tests are failed due to a validation error. Like this.

```
  1) Error:
DatabaseAuthenticatableTest#test_should_not_mutate_value_assigned_to_string_whitespace_key:
Mongoid::Errors::Validations: 
Problem:
  Validation of User failed.
Summary:
  The following errors were found: Email is already taken
Resolution:
  Try persisting the document with valid data or remove the validations.
    mongoid (4.0.2) lib/mongoid/persistable.rb:78:in `fail_due_to_validation!'
    mongoid (4.0.2) lib/mongoid/persistable/savable.rb:45:in `save!'
    /home/travis/build/plataformatec/devise/test/models/database_authenticatable_test.rb:55:in `block in <class:DatabaseAuthenticatableTest>'
```

All log I run on Travis CI is [here](https://travis-ci.org/plataformatec/devise/jobs/293096355).

When using mongoid, test data is preserved. ActiveRecord is no problem. It seems like `Mongoid.purge!` is not working.

Getting namespaces in `collection_names`

```rb
namespaces = self["system.namespaces"].find(name: { "$not" => /#{name}\.system\.|\$/ })
```

return `[]`.

My solution `session drop` is a little slow, and It might be moped's problem. So, it might not be the best way.