### PR TITLE
Change `rake secret` to `rails secret` in comments

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -149,7 +149,7 @@ module Devise
   mattr_accessor :timeout_in
   @@timeout_in = 30.minutes
 
-  # Used to hash the password. Please generate one with rake secret.
+  # Used to hash the password. Please generate one with rails secret.
   mattr_accessor :pepper
   @@pepper = nil
 

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -10,7 +10,7 @@ module Devise
     # DatabaseAuthenticatable adds the following options to devise_for:
     #
     #   * +pepper+: a random string used to provide a more secure hash. Use
-    #     `rake secret` to generate new keys.
+    #     `rails secret` to generate new keys.
     #
     #   * +stretches+: the cost given to bcrypt.
     #


### PR DESCRIPTION
Since `rails secret` can be used from Rails 5, reflects the change.