### PR TITLE
Provide additional info on devise_scope usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ end
 
 This way, you tell Devise to use the scope `:user` when "/sign_in" is accessed. Notice `devise_scope` is also aliased as `as` in your router.
 
+Please note: You will still need to add `devise_for` in your routes in order to use helper methods such as `current_user`.
+
+```ruby
+devise_for :users, skip: :all
+```
+
 ### I18n
 
 Devise uses flash messages with I18n, in conjunction with the flash keys :notice and :alert. To customize your app, you can set up your locale file:


### PR DESCRIPTION
After using `devise_scope` instead of `devise_for` I found I no longer had access to Devise helper`current_user`.

After searching I found this issue to be the answer to the problem:: https://github.com/plataformatec/devise/issues/2840

The issue is also reporter here: https://github.com/plataformatec/devise/issues/3069

I think this simple comment will clarify the issue and help other users in case they run into the same issue.