### PR TITLE
FIX plataformatec/devise#4127

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -142,10 +142,14 @@ module Devise
 
       opts[:format] = request_format unless skip_format?
 
-      opts[:script_name] = relative_url_root if relative_url_root?
-
       router_name = Devise.mappings[scope].router_name || Devise.available_router_name
       context = send(router_name)
+
+      if relative_url_root?
+        opts[:script_name] = relative_url_root
+      elsif defined? context.routes
+        opts[:script_name] = context.routes.url_helpers.root_path
+      end
 
       if context.respond_to?(route)
         context.send(route, opts)

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -148,7 +148,8 @@ module Devise
       if relative_url_root?
         opts[:script_name] = relative_url_root
       elsif defined? context.routes
-        opts[:script_name] = context.routes.url_helpers.root_path
+        rootpath = context.routes.url_helpers.root_path
+        opts[:script_name] = rootpath.chomp('/') unless rootpath.length <= 1
       end
 
       if context.respond_to?(route)

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -1,9 +1,22 @@
 require 'test_helper'
 
-class MyMountableEngine
-  def self.call(env)
-    ['200', { 'Content-Type' => 'text/html' }, ['Rendered content of MyMountableEngine']]
+module MyMountableEngine
+  class Engine < ::Rails::Engine
+    isolate_namespace MyMountableEngine
   end
+  class TestsController < ActionController::Base
+    def index
+      render plain: 'Root test successful'
+    end
+    def inner_route
+      render plain: 'Inner route test successful'
+    end
+  end
+end
+
+MyMountableEngine::Engine.routes.draw do
+  get 'test', to: 'tests#inner_route'
+  root to: 'tests#index'
 end
 
 # If disable_clear_and_finalize is set to true, Rails will not clear other routes when calling
@@ -13,7 +26,7 @@ Rails.application.routes.disable_clear_and_finalize = true
 
 Rails.application.routes.draw do
   authenticate(:user) do
-    mount MyMountableEngine, at: '/mountable_engine'
+    mount MyMountableEngine::Engine, at: '/mountable_engine'
   end
 end
 
@@ -31,6 +44,15 @@ class AuthenticatedMountedEngineTest < Devise::IntegrationTest
     get '/mountable_engine'
 
     assert_response :success
-    assert_contain 'Rendered content of MyMountableEngine'
+    assert_contain 'Root test successful'
+  end
+
+
+  test 'renders a inner route of the mounted engine when authenticated' do
+    sign_in_as_user
+    get '/mountable_engine/test'
+
+    assert_response :success
+    assert_contain 'Inner route test successful'
   end
 end

--- a/test/integration/mounted_engine_test.rb
+++ b/test/integration/mounted_engine_test.rb
@@ -55,4 +55,12 @@ class AuthenticatedMountedEngineTest < Devise::IntegrationTest
     assert_response :success
     assert_contain 'Inner route test successful'
   end
+
+  test 'respond properly to a non existing route of the mounted engine' do
+    sign_in_as_user
+    
+    assert_raise ActionController::RoutingError do
+      get '/mountable_engine/non-existing-route'
+    end
+  end
 end


### PR DESCRIPTION
I've been able to fix the issue for https://github.com/plataformatec/devise/issues/4127#issuecomment-309112353 though I'd like some help to create the test. 

It's pretty simple: the engine should point to a directory inside the engine, in order to trigger the redirect. Then the test would be:

```ruby
test 'redirect to login page when browsing an internal route without being authenticated' do
    get '/mountable_engine/some_route'
    follow_redirect!
    assert_response :success
    assert_contain 'Rendered content of MyMountableEngine'
end
```

@basiszwo, how can I add to [your code](https://github.com/plataformatec/devise/blob/cbbe932ee22947fb7fc741a4da3e6783091c88b0/test/integration/mounted_engine_test.rb#L3-L7) an internal route `some_route ` in order to test it?