### PR TITLE
Yield resource before saving in RegistrationsController

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -14,9 +14,9 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save
     yield resource if block_given?
-    if resource.persisted?
+
+    if resource.save
       if resource.active_for_authentication?
         set_flash_message! :notice, :signed_up
         sign_up(resource_name, resource)


### PR DESCRIPTION
The golden-path way of extending Devise functionality is to subclass things like RegistrationController and call super with a block. However, if you try something like:

```ruby
class RegistrationsController < Devise::RegistrationsController
  def create
    super { |user| user.skip_confirmation! if some_reason? }
   end
end
```

This doesn't actually prevent the confirm email from being sent, because RegistrationsController always saves before yielding the resource to the block.