### PR TITLE
Fix `signed_in?` docs w.r.t. running auth hooks

### DIFF
--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -6,7 +6,10 @@ module Devise
     # Included by default in all controllers.
     module SignInOut
       # Return true if the given scope is signed in session. If no scope given, return
-      # true if any scope is signed in. Does not run authentication hooks.
+      # true if any scope is signed in. This will run authentication hooks, which may
+      # cause exceptions to be thrown from this method; if you simply want to check
+      # if a scope has already previously been authenticated without running
+      # authentication hooks, you can directly call `warden.authenticated?(scope: scope)`
       def signed_in?(scope=nil)
         [scope || Devise.mappings.keys].flatten.any? do |_scope|
           warden.authenticate?(scope: _scope)


### PR DESCRIPTION
Addresses #4599

The docs previously mentioned that authentication hooks are not run when `signed_in?` is called, when in fact they are. This commit fixes the comment and suggests calling `authenticated?` on warden directly as an alternative for when you _don't_ want to run auth hooks.