### PR TITLE
ruby 2.5 syntax update

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -2,7 +2,9 @@ class Devise::SessionsController < DeviseController
   prepend_before_filter :require_no_authentication, only: [:new, :create]
   prepend_before_filter :allow_params_authentication!, only: :create
   prepend_before_filter :verify_signed_out_user, only: :destroy
-  prepend_before_filter only: [:create, :destroy] { request.env["devise.skip_timeout"] = true }
+  prepend_before_filter only: [:create, :destroy] do
+     request.env["devise.skip_timeout"] = true
+  end
 
   # GET /resource/sign_in
   def new


### PR DESCRIPTION
Looks like we need to use do/end now here as ruby 2.5.0 might have a syntax regression related to { } blocks...