### PR TITLE
Fix syntax error in ruby 2.5.0

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -4,7 +4,7 @@ class Devise::SessionsController < DeviseController
   prepend_before_action :require_no_authentication, only: [:new, :create]
   prepend_before_action :allow_params_authentication!, only: :create
   prepend_before_action :verify_signed_out_user, only: :destroy
-  prepend_before_action(only: [:create, :destroy]) { request.env["devise.skip_timeout"] = true }
+  prepend_before_action(only: [:create, :destroy]) do request.env["devise.skip_timeout"] = true end
 
   # GET /resource/sign_in
   def new


### PR DESCRIPTION
When trying to update rails app to ruby 2.5.0 it fails when booting on following error

```
gems/activesupport-5.1.4/lib/active_support/dependencies.rb:476:in `load': gems/devise-4.4.0/app/controllers/devise/sessions_controller.rb:5: syntax error, unexpected '{', expecting keyword_end (SyntaxError)
...ion only: [:create, :destroy] { request.env["devise.skip_tim...
...                              ^
gems/devise-4.4.0/app/controllers/devise/sessions_controller.rb:5: syntax error, unexpected '}', expecting keyword_end
..."devise.skip_timeout"] = true }
...                              ^
```

This fix it.
  