### PR TITLE
Backport Ruby 2.5.0 syntax fixes to 3-stable

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -2,7 +2,7 @@ class Devise::SessionsController < DeviseController
   prepend_before_filter :require_no_authentication, only: [:new, :create]
   prepend_before_filter :allow_params_authentication!, only: :create
   prepend_before_filter :verify_signed_out_user, only: :destroy
-  prepend_before_filter only: [:create, :destroy] { request.env["devise.skip_timeout"] = true }
+  prepend_before_filter(only: [:create, :destroy]) { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new


### PR DESCRIPTION
Our organization is still on Devise 3 but is hoping to move to Ruby 2.5. Any chance of backporting this commit?