### PR TITLE
Fix `ActiveRecord` check on `Confirmable`

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -48,7 +48,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if defined?(ActiveRecord) && self.is_a?(ActiveRecord::Base) # ActiveRecord
+        if defined?(ActiveRecord) && self < ActiveRecord::Base # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -8,6 +8,17 @@ class ConfirmableTest < ActiveSupport::TestCase
     setup_mailer
   end
 
+  test 'should set callbacks to send the mail' do
+    if DEVISE_ORM == :active_record
+      defined_callbacks = User._commit_callbacks.map(&:filter)
+      assert_includes defined_callbacks, :send_on_create_confirmation_instructions
+      assert_includes defined_callbacks, :send_reconfirmation_instructions
+    elsif DEVISE_ORM == :mongoid
+      assert_includes User._create_callbacks.map(&:filter), :send_on_create_confirmation_instructions
+      assert_includes User._update_callbacks.map(&:filter), :send_reconfirmation_instructions
+    end
+  end
+
   test 'should generate confirmation token after creating a record' do
     assert_nil new_user.confirmation_token
     assert_not_nil create_user.confirmation_token


### PR DESCRIPTION
As pointed out by @dark-panda in #4302, the condition for an `ActiveRecord` model is wrong inside the `Confirmable` initialization block.

https://github.com/plataformatec/devise/pull/4302#issuecomment-355103489