### PR TITLE
Update sample code in Devise::Models::Authenticatable.

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -134,16 +134,18 @@ module Devise
       # This is an internal method called every time Devise needs
       # to send a notification/mail. This can be overridden if you
       # need to customize the e-mail delivery logic. For instance,
-      # if you are using a queue to deliver e-mails (delayed job,
-      # sidekiq, resque, etc), you must add the delivery to the queue
+      # if you are using a queue to deliver e-mails (active job, delayed
+      # job, sidekiq, resque, etc), you must add the delivery to the queue
       # just after the transaction was committed. To achieve this,
       # you can override send_devise_notification to store the
-      # deliveries until the after_commit callback is triggered:
+      # deliveries until the after_commit callback is triggered.
+      #
+      # The following example uses Active Job's `deliver_later` :
       #
       #     class User
       #       devise :database_authenticatable, :confirmable
       #
-      #       after_commit :send_pending_notifications
+      #       after_commit :send_pending_devise_notifications
       #
       #       protected
       #
@@ -152,38 +154,43 @@ module Devise
       #         # delivery until the after_commit callback otherwise
       #         # send now because after_commit will not be called.
       #         if new_record? || changed?
-      #           pending_notifications << [notification, args]
+      #           pending_devise_notifications << [notification, args]
       #         else
-      #           message = devise_mailer.send(notification, self, *args)
-      #           Remove once we move to Rails 4.2+ only.
-      #           if message.respond_to?(:deliver_now)
-      #             message.deliver_now
-      #           else
-      #             message.deliver
-      #           end
+      #           render_and_send_devise_message(notification, *args)
       #         end
       #       end
       #
-      #       def send_pending_notifications
-      #         pending_notifications.each do |notification, args|
-      #           message = devise_mailer.send(notification, self, *args)
-      #           Remove once we move to Rails 4.2+ only.
-      #           if message.respond_to?(:deliver_now)
-      #             message.deliver_now
-      #           else
-      #             message.deliver
-      #           end
+      #       private
+      #
+      #       def send_pending_devise_notifications
+      #         pending_devise_notifications.each do |notification, args|
+      #           render_and_send_devise_message(notification, *args)
       #         end
       #
       #         # Empty the pending notifications array because the
       #         # after_commit hook can be called multiple times which
       #         # could cause multiple emails to be sent.
-      #         pending_notifications.clear
+      #         pending_devise_notifications.clear
       #       end
       #
-      #       def pending_notifications
-      #         @pending_notifications ||= []
+      #       def pending_devise_notifications
+      #         @pending_devise_notifications ||= []
       #       end
+      #
+      #       def render_and_send_devise_message(notification, *args)
+      #         message = devise_mailer.send(notification, self, *args)
+      #
+      #         # Deliver later with Active Job's `deliver_later`
+      #         if message.respond_to?(:deliver_later)
+      #           message.deliver_later
+      #         # Remove once we move to Rails 4.2+ only, as `deliver` is deprecated.
+      #         elsif message.respond_to?(:deliver_now)
+      #           message.deliver_now
+      #         else
+      #           message.deliver
+      #         end
+      #       end
+      #
       #     end
       #
       def send_devise_notification(notification, *args)


### PR DESCRIPTION
- DRY up some of the sample code by refactoring into smaller methods.
- ‘Namespace’ method names to reduce chances of conflict.
- Mark `send_pending_devise_notifications`, `pending_devise_notifications`, and `render_and_send_devise_message` methods as `private` since they are only used internally.
- Update comments.