### PR TITLE
Add an option to disable GET requests on /users/auth/provider to address RECONNECT vulnerability

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -292,6 +292,10 @@ module Devise
   mattr_accessor :token_generator
   @@token_generator = nil
 
+  # List of providers to disable GET-based oauth passthru for
+  mattr_accessor :disable_omniauth_get
+  @@disable_omniauth_get = []
+
   def self.rails51? # :nodoc:
     Rails.gem_version >= Gem::Version.new("5.1.x")
   end

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -447,7 +447,7 @@ ERROR
           match "#{path_prefix}/#{provider}",
             to: "#{controllers[:omniauth_callbacks]}#passthru",
             as: "#{provider}_omniauth_authorize",
-            via: [:get, :post]
+            via: Devise.disable_omniauth_get.include?(provider) ? [:get, :post] : [:post]
 
           match "#{path_prefix}/#{provider}/callback",
             to: "#{controllers[:omniauth_callbacks]}##{provider}",


### PR DESCRIPTION
This PR allows users of Devise's Omniauth support to mitigate the RECONNECT vulnerability specifically for Facebook OAuth discussed here: https://sakurity.com/blog/2015/03/05/RECONNECT.html

Specifically we address the vulnerability by adding an option `disable_omniauth_get` which allows the library user to specify a list of providers for which they do not wish to have a GET route available for the `/users/auth/:provider` endpoint. This mitigates the vulnerability by adding CSRF at the application level before it even reaches Facebook.

cc @rafaelfranca 