### PR TITLE
Added password_regex validation to validatable

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -114,6 +114,11 @@ module Devise
   mattr_accessor :email_regexp
   @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
+  # Password regex used to validate password formats.
+  # It validates if the password only uses alphanumericals, whitespace and underscore.
+  mattr_accessor :password_regexp
+  @@password_regexp = /\A[a-zA-Z0-9 _]*\z/
+
   # Range validation for password length
   mattr_accessor :password_length
   @@password_length = 6..128

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -12,6 +12,7 @@ module Devise
     # Validatable adds the following options to devise_for:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
+    #   * +password_regexp+: the regular expression used to validate passwords;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
     #
     module Validatable
@@ -40,6 +41,7 @@ module Devise
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
           validates_length_of       :password, within: password_length, allow_blank: true
+          validates_format_of       :password, with: password_regexp, if: :password_required?
         end
       end
 
@@ -66,7 +68,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(self, :email_regexp, :password_length, :password_regexp)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -166,6 +166,10 @@ Devise.setup do |config|
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
+  # Password regex used to validate password formats.
+  # It validates if the password only uses alphanumericals, whitespace and underscore.
+  config.password_regexp = /\A[a-zA-Z0-9 _]*\z/
+
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -106,4 +106,16 @@ class DeviseTest < ActiveSupport::TestCase
       assert_no_match Devise.email_regexp, email
     end
   end
+
+  test 'Devise.password_regexp should match valid passwords' do
+    valid_passwords = ["testPass123", "Hello456", "Ruby250Rails4210", "Example456"]
+    non_valid_passwords = ["rex@", "test!password", "test@user@pass", "server.com"]
+
+    valid_passwords.each do |password|
+      assert_match Devise.password_regexp, password
+    end
+    non_valid_passwords.each do |password|
+      assert_no_match Devise.password_regexp, password
+    end
+  end
 end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -93,7 +93,10 @@ Devise.setup do |config|
   # config.password_length = 8..72
 
   # Regex to use to validate the email address
-  # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # Regex to use to validate the password
+  # config.password_regexp = /\A[a-zA-Z0-9 _]*\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
We use Validatable instead of the custom validations as mentioned in https://github.com/plataformatec/devise/wiki/How-To:-Upgrade-to-Devise-4.4.0.

We still have a custom validation to check the password complexity which can be easily added to Validatable.