### PR TITLE
Split IP resolution from update_tracked_fields

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -22,7 +22,7 @@ module Devise
         self.last_sign_in_at     = old_current || new_current
         self.current_sign_in_at  = new_current
 
-        old_current, new_current = self.current_sign_in_ip, request.remote_ip
+        old_current, new_current = self.current_sign_in_ip, extract_ip_from(request)
         self.last_sign_in_ip     = old_current || new_current
         self.current_sign_in_ip  = new_current
 
@@ -39,6 +39,13 @@ module Devise
         update_tracked_fields(request)
         save(validate: false)
       end
+
+      protected
+
+      def extract_ip_from(request)
+        request.remote_ip
+      end
+
     end
   end
 end

--- a/test/models/trackable_test.rb
+++ b/test/models/trackable_test.rb
@@ -59,4 +59,22 @@ class TrackableTest < ActiveSupport::TestCase
 
     assert_not user.update_tracked_fields!(request)
   end
+
+  test 'extract_ip_from should be overridable' do
+    class UserWithOverride < User
+      protected
+        def extract_ip_from(request)
+          "127.0.0.2"
+        end
+    end
+
+    request = mock
+    request.stubs(:remote_ip).returns("127.0.0.1")
+    user = UserWithOverride.new
+
+    user.update_tracked_fields(request)
+
+    assert_equal "127.0.0.2", user.current_sign_in_ip
+    assert_equal "127.0.0.2", user.last_sign_in_ip
+  end
 end


### PR DESCRIPTION
This permits users to easily customize where the ip address
should be resolved.  When fronting the application with a webserver or
load balancer, the ip address may be the server and not be the user.

E.g. consider the IP address is passed as the header: "X-Forwarded-For".

```ruby
class User
  devise :trackable

  protected
    def extract_ip_from(request)
      request.headers["X-Forwarded-For"]
    end
end
```

See discussion in #4540 and https://groups.google.com/forum/#!topic/plataformatec-devise/aCuFLef16Sk

Edit: updated example based on feedback changes (#get_ip => #extract_ip_from)