### PR TITLE
Fixes #4783 - preserve content_type for unauthenticated test responses

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -139,6 +139,7 @@ module Devise
 
           status, headers, response = Devise.warden_config[:failure_app].call(env).to_a
           @controller.response.headers.merge!(headers)
+          @controller.response.content_type = headers["Content-Type"] unless Devise::Test.rails5?
           @controller.status = status
           @controller.response.body = response.body
           nil # causes process return @response

--- a/test/test/controller_helpers_test.rb
+++ b/test/test/controller_helpers_test.rb
@@ -100,6 +100,11 @@ class TestControllerHelpersTest < Devise::ControllerTestCase
     assert_equal response.body, "<html><body>You are being <a href=\"http://test.host/users/sign_in\">redirected</a>.</body></html>"
   end
 
+  test "returns the content type of a failure app" do
+    get :index, params: { format: :xml }
+    assert response.content_type.include?('application/xml')
+  end
+
   test "defined Warden after_authentication callback should not be called when sign_in is called" do
     begin
       Warden::Manager.after_authentication do |user, auth, opts|


### PR DESCRIPTION
In Rails 4, for unauthenticated controller tests which trigger the failure app, ensure that the simulated failure response includes a content_type.

This works in Rails5, which parses the content-type header on-demand, but not in Rails4 which requires setting the response's content_type explicitly.

Fixes #4783 
