### PR TITLE
Add #resource_validation_context on Devise::RegistrationsController a…

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -16,7 +16,7 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save(context: resource_validation_context)
+    resource.save(context: resource_validation_context_on_create)
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
@@ -94,7 +94,7 @@ class Devise::RegistrationsController < DeviseController
   # By default we want to require a password checks on update.
   # You can overwrite this method in your own RegistrationsController.
   def update_resource(resource, params)
-    resource.update_with_password(params)
+    resource.update_with_password(params.merge(context: resource_validation_context_on_update))
   end
 
   # Build a devise resource passing in the session. Useful to move
@@ -144,8 +144,12 @@ class Devise::RegistrationsController < DeviseController
     devise_parameter_sanitizer.sanitize(:account_update)
   end
 
-  def resource_validation_context
+  def resource_validation_context_on_create
     nil
+  end
+
+  def resource_validation_context_on_update
+    resource_validation_context_on_create
   end
 
   def translation_scope

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -16,7 +16,7 @@ class Devise::RegistrationsController < DeviseController
   def create
     build_resource(sign_up_params)
 
-    resource.save
+    resource.save(context: resource_validation_context)
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
@@ -142,6 +142,10 @@ class Devise::RegistrationsController < DeviseController
 
   def account_update_params
     devise_parameter_sanitizer.sanitize(:account_update)
+  end
+
+  def resource_validation_context
+    nil
   end
 
   def translation_scope

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -38,7 +38,7 @@ module Devise
       def initialize(*args, &block)
         @skip_email_changed_notification = false
         @skip_password_change_notification = false
-        super 
+        super
       end
 
       # Skips sending the email changed notification after_update
@@ -82,6 +82,7 @@ module Devise
       # is also rejected as long as it is also blank.
       def update_with_password(params, *options)
         current_password = params.delete(:current_password)
+        context = params.delete(:context)
 
         if params[:password].blank?
           params.delete(:password)
@@ -89,10 +90,11 @@ module Devise
         end
 
         result = if valid_password?(current_password)
-          update(params, *options)
+          assign_attributes(params, *options)
+          save(context: context)
         else
           assign_attributes(params, *options)
-          valid?
+          valid?(context: context)
           errors.add(:current_password, current_password.blank? ? :blank : :invalid)
           false
         end


### PR DESCRIPTION
…s POC

As a side feature of configuring permitted params in Devise::RegistrationsController, it might be a valid use case to be able to configure the validation context on resource registration.

Linked PR is just a POC. If you show some interest in this feature, I would be glad to investigate more in code quality (and adding tests).

Possibly related to #4705 