### PR TITLE
Fix error when params is not a hash

### DIFF
--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -135,7 +135,19 @@ module Devise
     end
 
     def default_params
-      @params.fetch(@resource_name, {})
+      if hashable_resource_params?
+        @params.fetch(@resource_name)
+      else
+        empty_params
+      end
+    end
+
+    def hashable_resource_params?
+      @params[@resource_name].respond_to?(:permit)
+    end
+
+    def empty_params
+      ActionController::Parameters.new({})
     end
 
     def permit_keys(parameters, keys)

--- a/test/parameter_sanitizer_test.rb
+++ b/test/parameter_sanitizer_test.rb
@@ -16,6 +16,34 @@ class ParameterSanitizerTest < ActiveSupport::TestCase
     assert_equal({ 'email' => 'jose' }, sanitized)
   end
 
+  test 'permits empty params when received not a hash' do
+    sanitizer = sanitizer({ 'user' => 'string' })
+    sanitized = sanitizer.sanitize(:sign_in)
+
+    assert_equal({}, sanitized)
+  end
+
+  test 'does not rise error when received string instead of hash' do
+    sanitizer = sanitizer('user' => 'string')
+    assert_nothing_raised do
+      sanitizer.sanitize(:sign_in)
+    end
+  end
+
+  test 'does not rise error when received nil instead of hash' do
+    sanitizer = sanitizer('user' => nil)
+    assert_nothing_raised do
+      sanitizer.sanitize(:sign_in)
+    end
+  end
+
+  test 'permits empty params when received nil instead of hash' do
+    sanitizer = sanitizer({ 'user' => nil })
+    sanitized = sanitizer.sanitize(:sign_in)
+
+    assert_equal({}, sanitized)
+  end
+
   test 'permits the default parameters for sign up' do
     sanitizer = sanitizer('user' => { 'email' => 'jose', 'role' => 'invalid' })
     sanitized = sanitizer.sanitize(:sign_up)


### PR DESCRIPTION
Hello!

When we send to devise controller string or nil instead hash in params we have error **undefined method permit' for "string":String**
This crash Rails app with 500 error and creates unnecessary records in errbit.

Example clean Rails app with Devise - https://shrouded-brook-83924.herokuapp.com
Course code -  https://github.com/b0nn1e/devise_test

**Normal case:**
`/users/sign_in?user[email]=test@example.com`
**Cases with error:** 
`/users/sign_in?user=test@example.com`
`/users/sign_in?user`

Link to reproduce bug:
-  https://shrouded-brook-83924.herokuapp.com/users/sign_in?user=string
-  https://shrouded-brook-83924.herokuapp.com/users/sign_in?user

rails 5.1.5
devise 4.4.1
ruby 2.4.2
