### PR TITLE
Unexpected 401 Unauthorized response status when action is public

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -12,11 +12,6 @@ module Devise
         if respond_to?(:helper_method)
           helper_method :warden, :signed_in?, :devise_controller?
         end
-
-        def append_info_to_payload(payload)
-          super
-          payload[:status] ||= 401 unless payload[:exception]
-        end
       end
 
       module ClassMethods
@@ -82,6 +77,11 @@ module Devise
               helper_method "current_#{group_name}", "current_#{group_name.to_s.pluralize}", "#{group_name}_signed_in?"
             end
           METHODS
+        end
+
+        def log_process_action(payload)
+          payload[:status] ||= 401 unless payload[:exception]
+          super
         end
       end
 

--- a/test/rails_app/app/controllers/home_controller.rb
+++ b/test/rails_app/app/controllers/home_controller.rb
@@ -16,6 +16,14 @@ class HomeController < ApplicationController
   def join
   end
 
+  def broken
+    raise 'Broken action'
+  end
+
+  def unprocessable_entity
+    head :unprocessable_entity
+  end
+
   def set
     session["devise.foo_bar"] = "something"
     head :ok

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
 
   unauthenticated do
     get "/join", to: "home#join"
+    get "/unprocessable_entity", to: "home#unprocessable_entity"
+    get "/broken", to: "home#broken"
   end
 
   # Routes for constraints testing


### PR DESCRIPTION
The PR https://github.com/plataformatec/devise/pull/4375 broke the logging in my app when I upgraded from 4.3.0 to 4.4.0, and 4.4.1 is still broken. I'm on Rails 5.1.4

I noticed that the logs in my app had `Completed 401 Unauthorized` when the actual response received by the client was a 500 Internal Server Error.

I reported this in https://github.com/plataformatec/devise/pull/4375#issuecomment-369289290 but @tegon suggested to submit this PR with a failing test case that reproduces the bug.

# Investigation

I dug in a little bit and I found out that in the following method, the `payload[:exception]` always returns `nil` even if a public action raises an error, so the `401` status is added to the payload. Also, Rails didn't add the 500 status at this point yet, so `payload[:status]` is `nil` as well

https://github.com/plataformatec/devise/blob/f39c6fd92774cb66f96f546d8d5e8281542b4e78/lib/devise/controllers/helpers.rb#L16-L19

# Solution

~I couldn't figure out the proper solution other than reverting that PR yet. I'll spend some time investigating later today, but it would be great to have some input from @fbbergamo~

Use `ActiveSupport::Notifications.instrument` instead of overriding `append_info_to_payload` since the former is called later in the stack, for which the `payload[:exception]` is present when an exception was raised
