### PR TITLE
Passing :scope option to uniqueness validator of :email

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -118,6 +118,10 @@ module Devise
   mattr_accessor :password_length
   @@password_length = 6..128
 
+  # Option :scope for Uniqueness Validator of email
+  mattr_accessor :email_scope
+  @@email_scope = nil
+
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for
   @@remember_for = 2.weeks

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -13,6 +13,7 @@ module Devise
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
+    #   * +email_scope+: the option :scope for :email validator;
     #
     module Validatable
       # All validations used by this module.
@@ -30,10 +31,10 @@ module Devise
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
           if Devise.activerecord51?
-            validates_uniqueness_of :email, allow_blank: true, if: :will_save_change_to_email?
+            validates_uniqueness_of :email, allow_blank: true, if: :will_save_change_to_email?, scope: email_scope
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
           else
-            validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+            validates_uniqueness_of :email, allow_blank: true, if: :email_changed?, scope: email_scope
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
           end
 
@@ -66,7 +67,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(self, :email_regexp, :password_length, :email_scope)
       end
     end
   end

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -13,8 +13,8 @@ class DeviseCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migrat
     end
 
     add_index :<%= table_name %>, :email,                unique: true
-    add_index :<%= table_name %>, :reset_password_token, unique: true
-    # add_index :<%= table_name %>, :confirmation_token,   unique: true
-    # add_index :<%= table_name %>, :unlock_token,         unique: true
+    add_index :<%= table_name %>, :reset_password_token, unique: true, where: '([reset_password_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :confirmation_token,   unique: true, where: '([confirmation_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :unlock_token,         unique: true, where: '([unlock_token] IS NOT NULL)'
   end
 end

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -14,9 +14,9 @@ class AddDeviseTo<%= table_name.camelize %> < ActiveRecord::Migration<%= migrati
     end
 
     add_index :<%= table_name %>, :email,                unique: true
-    add_index :<%= table_name %>, :reset_password_token, unique: true
-    # add_index :<%= table_name %>, :confirmation_token,   unique: true
-    # add_index :<%= table_name %>, :unlock_token,         unique: true
+    add_index :<%= table_name %>, :reset_password_token, unique: true, where: '([reset_password_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :confirmation_token,   unique: true, where: '([confirmation_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :unlock_token,         unique: true, where: '([unlock_token] IS NOT NULL)'
   end
 
   def self.down


### PR DESCRIPTION
Uniqueness validator of :email must have :scope option setting to solve many difficulties like for:
- per subdomain auth;
- soft deletion and paranoid like support;
- even example from https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address.