### PR TITLE
Generator templates indexes condition correction

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -13,8 +13,8 @@ class DeviseCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migrat
     end
 
     add_index :<%= table_name %>, :email,                unique: true
-    add_index :<%= table_name %>, :reset_password_token, unique: true
-    # add_index :<%= table_name %>, :confirmation_token,   unique: true
-    # add_index :<%= table_name %>, :unlock_token,         unique: true
+    add_index :<%= table_name %>, :reset_password_token, unique: true, where: '([reset_password_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :confirmation_token,   unique: true, where: '([confirmation_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :unlock_token,         unique: true, where: '([unlock_token] IS NOT NULL)'
   end
 end

--- a/lib/generators/active_record/templates/migration_existing.rb
+++ b/lib/generators/active_record/templates/migration_existing.rb
@@ -14,9 +14,9 @@ class AddDeviseTo<%= table_name.camelize %> < ActiveRecord::Migration<%= migrati
     end
 
     add_index :<%= table_name %>, :email,                unique: true
-    add_index :<%= table_name %>, :reset_password_token, unique: true
-    # add_index :<%= table_name %>, :confirmation_token,   unique: true
-    # add_index :<%= table_name %>, :unlock_token,         unique: true
+    add_index :<%= table_name %>, :reset_password_token, unique: true, where: '([reset_password_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :confirmation_token,   unique: true, where: '([confirmation_token] IS NOT NULL)'
+    # add_index :<%= table_name %>, :unlock_token,         unique: true, where: '([unlock_token] IS NOT NULL)'
   end
 
   def self.down


### PR DESCRIPTION
Indexes for tokens should have WHERE ...token IS NOT NULL construction.
Else we are admitted to create only one user.
Unfortunatelly, in worse cases people just remove these indexes...
Initially faced with it on MS SQL server (not checked other adapters
        though).
Inspired by https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/issues/153

Probably need to add test case for generated migrations with tokens