### PR TITLE
Check if the record is persisted in `update_tracked_fields!`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
     devise (4.4.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
 

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -31,8 +31,13 @@ module Devise
       end
 
       def update_tracked_fields!(request)
+        # We have to check if the user is already persisted before running
+        # `save` here because invalid users can be saved if we don't.
+        # See https://github.com/plataformatec/devise/issues/4673 for more details.
+        return if new_record?
+
         update_tracked_fields(request)
-        save
+        save(validate: false)
       end
     end
   end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -3,6 +3,12 @@
 require 'test_helper'
 
 class AuthenticationSanityTest < Devise::IntegrationTest
+  test 'sign in should not run model validations' do
+    sign_in_as_user
+
+    refute User.validations_performed
+  end
+
   test 'home should be accessible without sign in' do
     visit '/'
     assert_response :success

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -3,6 +3,12 @@
 require 'test_helper'
 
 class HttpAuthenticationTest < Devise::IntegrationTest
+  test 'sign in with HTTP should not run model validations' do
+    sign_in_as_new_user_with_http
+
+    refute User.validations_performed
+  end
+
   test 'handles unverified requests gets rid of caches but continues signed in' do
     swap ApplicationController, allow_forgery_protection: true do
       create_user

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -42,6 +42,17 @@ class OmniauthableIntegrationTest < Devise::IntegrationTest
     end
   end
 
+  test "omniauth sign in should not run model validations" do
+    stub_action!(:sign_in_facebook) do
+      create_user
+      visit "/users/sign_in"
+      click_link "Sign in with FaceBook"
+      assert warden.authenticated?(:user)
+
+      refute User.validations_performed
+    end
+  end
+
   test "can access omniauth.auth in the env hash" do
     visit "/users/sign_in"
     click_link "Sign in with FaceBook"

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class TrackableHooksTest < Devise::IntegrationTest
+  test "trackable should not run model validations" do
+    sign_in_as_user
+
+    refute User.validations_performed
+  end
 
   test "current and last sign in timestamps are updated on each sign in" do
     user = create_user

--- a/test/models/trackable_test.rb
+++ b/test/models/trackable_test.rb
@@ -41,12 +41,22 @@ class TrackableTest < ActiveSupport::TestCase
     assert_equal 0, user.sign_in_count
   end
 
-  test 'update_tracked_fields should run model validations' do
+  test "update_tracked_fields! should not persist invalid records" do
     user = UserWithValidations.new
     request = mock
     request.stubs(:remote_ip).returns("127.0.0.1")
 
     assert_not user.update_tracked_fields!(request)
     assert_not user.persisted?
+  end
+
+  test "update_tracked_fields! should not run model validations" do
+    user = User.new
+    request = mock
+    request.stubs(:remote_ip).returns("127.0.0.1")
+
+    user.expects(:after_validation_callback).never
+
+    assert_not user.update_tracked_fields!(request)
   end
 end

--- a/test/rails_app/app/active_record/user.rb
+++ b/test/rails_app/app/active_record/user.rb
@@ -8,4 +8,13 @@ class User < ActiveRecord::Base
   include ActiveModel::Serializers::Xml if Devise::Test.rails5?
 
   validates :sign_in_count, presence: true
+
+  cattr_accessor :validations_performed
+
+  after_validation :after_validation_callback
+
+  def after_validation_callback
+    # used to check in our test if the validations were called
+    @@validations_performed = true
+  end
 end

--- a/test/rails_app/app/mongoid/user.rb
+++ b/test/rails_app/app/mongoid/user.rb
@@ -38,4 +38,13 @@ class User
   field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
   field :unlock_token,    type: String # Only if unlock strategy is :email or :both
   field :locked_at,       type: Time
+
+  cattr_accessor :validations_performed
+
+  after_validation :after_validation_callback
+
+  def after_validation_callback
+    # used to check in our test if the validations were called
+    @@validations_performed = true
+  end
 end

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -19,6 +19,7 @@ class ActionDispatch::IntegrationTest
       user.update_attribute(:confirmation_sent_at, options[:confirmation_sent_at]) if options[:confirmation_sent_at]
       user.confirm unless options[:confirm] == false
       user.lock_access! if options[:locked] == true
+      User.validations_performed = false
       user
     end
   end


### PR DESCRIPTION
In some cases, invalid records could be created during the signup process because we were calling `save(validate: false)` inside the `update_tracked_fields!` method. See https://github.com/plataformatec/devise/issues/4673 for more information.
This was fixed on https://github.com/plataformatec/devise/pull/4674 by calling `save` directly, but it caused some trouble and confusion since it changed Devise's behavior significantly.
We talked about on https://github.com/plataformatec/devise/issues/4790 and it doesn't even make sense to call `save` on an object that isn't persisted yet, so I've added a guard clause to the `update_tracked_fields!` method.