### PR TITLE
Fix `Devise::Test::ControllerHelpers`

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -139,7 +139,7 @@ module Devise
 
           status, headers, response = Devise.warden_config[:failure_app].call(env).to_a
           @controller.response.headers.merge!(headers)
-          @controller.response.content_type = headers["Content-Type"] unless Devise::Test.rails5?
+          @controller.response.content_type = headers["Content-Type"] unless Rails.version.start_with?('5')
           @controller.status = status
           @controller.response.body = response.body
           nil # causes process return @response


### PR DESCRIPTION
This was broken on https://github.com/plataformatec/devise/commit/3e23371b01443d6b8bdbfcbdcd33d2883847e39d#diff-bafaaa60fc003e648eb4981c9add523eR142
because of a call to the method `Devise::Test.rails5?` which is only defined in our test suite's rails app https://github.com/plataformatec/devise/blob/a45bbe1783e4b46af15825a0bb2eb5917a9b8726/test/rails_app/config/boot.rb#L19
This commits checks for the rails version directly.

Since this works inside our test suite, we haven't noticed this bug. It only happens when other projects require the controller helpers outside devise. I'm not sure how we could add an automated test for this, I accept suggestions. But I believe a better solution would be to change this class namespace for our test suite's rails app so we don't face this kind of confusion anymore.

Fixes #4808