### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/guides/bug_report_templates/integration_test.rb
+++ b/guides/bug_report_templates/integration_test.rb
@@ -76,7 +76,7 @@ end
 class TestController < ApplicationController
   include Rails.application.routes.url_helpers
 
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def index
     render plain: 'Home'


### PR DESCRIPTION
The integration test template was using the deprecated `before_filter` rather than `before_action`