### PR TITLE
README section on controller tests should explain need for "include Devise::Test::IntegrationHelpers" in rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,8 @@ cases/specs.
 Controller tests require that you include `Devise::Test::ControllerHelpers` on
 your test case or its parent `ActionController::TestCase` superclass.
 For Rails 5, include `Devise::Test::IntegrationHelpers` instead, since the superclass
-for controller tests has been changed to ActionDispatch::IntegrationTest.
+for controller tests has been changed to ActionDispatch::IntegrationTest
+(for more details, see the [Integration tests](#integration-tests) section).
 
 ```ruby
 class PostsControllerTest < ActionController::TestCase

--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ cases/specs.
 
 Controller tests require that you include `Devise::Test::ControllerHelpers` on
 your test case or its parent `ActionController::TestCase` superclass.
+For Rails 5, include `Devise::Test::IntegrationHelpers` instead, since the superclass
+for controller tests has been changed to ActionDispatch::IntegrationTest.
 
 ```ruby
 class PostsControllerTest < ActionController::TestCase


### PR DESCRIPTION
# Issue

https://github.com/plataformatec/devise/issues/4819

# Problem

In the Controller tests section of the README, it is stated that `Devise::Test::ControllerHelpers` needs to be included for devise to work in tests. 
However, from Rails 5 controller tests no longer belong to `ActionController::TestCase`, and now belong to ` ActionDispatch::IntegrationTest`. Therefore, `Devise::Test::IntegrationHelpers` needs to be included instead of `Devise::Test::ControllerHelpers`.

# Solution

I added a short passage in the README explaining this difference.