### PR TITLE
issue 4526 adds skip email and password change notifications methods

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -35,6 +35,16 @@ module Devise
         attr_accessor :password_confirmation
       end
 
+      # Skips sending the email changed notification after_update
+      def skip_email_changed_notification!
+        @skip_email_changed_notification = true
+      end
+
+      # Skips sending the password change notification after_update
+      def skip_password_change_notification!
+        @skip_password_change_notification = true
+      end
+
       def self.required_fields(klass)
         [:encrypted_password] + klass.authentication_keys
       end
@@ -169,21 +179,21 @@ module Devise
 
       if Devise.activerecord51?
         def send_email_changed_notification?
-          self.class.send_email_changed_notification && saved_change_to_email?
+          self.class.send_email_changed_notification && saved_change_to_email? && !@skip_email_changed_notification
         end
       else
         def send_email_changed_notification?
-          self.class.send_email_changed_notification && email_changed?
+          self.class.send_email_changed_notification && email_changed? && !@skip_email_changed_notification
         end
       end
 
       if Devise.activerecord51?
         def send_password_change_notification?
-          self.class.send_password_change_notification && saved_change_to_encrypted_password?
+          self.class.send_password_change_notification && saved_change_to_encrypted_password? && !@skip_password_change_notification
         end
       else
         def send_password_change_notification?
-          self.class.send_password_change_notification && encrypted_password_changed?
+          self.class.send_password_change_notification && encrypted_password_changed? && !@skip_password_change_notification
         end
       end
 

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -35,6 +35,12 @@ module Devise
         attr_accessor :password_confirmation
       end
 
+      def initialize(*args, &block)
+        @skip_email_changed_notification = false
+        @skip_password_change_notification = false
+        super 
+      end
+
       # Skips sending the email changed notification after_update
       def skip_email_changed_notification!
         @skip_email_changed_notification = true

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -259,6 +259,26 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should not notify email on password change even when configured if skip_password_change_notification! is invoked' do
+    swap Devise, send_email_changed_notification: true do
+      user = create_user
+      user.skip_password_change_notification!
+      assert_email_not_sent do
+        assert user.update(password: 'newpass', password_confirmation: 'newpass')
+      end
+    end
+  end
+
+  test 'should not notify email on email change even when configured if skip_email_changed_notification! is invoked' do
+    swap Devise, send_email_changed_notification: true do
+      user = create_user
+      user.skip_email_changed_notification!
+      assert_email_not_sent do
+        assert user.update(email: 'new-email@example.com')
+      end
+    end
+  end
+
   test 'downcase_keys with validation' do
     User.create(email: "HEllO@example.com", password: "123456")
     user = User.create(email: "HEllO@example.com", password: "123456")

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -260,7 +260,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   end
 
   test 'should not notify email on password change even when configured if skip_password_change_notification! is invoked' do
-    swap Devise, send_email_changed_notification: true do
+    swap Devise, send_password_change_notification: true do
       user = create_user
       user.skip_password_change_notification!
       assert_email_not_sent do


### PR DESCRIPTION
 I added methods to skip email change notifications and password change notifications on per edit basis like the issue was requesting.  I also added tests for these two methods.  All the tests are passing and the functionality worked when I tried it out on my test app.  This is my first PR so please let me know if I missed conforming to any guidelines or if I need to improve or adjust the code to fit your structure better. Thanks!