### PR TITLE
Add note in the documentation about `sign_in` and timeoutable [ci skip]

### DIFF
--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -19,6 +19,9 @@ module Devise
       # Sign in a user that already was authenticated. This helper is useful for logging
       # users in after sign up. All options given to sign_in is passed forward
       # to the set_user method in warden.
+      # If you are using a custom warden strategy and the timeoutable module, you have to
+      # set `env["devise.skip_timeout"] = true` in the request to use this method, like we do
+      # in the sessions controller: https://github.com/plataformatec/devise/blob/master/app/controllers/devise/sessions_controller.rb#L7
       #
       # Examples:
       #


### PR DESCRIPTION
In order to use the `sign_in` helper along with the timeoutable module, we have to set `env["devise.skip_timeout"] = true` in the request.
Currently, we do this in the sessions controller: https://github.com/plataformatec/devise/blob/master/app/controllers/devise/sessions_controller.rb#L7
This commit adds a note to the `sign_in` documentation to help other developers that want to use custom warden strategies.

Closes #4773