### PR TITLE
Make secure_compare handle empty strings comparison correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,8 @@ cases/specs.
 Controller tests require that you include `Devise::Test::ControllerHelpers` on
 your test case or its parent `ActionController::TestCase` superclass.
 For Rails 5, include `Devise::Test::IntegrationHelpers` instead, since the superclass
-for controller tests has been changed to ActionDispatch::IntegrationTest.
+for controller tests has been changed to ActionDispatch::IntegrationTest
+(for more details, see the [Integration tests](#integration-tests) section).
 
 ```ruby
 class PostsControllerTest < ActionController::TestCase

--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ cases/specs.
 
 Controller tests require that you include `Devise::Test::ControllerHelpers` on
 your test case or its parent `ActionController::TestCase` superclass.
+For Rails 5, include `Devise::Test::IntegrationHelpers` instead, since the superclass
+for controller tests has been changed to ActionDispatch::IntegrationTest.
 
 ```ruby
 class PostsControllerTest < ActionController::TestCase

--- a/guides/bug_report_templates/integration_test.rb
+++ b/guides/bug_report_templates/integration_test.rb
@@ -76,7 +76,7 @@ end
 class TestController < ApplicationController
   include Rails.application.routes.url_helpers
 
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 
   def index
     render plain: 'Home'

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -498,12 +498,8 @@ module Devise
 
   # constant-time comparison algorithm to prevent timing attacks
   def self.secure_compare(a, b)
-    return false if a.blank? || b.blank? || a.bytesize != b.bytesize
-    l = a.unpack "C#{a.bytesize}"
-
-    res = 0
-    b.each_byte { |byte| res |= byte ^ l.shift }
-    res == 0
+    return false if a.nil? || b.nil?
+    ActiveSupport::SecurityUtils.secure_compare(a, b)
   end
 end
 

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -260,5 +260,7 @@ module Devise
     def relative_url_root?
       relative_url_root.present?
     end
+
+    ActiveSupport.run_load_hooks(:devise_failure_app, self)
   end
 end

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -134,16 +134,18 @@ module Devise
       # This is an internal method called every time Devise needs
       # to send a notification/mail. This can be overridden if you
       # need to customize the e-mail delivery logic. For instance,
-      # if you are using a queue to deliver e-mails (delayed job,
-      # sidekiq, resque, etc), you must add the delivery to the queue
+      # if you are using a queue to deliver e-mails (active job, delayed
+      # job, sidekiq, resque, etc), you must add the delivery to the queue
       # just after the transaction was committed. To achieve this,
       # you can override send_devise_notification to store the
-      # deliveries until the after_commit callback is triggered:
+      # deliveries until the after_commit callback is triggered.
+      #
+      # The following example uses Active Job's `deliver_later` :
       #
       #     class User
       #       devise :database_authenticatable, :confirmable
       #
-      #       after_commit :send_pending_notifications
+      #       after_commit :send_pending_devise_notifications
       #
       #       protected
       #
@@ -152,38 +154,43 @@ module Devise
       #         # delivery until the after_commit callback otherwise
       #         # send now because after_commit will not be called.
       #         if new_record? || changed?
-      #           pending_notifications << [notification, args]
+      #           pending_devise_notifications << [notification, args]
       #         else
-      #           message = devise_mailer.send(notification, self, *args)
-      #           Remove once we move to Rails 4.2+ only.
-      #           if message.respond_to?(:deliver_now)
-      #             message.deliver_now
-      #           else
-      #             message.deliver
-      #           end
+      #           render_and_send_devise_message(notification, *args)
       #         end
       #       end
       #
-      #       def send_pending_notifications
-      #         pending_notifications.each do |notification, args|
-      #           message = devise_mailer.send(notification, self, *args)
-      #           Remove once we move to Rails 4.2+ only.
-      #           if message.respond_to?(:deliver_now)
-      #             message.deliver_now
-      #           else
-      #             message.deliver
-      #           end
+      #       private
+      #
+      #       def send_pending_devise_notifications
+      #         pending_devise_notifications.each do |notification, args|
+      #           render_and_send_devise_message(notification, *args)
       #         end
       #
       #         # Empty the pending notifications array because the
       #         # after_commit hook can be called multiple times which
       #         # could cause multiple emails to be sent.
-      #         pending_notifications.clear
+      #         pending_devise_notifications.clear
       #       end
       #
-      #       def pending_notifications
-      #         @pending_notifications ||= []
+      #       def pending_devise_notifications
+      #         @pending_devise_notifications ||= []
       #       end
+      #
+      #       def render_and_send_devise_message(notification, *args)
+      #         message = devise_mailer.send(notification, self, *args)
+      #
+      #         # Deliver later with Active Job's `deliver_later`
+      #         if message.respond_to?(:deliver_later)
+      #           message.deliver_later
+      #         # Remove once we move to Rails 4.2+ only, as `deliver` is deprecated.
+      #         elsif message.respond_to?(:deliver_now)
+      #           message.deliver_now
+      #         else
+      #           message.deliver
+      #         end
+      #       end
+      #
       #     end
       #
       def send_devise_notification(notification, *args)

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -73,7 +73,7 @@ module Devise
         end
 
         result = if valid_password?(current_password)
-          update_attributes(params, *options)
+          update(params, *options)
         else
           self.assign_attributes(params, *options)
           self.valid?
@@ -101,7 +101,7 @@ module Devise
         params.delete(:password)
         params.delete(:password_confirmation)
 
-        result = update_attributes(params, *options)
+        result = update(params, *options)
         clean_up_passwords
         result
       end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -284,7 +284,7 @@ Devise.setup do |config|
   # ==> Turbolinks configuration
   # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
   #
-  # ActiveSupport.on_load(:devise_failure_app)
+  # ActiveSupport.on_load(:devise_failure_app) do
   #   include Turbolinks::Controller
   # end
 end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -280,4 +280,11 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app)
+  #   include Turbolinks::Controller
+  # end
 end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -90,9 +90,12 @@ class DeviseTest < ActiveSupport::TestCase
     [nil, ""].each do |empty|
       refute Devise.secure_compare(empty, "something")
       refute Devise.secure_compare("something", empty)
-      refute Devise.secure_compare(empty, empty)
     end
     refute Devise.secure_compare("size_1", "size_four")
+  end
+
+  test 'Devise.secure_compare should return true if strings are same' do
+    assert Devise.secure_compare('', '')
   end
 
   test 'Devise.email_regexp should match valid email addresses' do

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -337,4 +337,10 @@ class FailureTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "Lazy loading" do
+    test "loads" do
+      assert_equal Devise::FailureApp.new.lazy_loading_works?, "yes it does"
+    end
+  end
 end

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -263,7 +263,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
 
   test 'admin should be able to request a new confirmation after email changed' do
     admin = create_admin
-    admin.update_attributes(email: 'new_test@example.com')
+    admin.update(email: 'new_test@example.com')
 
     visit new_admin_session_path
     click_link "Didn't receive confirmation instructions?"
@@ -279,7 +279,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
 
   test 'admin with valid confirmation token should be able to confirm email after email changed' do
     admin = create_admin
-    admin.update_attributes(email: 'new_test@example.com')
+    admin.update(email: 'new_test@example.com')
     assert_equal 'new_test@example.com', admin.unconfirmed_email
     visit_admin_confirmation_with_token(admin.raw_confirmation_token)
 
@@ -291,13 +291,13 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
 
   test 'admin with previously valid confirmation token should not be able to confirm email after email changed again' do
     admin = create_admin
-    admin.update_attributes(email: 'first_test@example.com')
+    admin.update(email: 'first_test@example.com')
     assert_equal 'first_test@example.com', admin.unconfirmed_email
 
     raw_confirmation_token = admin.raw_confirmation_token
     admin = Admin.find(admin.id)
 
-    admin.update_attributes(email: 'second_test@example.com')
+    admin.update(email: 'second_test@example.com')
     assert_equal 'second_test@example.com', admin.unconfirmed_email
 
     visit_admin_confirmation_with_token(raw_confirmation_token)
@@ -313,7 +313,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
 
   test 'admin email should be unique also within unconfirmed_email' do
     admin = create_admin
-    admin.update_attributes(email: 'new_admin_test@example.com')
+    admin.update(email: 'new_admin_test@example.com')
     assert_equal 'new_admin_test@example.com', admin.unconfirmed_email
 
     create_second_admin(email: "new_admin_test@example.com")

--- a/test/mailers/email_changed_test.rb
+++ b/test/mailers/email_changed_test.rb
@@ -19,7 +19,7 @@ class EmailChangedTest < ActionMailer::TestCase
   def user
     @user ||= create_user.tap { |u|
       @original_user_email = u.email
-      u.update_attributes!(email: 'new-email@example.com')
+      u.update!(email: 'new-email@example.com')
     }
   end
 
@@ -108,7 +108,7 @@ class EmailChangedReconfirmationTest < ActionMailer::TestCase
   def admin
     @admin ||= create_admin.tap { |u|
       @original_admin_email = u.email
-      u.update_attributes!(email: 'new-email@example.com')
+      u.update!(email: 'new-email@example.com')
     }
   end
 

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -372,7 +372,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin = create_admin
     assert admin.confirm
     residual_token = admin.confirmation_token
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert_not_equal residual_token, admin.confirmation_token
   end
 
@@ -381,7 +381,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     original_token = admin.confirmation_token
     assert admin.confirm
     admin.skip_reconfirmation!
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert admin.confirmed?
     refute admin.pending_reconfirmation?
     assert_equal original_token, admin.confirmation_token
@@ -392,16 +392,16 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin.skip_confirmation_notification!
 
     assert_email_not_sent do
-      admin.update_attributes(email: 'new_test@example.com')
+      admin.update(email: 'new_test@example.com')
     end
   end
 
   test 'should regenerate confirmation token after changing email' do
     admin = create_admin
     assert admin.confirm
-    assert admin.update_attributes(email: 'old_test@example.com')
+    assert admin.update(email: 'old_test@example.com')
     token = admin.confirmation_token
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert_not_equal token, admin.confirmation_token
   end
 
@@ -409,7 +409,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin = create_admin
     assert admin.confirm
     assert_email_sent "new_test@example.com" do
-      assert admin.update_attributes(email: 'new_test@example.com')
+      assert admin.update(email: 'new_test@example.com')
     end
     assert_match "new_test@example.com", ActionMailer::Base.deliveries.last.body.encoded
   end
@@ -417,7 +417,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
   test 'should send confirmation instructions by email after changing email from nil' do
     admin = create_admin(email: nil)
     assert_email_sent "new_test@example.com" do
-      assert admin.update_attributes(email: 'new_test@example.com')
+      assert admin.update(email: 'new_test@example.com')
     end
     assert_match "new_test@example.com", ActionMailer::Base.deliveries.last.body.encoded
   end
@@ -426,7 +426,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin = create_admin
     assert admin.confirm
     assert_email_not_sent do
-      assert admin.update_attributes(password: 'newpass', password_confirmation: 'newpass')
+      assert admin.update(password: 'newpass', password_confirmation: 'newpass')
     end
   end
 
@@ -442,14 +442,14 @@ class ReconfirmableTest < ActiveSupport::TestCase
   test 'should stay confirmed when email is changed' do
     admin = create_admin
     assert admin.confirm
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert admin.confirmed?
   end
 
   test 'should update email only when it is confirmed' do
     admin = create_admin
     assert admin.confirm
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert_not_equal 'new_test@example.com', admin.email
     assert admin.confirm
     assert_equal 'new_test@example.com', admin.email
@@ -458,16 +458,16 @@ class ReconfirmableTest < ActiveSupport::TestCase
   test 'should not allow admin to get past confirmation email by resubmitting their new address' do
     admin = create_admin
     assert admin.confirm
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert_not_equal 'new_test@example.com', admin.email
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     assert_not_equal 'new_test@example.com', admin.email
   end
 
   test 'should find a admin by send confirmation instructions with unconfirmed_email' do
     admin = create_admin
     assert admin.confirm
-    assert admin.update_attributes(email: 'new_test@example.com')
+    assert admin.update(email: 'new_test@example.com')
     confirmation_admin = Admin.send_confirmation_instructions(email: admin.unconfirmed_email)
     assert_equal confirmation_admin, admin
   end
@@ -536,7 +536,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
       original_email = admin.email
 
       assert_difference 'ActionMailer::Base.deliveries.size', 2 do
-        assert admin.update_attributes(email: 'new-email@example.com')
+        assert admin.update(email: 'new-email@example.com')
       end
       assert_equal original_email, ActionMailer::Base.deliveries[-2]['to'].to_s
       assert_equal 'new-email@example.com', ActionMailer::Base.deliveries[-1]['to'].to_s

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -234,7 +234,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   test 'should not email on password change' do
     user = create_user
     assert_email_not_sent do
-      assert user.update_attributes(password: 'newpass', password_confirmation: 'newpass')
+      assert user.update(password: 'newpass', password_confirmation: 'newpass')
     end
   end
 
@@ -243,7 +243,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
       user = create_user
       original_email = user.email
       assert_email_sent original_email do
-        assert user.update_attributes(email: 'new-email@example.com')
+        assert user.update(email: 'new-email@example.com')
       end
       assert_match original_email, ActionMailer::Base.deliveries.last.body.encoded
     end
@@ -253,7 +253,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     swap Devise, send_password_change_notification: true do
       user = create_user
       assert_email_sent user.email do
-        assert user.update_attributes(password: 'newpass', password_confirmation: 'newpass')
+        assert user.update(password: 'newpass', password_confirmation: 'newpass')
       end
       assert_match user.email, ActionMailer::Base.deliveries.last.body.encoded
     end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -179,4 +179,9 @@ Devise.setup do |config|
   #   manager.failure_app = AnotherApp
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+
+  ActiveSupport.on_load(:devise_failure_app) do
+    require "lazy_load_test_module"
+    include LazyLoadTestModule
+  end
 end

--- a/test/rails_app/lib/lazy_load_test_module.rb
+++ b/test/rails_app/lib/lazy_load_test_module.rb
@@ -1,0 +1,5 @@
+module LazyLoadTestModule
+  def lazy_loading_works?
+    "yes it does"
+  end
+end


### PR DESCRIPTION
Used Rails' secure_compare method inside the definition of secure_compare. This will handle the empty strings comparison and return true when both the parameters are blank strings.

Fixes #4441