### PR TITLE
When password reset token expires, redirect to new password path

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -47,7 +47,12 @@ class Devise::PasswordsController < DeviseController
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
       set_minimum_password_length
-      respond_with resource
+
+      if expired_token_error(resource)
+        redirect_to new_password_path(resource_name), alert: resource.errors.full_messages.join("\n")
+      else
+        respond_with resource
+      end
     end
   end
 
@@ -79,5 +84,12 @@ class Devise::PasswordsController < DeviseController
 
     def translation_scope
       'devise.passwords'
+    end
+
+  private
+    def expired_token_error(resource)
+      (resource.errors.respond_to?(:details) &&
+          resource.errors.details[:reset_password_token].any? { |error| error[:error] == :expired }) ||
+          resource.errors[:reset_password_token].any? { |error| error =~ /expired/ }
     end
 end

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -49,7 +49,8 @@ class Devise::PasswordsController < DeviseController
       set_minimum_password_length
 
       if expired_token_error(resource)
-        redirect_to new_password_path(resource_name), alert: resource.errors.full_messages.join("\n")
+        alert = resource.errors.full_messages_for(:reset_password_token).join("\n")
+        redirect_to new_password_path(resource_name), alert: alert
       else
         respond_with resource
       end

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -48,7 +48,7 @@ class Devise::PasswordsController < DeviseController
     else
       set_minimum_password_length
 
-      if expired_token_error(resource)
+      if expired_token_error?(resource)
         redirect_to new_password_path(resource_name), alert: t('devise.passwords.expired_token')
       else
         respond_with resource
@@ -87,9 +87,7 @@ class Devise::PasswordsController < DeviseController
     end
 
   private
-    def expired_token_error(resource)
-      (resource.errors.respond_to?(:details) &&
-          resource.errors.details[:reset_password_token].any? { |error| error[:error] == :expired }) ||
-          resource.errors[:reset_password_token].any? { |error| error =~ /expired/ }
+    def expired_token_error?(resource)
+      resource.errors.details[:reset_password_token].any? { |error| error[:error] == :expired }
     end
 end

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -49,8 +49,7 @@ class Devise::PasswordsController < DeviseController
       set_minimum_password_length
 
       if expired_token_error(resource)
-        alert = resource.errors.full_messages_for(:reset_password_token).join("\n")
-        redirect_to new_password_path(resource_name), alert: alert
+        redirect_to new_password_path(resource_name), alert: t('devise.passwords.expired_token')
       else
         respond_with resource
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
+      expired_token: "The password recovery link expired. Please request a new one."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -36,4 +36,10 @@ class PasswordsControllerTest < Devise::ControllerTestCase
     User.any_instance.expects :after_database_authentication
     put_update_with_params
   end
+
+  test 'redirects to new_password_path when token has expired' do
+    @user.update(reset_password_sent_at: Time.now - 1.year)
+    put_update_with_params
+    assert_redirected_to new_user_password_path
+  end
 end

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -152,6 +152,19 @@ class PasswordTest < Devise::IntegrationTest
     refute user.reload.valid_password?('987654321')
   end
 
+  test 'not authenticated user with expired reset password token should be redirected to new password path' do
+    user = create_user
+    request_forgot_password
+    user.update(reset_password_sent_at: Time.now - 1.year)
+
+    visit edit_user_password_path(reset_password_token: 'abcdef')
+    fill_in 'New password', with: '987654321'
+    fill_in 'Confirm new password', with: '987654321'
+    click_button 'Change my password'
+
+    assert_contain 'The password recovery link expired. Please request a new one.'
+  end
+
   test 'not authenticated user with valid reset password token but invalid password should not be able to change their password' do
     user = create_user
     request_forgot_password


### PR DESCRIPTION
Addresses issue #4399.

The flow of `PasswordController#update` re-rendered the edit view whenever there was an error resetting the password. But if the error was that the token has expired the message said "Reset password token has expired, please request a new one" — with no instructions on how to do that. 

This pull requests changes the behavior such that if the error is an expired password token, devise redirects to the `new_password_path`. That way the user has the form in front of them to make that request.