### PR TITLE
Adds feature require_password_to_destroy

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -66,11 +66,23 @@ class Devise::RegistrationsController < DeviseController
 
   # DELETE /resource
   def destroy
-    resource.destroy
-    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-    set_flash_message! :notice, :destroyed
-    yield resource if block_given?
-    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    if resource.class.require_password_to_destroy
+      resource_destroyed = destroy_resource(resource, account_destroy_params)
+      if resource_destroyed
+        Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+        set_flash_message! :notice, :destroyed
+        yield resource if block_given?
+        respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+      else
+        render :edit
+      end
+    else
+      resource.destroy
+      Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+      set_flash_message! :notice, :destroyed
+      yield resource if block_given?
+      respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    end
   end
 
   # GET /resource/cancel
@@ -95,6 +107,10 @@ class Devise::RegistrationsController < DeviseController
   # You can overwrite this method in your own RegistrationsController.
   def update_resource(resource, params)
     resource.update_with_password(params)
+  end
+
+  def destroy_resource(resource, params)
+    resource.destroy_with_password(params)
   end
 
   # Build a devise resource passing in the session. Useful to move
@@ -142,6 +158,10 @@ class Devise::RegistrationsController < DeviseController
 
   def account_update_params
     devise_parameter_sanitizer.sanitize(:account_update)
+  end
+
+  def account_destroy_params
+    devise_parameter_sanitizer.sanitize(:account_destroy)[:current_password]
   end
 
   def translation_scope

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,21 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<% if resource.class.require_password_to_destroy %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }) do |f| %>
+    <%= devise_error_messages! %>
+
+    <div class="field destroy-password">
+      <%= f.label :current_password %> <i>(we need your current password to delete your account)</i><br />
+      <%= f.password_field :current_password, autocomplete: "off" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Cancel my account" %>
+    </div>
+  <% end %>
+<% else %>
+  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<% end %>
 
 <%= link_to "Back", :back %>

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -293,6 +293,10 @@ module Devise
   mattr_accessor :token_generator
   @@token_generator = nil
 
+  # When true, signed in users must provide their current password to cancel account
+  mattr_accessor :require_password_to_destroy
+  @@require_password_to_destroy = false
+
   def self.rails51? # :nodoc:
     Rails.gem_version >= Gem::Version.new("5.1.x")
   end

--- a/lib/devise/models/registerable.rb
+++ b/lib/devise/models/registerable.rb
@@ -21,6 +21,7 @@ module Devise
         def new_with_session(params, session)
           new(params)
         end
+        Devise::Models.config(self, :require_password_to_destroy)
       end
     end
   end

--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -38,7 +38,8 @@ module Devise
     DEFAULT_PERMITTED_ATTRIBUTES = {
       sign_in: [:password, :remember_me],
       sign_up: [:password, :password_confirmation],
-      account_update: [:password, :password_confirmation, :current_password]
+      account_update: [:password, :password_confirmation, :current_password],
+      account_destroy: [:current_password]
     }
 
     def initialize(resource_class, resource_name, params)

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -9,7 +9,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '<%= SecureRandom.hex(64) %>'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
@@ -122,6 +122,8 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  #
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be
@@ -146,6 +148,9 @@ Devise.setup do |config|
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]
+
+  # If true, requires user to provide password to delete record.
+  config.require_password_to_destroy = false 
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -221,7 +221,7 @@ class RegistrationTest < Devise::IntegrationTest
     assert_contain "Password confirmation doesn't match Password"
     refute User.to_adapter.find_first.valid_password?('pas123')
   end
-  
+
   test 'a signed in user should see a warning about minimum password length' do
     sign_in_as_user
     get edit_user_registration_path
@@ -236,6 +236,38 @@ class RegistrationTest < Devise::IntegrationTest
     assert_contain "Bye! Your account has been successfully cancelled. We hope to see you again soon."
 
     assert User.to_adapter.find_all.empty?
+  end
+
+  test 'a signed in user should be able to cancel their account with current password if password required' do
+    swap Devise, require_password_to_destroy: true  do
+      sign_in_as_user
+      get edit_user_registration_path
+
+      within(".destroy-password") do
+        fill_in 'current password', with: '12345678'
+      end
+
+      click_button "Cancel my account"
+      assert_contain "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+    end
+    assert User.to_adapter.find_all.empty?
+  end
+
+  test 'a signed in user should not be able to cancel their account with incorrect password if password required' do
+    swap Devise, require_password_to_destroy: true  do
+      sign_in_as_user
+      get edit_user_registration_path
+
+      within(".destroy-password") do
+        fill_in 'current password', with: '87654321'
+      end
+
+      click_button "Cancel my account"
+      assert_contain "Current password is invalid"
+
+      assert_current_url '/users'
+    end
+    assert_equal "user@test.com", User.to_adapter.find_first.email
   end
 
   test 'a user should be able to cancel sign up by deleting data in the session' do


### PR DESCRIPTION
This feature addresses issue #4816. I added a setting for requiring a user's current password in order to destroy their account.  This setting is set to false by default.  Please let me know if I went about coding this feature according to your typical structure. I tried to follow Devise's code structure as closely as possible.  All of Devise's tests including my test additions are passing. I also tried this feature out on my own test app with no issues. 