### PR TITLE
Change confirmation mail greeting to also fit use for reconfirmation

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @email %>!</p>
+<p>Hello <%= @email %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/lib/generators/templates/markerb/confirmation_instructions.markerb
+++ b/lib/generators/templates/markerb/confirmation_instructions.markerb
@@ -1,5 +1,5 @@
-Welcome <%= @email %>!
+Hello <%= @email %>!
 
-You can confirm your account through the link below:
+You can confirm your account email through the link below:
 
 [Confirm my account](<%= confirmation_url(@resource, confirmation_token: @token) %>)


### PR DESCRIPTION
The template is also used by the re-confirmation e-mail. In that context, the "Welcome" greeting doesn't make sense, so a more general greeting is better suited.