### PR TITLE
Issue 4763: Use same string on failed login regardless of whether account exists when in paranoid mode

### DIFF
--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -17,7 +17,9 @@ module Devise
         end
 
         mapping.to.new.password = password if !hashed && Devise.paranoid
-        fail(:not_found_in_database) unless resource
+        unless resource
+          Devise.paranoid ? fail(:invalid) : fail(:not_found_in_database)
+        end
       end
     end
   end

--- a/test/integration/database_authenticatable_test.rb
+++ b/test/integration/database_authenticatable_test.rb
@@ -74,6 +74,19 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
     refute warden.authenticated?(:admin)
   end
 
+  test 'when in paranoid mode and without a valid e-mail' do
+    swap Devise, paranoid: true do
+      store_translations :en, devise: { failure: { not_found_in_database: 'Not found in database' } } do
+        sign_in_as_user do
+          fill_in 'email', with: 'wrongemail@test.com'
+        end
+        
+        assert_not_contain 'Not found in database'
+        assert_contain 'Invalid Email or password.'
+      end
+    end
+  end
+
   test 'error message is configurable by resource name' do
     store_translations :en, devise: { failure: { admin: { invalid: "Invalid credentials" } } } do
       sign_in_as_admin do


### PR DESCRIPTION
Addresses issue #4763.

If paranoid mode is enabled, Devise will use `devise.failure.invalid` whether or not the user is attempting to log in with an existing identifier.

Previously, log in attempts in paranoid mode were using `devise.failure.not_found_in_database` if identifier did not exist, or `devise.failure.invalid` if identifier existed but password was wrong.