### PR TITLE
remove :trackable from the default modules

### DIFF
--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -54,11 +54,11 @@ module ActiveRecord
       t.datetime :remember_created_at
 
       ## Trackable
-      t.integer  :sign_in_count, default: 0, null: false
-      t.datetime :current_sign_in_at
-      t.datetime :last_sign_in_at
-      t.#{ip_column} :current_sign_in_ip
-      t.#{ip_column} :last_sign_in_ip
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.#{ip_column} :current_sign_in_ip
+      # t.#{ip_column} :last_sign_in_ip
 
       ## Confirmable
       # t.string   :confirmation_token

--- a/lib/generators/devise/orm_helpers.rb
+++ b/lib/generators/devise/orm_helpers.rb
@@ -6,9 +6,9 @@ module Devise
       def model_contents
         buffer = <<-CONTENT
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
 
 CONTENT
         buffer

--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -34,11 +34,11 @@ module Mongoid
   field :remember_created_at, type: Time
 
   ## Trackable
-  field :sign_in_count,      type: Integer, default: 0
-  field :current_sign_in_at, type: Time
-  field :last_sign_in_at,    type: Time
-  field :current_sign_in_ip, type: String
-  field :last_sign_in_ip,    type: String
+  # field :sign_in_count,      type: Integer, default: 0
+  # field :current_sign_in_at, type: Time
+  # field :last_sign_in_at,    type: Time
+  # field :current_sign_in_ip, type: String
+  # field :last_sign_in_ip,    type: String
 
   ## Confirmable
   # field :confirmation_token,   type: String


### PR DESCRIPTION
Hello 👋 

This refers to the discussion in #4849.

With the upcoming arrival of GDPR, I thought it would be preferable to remove the `:trackable` module from the default generator.

An IP address is considered as personal data, and storing it in the database along with tracking the user would require explicit consent from them.

I thus thought it would be a shame that a developer would get in legal trouble just because they left the `trackable` option when they first installed devise on their projects/applications (especially when using it for the first time, that's not the first thing we check or notice).