### PR TITLE
Fix in rdoc of DeviseController#_prefixes

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -22,7 +22,7 @@ class DeviseController < Devise.parent_controller.constantize
   # Action Controller tests that forces _prefixes to be
   # loaded before even having a request object.
   #
-  # This method should be public as it is is in ActionPack
+  # This method should be public as it is in ActionPack
   # itself. Changing its visibility may break other gems.
   def _prefixes #:nodoc:
     @_prefixes ||= if self.class.scoped_views? && request && devise_mapping


### PR DESCRIPTION
Removing an additional "is" in the rdoc for DeviseController#_prefixes