### PR TITLE
find auto-generated secret_key_base in development

### DIFF
--- a/lib/devise/secret_key_finder.rb
+++ b/lib/devise/secret_key_finder.rb
@@ -13,6 +13,8 @@ module Devise
         @application.secrets.secret_key_base
       elsif @application.config.respond_to?(:secret_key_base) && key_exists?(@application.config)
         @application.config.secret_key_base
+      elsif @application.respond_to?(:secret_key_base) && key_exists?(@application)
+        @application.secret_key_base
       end
     end
 

--- a/test/secret_key_finder_test.rb
+++ b/test/secret_key_finder_test.rb
@@ -32,6 +32,24 @@ class Rails52Config
   end
 end
 
+class Rails52SecretKeyBase
+  def credentials
+    OpenStruct.new(secret_key_base: nil)
+  end
+
+  def secrets
+    OpenStruct.new(secret_key_base: nil)
+  end
+
+  def config
+    OpenStruct.new(secret_key_base: nil)
+  end
+  
+  def secret_key_base
+    'secret_key_base'
+  end
+end
+
 class Rails41Secrets
   def secrets
     OpenStruct.new(secret_key_base: 'secrets')
@@ -75,6 +93,12 @@ class SecretKeyFinderTest < ActiveSupport::TestCase
     secret_key_finder = Devise::SecretKeyFinder.new(Rails52Config.new)
 
     assert_equal 'config', secret_key_finder.find
+  end
+
+  test "rails 5.2 uses secret_key_base when config is empty" do
+    secret_key_finder = Devise::SecretKeyFinder.new(Rails52SecretKeyBase.new)
+
+    assert_equal 'secret_key_base', secret_key_finder.find
   end
 
   test "rails 4.1 uses secrets" do


### PR DESCRIPTION
With this fix, we will try latest changes in Rails 5.2 together with standard auto-generated secret_key_base in development as a fallback.

If no specified key found, auto-generated value will be used instead.

This fixes #4864