### PR TITLE
Docs: Improve getting started text

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Once you have solidified your understanding of Rails and authentication mechanis
 
 ## Getting started
 
-Devise 4.0 works with Rails 4.1 onwards. You can add it to your Gemfile with:
+Devise 4.0 works with Rails 4.1 onwards. Add the following line to your Gemfile:
 
 ```ruby
 gem 'devise'


### PR DESCRIPTION
The original text: 

> You can add it to your Gemfile with:

Could easily be read as: "Run this command to add it to your Gemfile"

That's what I did at least. I think the change makes it much clearer that you need to really manually add a line of text into the Gemfile.

One of the reasons why this is not fully clear is that it's badly visible on Github whether a command is a console / terminal command or a ruby line of code. Visually they look the same except for the $ sign which is easy to overlook.