### PR TITLE
Modified sessions controller to return 401 for destroy action with no user signed in

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -28,7 +28,7 @@ class Devise::SessionsController < DeviseController
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
     set_flash_message! :notice, :signed_out if signed_out
     yield if block_given?
-    respond_to_on_destroy
+    respond_to_on_destroy(status: :no_content)
   end
 
   protected
@@ -62,10 +62,7 @@ class Devise::SessionsController < DeviseController
     if all_signed_out?
       set_flash_message! :notice, :already_signed_out
 
-      respond_to do |format|
-        format.all {head :unauthorized}
-        format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
-      end
+      respond_to_on_destroy(status: :unauthorized)
     end
   end
 
@@ -75,11 +72,11 @@ class Devise::SessionsController < DeviseController
     users.all?(&:blank?)
   end
 
-  def respond_to_on_destroy
+  def respond_to_on_destroy(status: status)
     # We actually need to hardcode this as Rails default responder doesn't
     # support returning empty response on GET request
     respond_to do |format|
-      format.all { head :no_content }
+      format.all { head status }
       format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
     end
   end

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -62,7 +62,10 @@ class Devise::SessionsController < DeviseController
     if all_signed_out?
       set_flash_message! :notice, :already_signed_out
 
-      respond_to_on_destroy
+      respond_to do |format|
+        format.all {head :unauthorized}
+        format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      end
     end
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -88,7 +88,7 @@ class SessionsControllerTest < Devise::ControllerTestCase
     assert_equal 204, @response.status
   end
 
-  test "#destroy returns 204 status when an authenticated user signs out" do
+  test "#destroy returns 204 status if the requested format is not navigational" do
     request.env["devise.mapping"] = Devise.mappings[:user]
     user = create_user
     user.confirm
@@ -97,7 +97,7 @@ class SessionsControllerTest < Devise::ControllerTestCase
         password: user.password
       }
     }
-    delete :destroy
+    delete :destroy, format:'json'
     assert_equal 204, @response.status
   end
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -88,6 +88,30 @@ class SessionsControllerTest < Devise::ControllerTestCase
     assert_equal 204, @response.status
   end
 
+  test "#destroy returns 204 status when an authenticated user signs out" do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    user = create_user
+    user.confirm
+    post :create, params: { format: 'json', user: {
+        email: user.email,
+        password: user.password
+      }
+    }
+    delete :destroy
+    assert_equal 204, @response.status
+  end
+
+  test "#destroy returns 401 status if user is not signed in and the requested format is not navigational" do
+    delete :destroy, format: 'json'
+    assert_equal 401, @response.status
+  end
+
+  test "#destroy returns 302 status if user is not signed in and the requested format is navigational" do
+    request.env["devise.mapping"] = Devise.mappings[:user]
+    delete :destroy
+    assert_equal 302, @response.status
+  end
+
   if defined?(ActiveRecord) && ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
     test "#new doesn't raise mass-assignment exception even if sign-in key is attr_protected" do
       request.env["devise.mapping"] = Devise.mappings[:user]

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -74,7 +74,7 @@ class SessionsControllerTest < Devise::ControllerTestCase
     assert_template "devise/sessions/new"
   end
 
-  test "#destroy doesn't set the flash if the requested format is not navigational" do
+  test "#destroy doesn't set the flash and returns 204 status if the requested format is not navigational" do
     request.env["devise.mapping"] = Devise.mappings[:user]
     user = create_user
     user.confirm
@@ -85,19 +85,6 @@ class SessionsControllerTest < Devise::ControllerTestCase
     }
     delete :destroy, format: 'json'
     assert flash[:notice].blank?, "flash[:notice] should be blank, not #{flash[:notice].inspect}"
-    assert_equal 204, @response.status
-  end
-
-  test "#destroy returns 204 status if the requested format is not navigational" do
-    request.env["devise.mapping"] = Devise.mappings[:user]
-    user = create_user
-    user.confirm
-    post :create, params: { format: 'json', user: {
-        email: user.email,
-        password: user.password
-      }
-    }
-    delete :destroy, format:'json'
     assert_equal 204, @response.status
   end
 


### PR DESCRIPTION
This PR is for issue #4782  @tegon
To clarify the 3 tests added:

### 1. Authenticated non-navigational request - returns 204.
- This was the original behavior before I made any changes. I simply added this test to ensure this was not broken after my implementation.  

### 2. Unauthenticated non-navigational request - returns 401.
- This is the new behavior added.

### 3. Unauthenticated navigational request -  returns 302.
- This was the original behavior before I made any changes. I simply added this test to ensure this was not broken after my implementation.  