### PR TITLE
Add request path tracking to Trackable

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -58,8 +58,9 @@ module Devise
 
       BLACKLIST_FOR_SERIALIZATION = [:encrypted_password, :reset_password_token, :reset_password_sent_at,
         :remember_created_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip,
-        :last_sign_in_ip, :password_salt, :confirmation_token, :confirmed_at, :confirmation_sent_at,
-        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
+        :last_sign_in_ip, :current_sign_in_path, :last_sign_in_path, :password_salt, :confirmation_token,
+        :confirmed_at, :confirmation_sent_at, :remember_token, :unconfirmed_email, :failed_attempts,
+        :unlock_token, :locked_at]
 
       included do
         class_attribute :devise_modules, instance_writer: false

--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -6,15 +6,18 @@ module Devise
   module Models
     # Track information about your user sign in. It tracks the following columns:
     #
-    # * sign_in_count      - Increased every time a sign in is made (by form, openid, oauth)
-    # * current_sign_in_at - A timestamp updated when the user signs in
-    # * last_sign_in_at    - Holds the timestamp of the previous sign in
-    # * current_sign_in_ip - The remote ip updated when the user sign in
-    # * last_sign_in_ip    - Holds the remote ip of the previous sign in
+    # * sign_in_count        - Increased every time a sign in is made (by form, openid, oauth)
+    # * current_sign_in_at   - A timestamp updated when the user signs in
+    # * last_sign_in_at      - Holds the timestamp of the previous sign in
+    # * current_sign_in_ip   - The remote ip updated when the user sign in
+    # * last_sign_in_ip      - Holds the remote ip of the previous sign in
+    # * current_sign_in_path - The sign in path updated when the user signs in
+    # * last_sign_in_path    - Holds the path of the previous sign in
     #
     module Trackable
       def self.required_fields(klass)
-        [:current_sign_in_at, :current_sign_in_ip, :last_sign_in_at, :last_sign_in_ip, :sign_in_count]
+        [:current_sign_in_at, :current_sign_in_ip, :current_sign_in_path, :last_sign_in_at,
+         :last_sign_in_ip, :last_sign_in_path, :sign_in_count]
       end
 
       def update_tracked_fields(request)
@@ -25,6 +28,10 @@ module Devise
         old_current, new_current = self.current_sign_in_ip, extract_ip_from(request)
         self.last_sign_in_ip     = old_current || new_current
         self.current_sign_in_ip  = new_current
+
+        old_current, new_current = self.current_sign_in_path, extract_path_from(request)
+        self.last_sign_in_path     = old_current || new_current
+        self.current_sign_in_path  = new_current
 
         self.sign_in_count ||= 0
         self.sign_in_count += 1
@@ -45,6 +52,11 @@ module Devise
       def extract_ip_from(request)
         request.remote_ip
       end
+
+      def extract_path_from(request)
+        request.path
+      end
+
 
     end
   end

--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -59,6 +59,8 @@ module ActiveRecord
       # t.datetime :last_sign_in_at
       # t.#{ip_column} :current_sign_in_ip
       # t.#{ip_column} :last_sign_in_ip
+      # t.string :current_sign_in_path
+      # t.string :last_sign_in_path
 
       ## Confirmable
       # t.string   :confirmation_token

--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -39,6 +39,8 @@ module Mongoid
   # field :last_sign_in_at,    type: Time
   # field :current_sign_in_ip, type: String
   # field :last_sign_in_ip,    type: String
+  # field :current_sign_in_path, type: String
+  # field :last_sign_in_path,    type: String
 
   ## Confirmable
   # field :confirmation_token,   type: String

--- a/test/generators/active_record_generator_test.rb
+++ b/test/generators/active_record_generator_test.rb
@@ -77,6 +77,12 @@ if DEVISE_ORM == :active_record
       assert_migration "db/migrate/devise_create_monsters.rb", /t.string   :last_sign_in_ip/
     end
 
+    test "use string column type for path" do
+      run_generator %w(monster)
+      assert_migration "db/migrate/devise_create_monsters.rb", /t.string :current_sign_in_path/
+      assert_migration "db/migrate/devise_create_monsters.rb", /t.string :last_sign_in_path/
+    end
+
     test "do NOT add primary key type when NOT specified in rails generator" do
       run_generator %w(monster)
       assert_migration "db/migrate/devise_create_monsters.rb", /create_table :monsters do/

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -44,6 +44,18 @@ class TrackableHooksTest < Devise::IntegrationTest
     assert_equal "127.0.0.1", user.last_sign_in_ip
   end
 
+  test "current and last sign in path are updated on each sign in" do
+    user = create_user
+    assert_nil user.current_sign_in_path
+    assert_nil user.last_sign_in_path
+
+    sign_in_as_user
+    user.reload
+
+    assert_equal "/users/sign_in", user.current_sign_in_path
+    assert_equal "/users/sign_in", user.last_sign_in_path
+  end
+
   test "current remote ip returns original ip behind a non transparent proxy" do
     user = create_user
 

--- a/test/models/trackable_test.rb
+++ b/test/models/trackable_test.rb
@@ -7,8 +7,10 @@ class TrackableTest < ActiveSupport::TestCase
     assert_equal Devise::Models::Trackable.required_fields(User), [
       :current_sign_in_at,
       :current_sign_in_ip,
+      :current_sign_in_path,
       :last_sign_in_at,
       :last_sign_in_ip,
+      :last_sign_in_path,
       :sign_in_count
     ]
   end
@@ -17,11 +19,14 @@ class TrackableTest < ActiveSupport::TestCase
     user = create_user
     request = mock
     request.stubs(:remote_ip).returns("127.0.0.1")
+    request.stubs(:path).returns("/sign_in")
 
     assert_nil user.current_sign_in_ip
     assert_nil user.last_sign_in_ip
     assert_nil user.current_sign_in_at
     assert_nil user.last_sign_in_at
+    assert_nil user.current_sign_in_path
+    assert_nil user.last_sign_in_path
     assert_equal 0, user.sign_in_count
 
     user.update_tracked_fields(request)
@@ -30,6 +35,8 @@ class TrackableTest < ActiveSupport::TestCase
     assert_equal "127.0.0.1", user.last_sign_in_ip
     assert_not_nil user.current_sign_in_at
     assert_not_nil user.last_sign_in_at
+    assert_equal "/sign_in", user.current_sign_in_path
+    assert_equal "/sign_in", user.last_sign_in_path
     assert_equal 1, user.sign_in_count
 
     user.reload
@@ -38,6 +45,8 @@ class TrackableTest < ActiveSupport::TestCase
     assert_nil user.last_sign_in_ip
     assert_nil user.current_sign_in_at
     assert_nil user.last_sign_in_at
+    assert_nil user.current_sign_in_path
+    assert_nil user.last_sign_in_path
     assert_equal 0, user.sign_in_count
   end
 
@@ -45,6 +54,7 @@ class TrackableTest < ActiveSupport::TestCase
     user = UserWithValidations.new
     request = mock
     request.stubs(:remote_ip).returns("127.0.0.1")
+    request.stubs(:path).returns("/sign_in")
 
     assert_not user.update_tracked_fields!(request)
     assert_not user.persisted?
@@ -54,6 +64,7 @@ class TrackableTest < ActiveSupport::TestCase
     user = User.new
     request = mock
     request.stubs(:remote_ip).returns("127.0.0.1")
+    request.stubs(:path).returns("/sign_in")
 
     user.expects(:after_validation_callback).never
 
@@ -70,6 +81,7 @@ class TrackableTest < ActiveSupport::TestCase
 
     request = mock
     request.stubs(:remote_ip).returns("127.0.0.1")
+    request.stubs(:path).returns("/sign_in")
     user = UserWithOverride.new
 
     user.update_tracked_fields(request)

--- a/test/rails_app/app/mongoid/user.rb
+++ b/test/rails_app/app/mongoid/user.rb
@@ -27,6 +27,8 @@ class User
   field :last_sign_in_at,    type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip,    type: String
+  field :current_sign_in_path, type: String
+  field :last_sign_in_path,    type: String
 
   ## Confirmable
   field :confirmation_token,   type: String

--- a/test/rails_app/app/mongoid/user_on_main_app.rb
+++ b/test/rails_app/app/mongoid/user_on_main_app.rb
@@ -27,6 +27,8 @@ class UserOnMainApp
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :current_sign_in_path, type: String
+  field :last_sign_in_path, type: String
 
   ## Confirmable
   field :confirmation_token, type: String

--- a/test/rails_app/app/mongoid/user_with_validations.rb
+++ b/test/rails_app/app/mongoid/user_with_validations.rb
@@ -27,6 +27,8 @@ class UserWithValidations
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :current_sign_in_path, type: String
+  field :last_sign_in_path, type: String
 
   ## Lockable
   field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts

--- a/test/rails_app/app/mongoid/user_without_email.rb
+++ b/test/rails_app/app/mongoid/user_without_email.rb
@@ -27,6 +27,8 @@ class UserWithoutEmail
   field :last_sign_in_at, type: Time
   field :current_sign_in_ip, type: String
   field :last_sign_in_ip, type: String
+  field :current_sign_in_path, type: String
+  field :last_sign_in_path, type: String
 
   ## Lockable
   field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts

--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -27,6 +27,8 @@ class CreateTables < superclass
       t.datetime :last_sign_in_at
       t.string   :current_sign_in_ip
       t.string   :last_sign_in_ip
+      t.string   :current_sign_in_path
+      t.string   :last_sign_in_path
 
       ## Confirmable
       t.string   :confirmation_token

--- a/test/rails_app/db/schema.rb
+++ b/test/rails_app/db/schema.rb
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 20100401102949) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_path"
+    t.string   "last_sign_in_path"
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
This PR adds persisting of the request path to Trackable. This is useful for apps that have multiple sign in pages or that use omniauth for sign in via an external identity provider. In those apps, the `*_sign_in_path` field added by the Trackable module will allow developers to see how the user signed in.

For example, we've added this to one of our apps and can now quickly get a report of which sign in methods our User's prefer:

```
irb(main):001:0> pp User.where(current_sign_in_at: 1.week.ago.all_week).group(:current_sign_in_path).count.sort_by(&:last).reverse
[["/users/sign_in", 12643],
 ["/auth/saml/callback", 777],
 ["/auth/linkedin/callback", 353],
 ["/password", 281],
 ["/auth/twitter/callback", 92],
 ["/password/edit", 8]]
```