### PR TITLE
Add dependency version and SemVer badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ By [Plataformatec](http://plataformatec.com.br/).
 
 [![Build Status](https://api.travis-ci.org/plataformatec/devise.svg?branch=master)](http://travis-ci.org/plataformatec/devise)
 [![Code Climate](https://codeclimate.com/github/plataformatec/devise.svg)](https://codeclimate.com/github/plataformatec/devise)
+[![Gem Version](https://badge.fury.io/rb/devise.svg)](https://rubygems.org/gems/devise)
+[![SemVer compatibility](https://api.dependabot.com/badges/compatibility_score?dependency-name=devise&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=devise&package-manager=bundler&version-scheme=semver)
 
 This README is [also available in a friendly navigable format](http://devise.plataformatec.com.br/).
 
@@ -190,7 +192,7 @@ In the following command you will replace `MODEL` with the class name used for t
 $ rails generate devise MODEL
 ```
 
-Next, check the MODEL for any additional configuration options you might want to add, such as confirmable or lockable. If you add an option, be sure to inspect the migration file (created by the generator if your ORM supports them) and uncomment the appropriate section.  For example, if you add the confirmable option in the model, you'll need to uncomment the Confirmable section in the migration. 
+Next, check the MODEL for any additional configuration options you might want to add, such as confirmable or lockable. If you add an option, be sure to inspect the migration file (created by the generator if your ORM supports them) and uncomment the appropriate section.  For example, if you add the confirmable option in the model, you'll need to uncomment the Confirmable section in the migration.
 
 Then run `rails db:migrate`
 


### PR DESCRIPTION
Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below. I've also added a gem version badge, as I always look for that when figuring out what version to use in my Gemfile.

[![Gem Version](https://badge.fury.io/rb/devise.svg)](https://rubygems.org/gems/devise) [![SemVer compatibility](https://api.dependabot.com/badges/compatibility_score?dependency-name=devise&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=devise&package-manager=bundler&version-scheme=semver)

If you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use devise and checks what percentage of the time specs pass on the upgrade PR.

The score isn't 100% because the 4.4.2 release broke a few people's tests, but it should steadily climb back up, assuming you're following SemVer.

In future, I'm also planning to build a tool that lets you view the Dependabot data for pre-release updates, so you'd be able to see whether they break anyone's tests before releasing a full release.