### PR TITLE
update devise to use latest minor bcrypt version

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("warden", "~> 1.2.3")
   s.add_dependency("orm_adapter", "~> 0.1")
-  s.add_dependency("bcrypt", "~> 3.0")
+  s.add_dependency("bcrypt", "~> 3.1")
   s.add_dependency("railties", ">= 4.1.0", "< 6.0")
   s.add_dependency("responders")
 end


### PR DESCRIPTION
bcrypt fails when it is being used with libxcrypt instead of glib libcrypt.

reference:
https://gitlab.com/gitlab-org/gitlab-ce/issues/48149

The latest bcrypt (3.1.12) supports libxcrypt which is being used in fedora linux distributions. fedora does not use libcrypt and this update will fix that.
