### PR TITLE
Add check that confirmation token is present

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -345,7 +345,7 @@ module Devise
         # If the user is already confirmed, create an error for the user
         # Options must have the confirmation_token
         def confirm_by_token(confirmation_token)
-          confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
+          confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token) if confirmation_token.present?
           unless confirmable
             confirmation_digest = Devise.token_generator.digest(self, :confirmation_token, confirmation_token)
             confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_digest)

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -114,6 +114,28 @@ class ConfirmationTest < Devise::IntegrationTest
     assert_contain 'already confirmed'
   end
 
+  test 'already confirmed user with nil confirmation token should return validation error' do
+    user = create_user(confirm: false)
+    user.confirmed_at = Time.now
+    user.confirmation_token = nil
+    user.save
+    visit_user_confirmation_with_token(nil)
+
+    assert_have_selector '#error_explanation'
+    assert_contain 'Confirmation token can\'t be blank'
+  end
+
+  test 'already confirmed user with blank confirmation token should return validation error' do
+    user = create_user(confirm: false)
+    user.confirmed_at = Time.now
+    user.confirmation_token = ''
+    user.save
+    visit_user_confirmation_with_token('')
+
+    assert_have_selector '#error_explanation'
+    assert_contain 'Confirmation token can\'t be blank'
+  end
+
   test 'already confirmed user should not be able to confirm the account again neither request confirmation' do
     user = create_user(confirm: false)
     user.confirmed_at = Time.now


### PR DESCRIPTION
Not really a bug in Devise, if the rails app using Devise incorrectly writes the token blank rather than nil devise will find that user here if a blank confirmation_token is passed and return the resource to the controller.

For safety, would you consider allowing this extra check to make sure an actual value is passed through?