### PR TITLE
Confirmable and rails apps using both ActiveRecord and Mongoid

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -61,6 +61,10 @@ module Devise
   # True values used to check params
   TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE']
 
+  # ORM used by Devise. Allowed values [:activerecord, :mongoid]
+  mattr_accessor :orm
+  @@orm = :active_record
+
   # Secret key used by the key generator
   mattr_accessor :secret_key
   @@secret_key = nil
@@ -298,7 +302,15 @@ module Devise
   end
 
   def self.activerecord51? # :nodoc:
-    defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")
+    self.activerecord? && (defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x"))
+  end
+
+  def self.activerecord? # :nodoc:
+    Devise.orm.to_sym == :active_record
+  end
+
+  def self.mongoid? # :nodoc:
+    Devise.orm.to_sym == :mongoid
   end
 
   # Default way to set up Devise. Run rails generate devise_install to create

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -48,7 +48,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if defined?(ActiveRecord) && self < ActiveRecord::Base # ActiveRecord
+        if Devise.activerecord? && defined?(ActiveRecord) && self < ActiveRecord::Base # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid

--- a/lib/devise/orm/active_record.rb
+++ b/lib/devise/orm/active_record.rb
@@ -2,6 +2,7 @@
 
 require 'orm_adapter/adapters/active_record'
 
+Devise.orm = :active_record
 ActiveSupport.on_load(:active_record) do
   extend Devise::Models
 end

--- a/lib/devise/orm/mongoid.rb
+++ b/lib/devise/orm/mongoid.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+Devise.orm = :mongoid
 ActiveSupport.on_load(:mongoid) do
   require 'orm_adapter/adapters/mongoid'
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -88,7 +88,7 @@ class SessionsControllerTest < Devise::ControllerTestCase
     assert_equal 204, @response.status
   end
 
-  if defined?(ActiveRecord) && ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
+  if Devise.activerecord51? && ActiveRecord::Base.respond_to?(:mass_assignment_sanitizer)
     test "#new doesn't raise mass-assignment exception even if sign-in key is attr_protected" do
       request.env["devise.mapping"] = Devise.mappings[:user]
 


### PR DESCRIPTION
## Problem Statement

The `confirmable` module doesn't work as expected when the parent Rails app is using both ActiveRecord and Mongoid.

## Solution

Assign a default `orm` attribute to the Devise config with a default value of `activerecord`. This value then is overridden/changed to `mongoid` if `lib/devise/orm/mongoid` is required by the parent Rails application.