### PR TITLE
Change priority of SECRET_KEY_BASE configuration locations

### DIFF
--- a/test/secret_key_finder_test.rb
+++ b/test/secret_key_finder_test.rb
@@ -77,6 +77,14 @@ class Rails40Config
 end
 
 class SecretKeyFinderTest < ActiveSupport::TestCase
+  test "uses ENV when available" do
+    old_env = ENV['SECRET_KEY_BASE']
+    ENV['SECRET_KEY_BASE'] = 'Secret!'
+    secret_key_finder = Devise::SecretKeyFinder.new(Rails52SecretKeyBase.new)
+    assert_equal 'Secret!', secret_key_finder.find
+    ENV['SECRET_KEY_BASE'] = old_env
+  end
+
   test "rails 5.2 uses credentials when they're available" do
     secret_key_finder = Devise::SecretKeyFinder.new(Rails52Credentials.new)
 


### PR DESCRIPTION
This PR changes the priority of search locations:

- If `ENV['SECRET_KEY_BASE'` is set, use that: https://github.com/plataformatec/devise/pull/4869#issuecomment-413586348
- Check common Rails configuration locations:
  - Default, unified location in Rails 5 (includes autogenerated value for dev/test in newer Rails): https://github.com/plataformatec/devise/issues/4864, https://github.com/plataformatec/devise/pull/4869#issuecomment-387874576
  - Other common locations for backwards compatibility

I found the `SecretKeyFinder` to be hard to understand since there were a lot of safe-access checks, and a lot of duplication of effort. This is the result of my attempt to refactor this, making more quick to understand how and where we are checking.

The previous version was essentially a list of "if we get a value from safely navigating here, then return it". Now there is a simple list of method chains to attempt. It should be compatible with older rubies, as it avoids using `&.`.

`Enumerable#find` is convenient for this, since it will return `nil` if nothing matched, and we can `break` early to return a result (instead of the enumerated item). I learned this trick at Rubyconf last year, and thought it was clever: [link](https://youtu.be/nOa6FhMKsZ0?t=1282).