### PR TITLE
rememberable and timeoutable should work together

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -101,7 +101,7 @@ module Devise
       end
 
       def remember_expired?
-        remember_created_at.nil? || (remember_expires_at <= Time.now.utc)
+        remember_created_at.nil? || (remember_expires_at <= Time.zone.now.utc)
       end
 
       def remember_me?(token, generated_at)

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -100,6 +100,10 @@ module Devise
       def after_remembered
       end
 
+      def remember_expired?
+        remember_created_at.nil? || (remember_expires_at <= Time.now.utc)
+      end
+
       def remember_me?(token, generated_at)
         # TODO: Normalize the JSON type coercion along with the Timeoutable hook
         # in a single place https://github.com/plataformatec/devise/blob/ffe9d6d406e79108cf32a2c6a1d0b3828849c40b/lib/devise/hooks/timeoutable.rb#L14-L18

--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -27,10 +27,16 @@ module Devise
       end
 
       # Checks whether the user session has expired based on configured time.
+      # Returns false if Rememberable has been enabled and has not expired
       def timedout?(last_access)
+        return false if remember_exists_and_not_expired?
         !timeout_in.nil? && last_access && last_access <= timeout_in.ago
       end
 
+      def remember_exists_and_not_expired?
+        return false unless respond_to?(:remember_created_at) && respond_to?(:remember_expired?)
+        remember_created_at && !remember_expired?
+      end
       def timeout_in
         self.class.timeout_in
       end

--- a/test/models/timeoutable_test.rb
+++ b/test/models/timeoutable_test.rb
@@ -50,4 +50,10 @@ class TimeoutableTest < ActiveSupport::TestCase
     user = create_admin(remember_created_at: Time.current)
     assert user.timedout?(31.minutes.ago)
   end
+
+  test 'should return false if rememberable is enabled and has not expired' do
+    user = create_user
+    user.remember_me!
+    refute user.timedout?(31.minutes.ago)
+  end
 end


### PR DESCRIPTION
Fixes #4778

Now if rememberable is enabled and has not expired then `timedout?` returns false. 
Added a test for this behavior.


