### PR TITLE
Missing comma in form input

### DIFF
--- a/lib/generators/templates/simple_form_for/registrations/edit.html.erb
+++ b/lib/generators/templates/simple_form_for/registrations/edit.html.erb
@@ -12,7 +12,7 @@
 
     <%= f.input :password,
                 hint: "leave it blank if you don't want to change it",
-                required: false
+                required: false,
                 input_html: { autocomplete: "new-password" } %>
     <%= f.input :password_confirmation,
                 required: false,


### PR DESCRIPTION
#4931 

Just a very small syntax error (missing comma in the argument list)