### PR TITLE
Issue #4939: don’t delete by default when retrieving stored_location_for

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -213,7 +213,7 @@ module Devise
       #   end
       #
       def after_sign_in_path_for(resource_or_scope)
-        stored_location_for(resource_or_scope) || signed_in_root_path(resource_or_scope)
+        (is_navigational_format? ? pop_stored_location_for(resource_or_scope) : stored_location_for(resource_or_scope)) || signed_in_root_path(resource_or_scope)
       end
 
       # Method used by sessions controller to sign out a user. You can overwrite

--- a/lib/devise/controllers/store_location.rb
+++ b/lib/devise/controllers/store_location.rb
@@ -8,21 +8,28 @@ module Devise
     # Used to redirect back to a desired path after sign in.
     # Included by default in all controllers.
     module StoreLocation
-      # Returns and delete (if it's navigational format) the url stored in the session for
-      # the given scope. Useful for giving redirect backs after sign up:
+      # Returns the url stored in the session for the given scope. Useful for evaluating
+      # the stored_location before actually redirecting to it after sign up:
       #
       # Example:
       #
-      #   redirect_to stored_location_for(:user) || root_path
+      #   logger.debug stored_location_for(:user)
       #
       def stored_location_for(resource_or_scope)
         session_key = stored_location_key_for(resource_or_scope)
+        session[session_key]
+      end
 
-        if is_navigational_format?
-          session.delete(session_key)
-        else
-          session[session_key]
-        end
+      # Returns and delete the url stored in the session for the given scope.
+      # Useful for giving redirect backs after sign up:
+      #
+      # Example:
+      #
+      #   redirect_to pop_stored_location_for(:user) || root_path
+      #
+      def pop_stored_location_for(resource_or_scope)
+        session_key = stored_location_key_for(resource_or_scope)
+        session.delete(session_key)
       end
 
       # Stores the provided location to redirect the user after signing in.
@@ -35,7 +42,7 @@ module Devise
       #
       def store_location_for(resource_or_scope, location)
         session_key = stored_location_key_for(resource_or_scope)
-        
+
         path = extract_path_from_location(location)
         session[session_key] = path if path
       end
@@ -56,7 +63,7 @@ module Devise
       def extract_path_from_location(location)
         uri = parse_uri(location)
 
-        if uri 
+        if uri
           path = remove_domain_from_uri(uri)
           path = add_fragment_back_to_path(uri, path)
 

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -212,10 +212,17 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
     assert_equal "/foo.bar", @controller.stored_location_for(User.new)
   end
 
-  test 'stored location cleans information after reading' do
+  test 'stored location for does not clean information after reading' do
     @controller.session[:"user_return_to"] = "/foo.bar"
     assert_equal "/foo.bar", @controller.stored_location_for(:user)
-    assert_nil @controller.session[:"user_return_to"]
+    assert_equal "/foo.bar", @controller.session[:"user_return_to"]
+  end
+
+  test 'pop stored location for cleans information after reading' do
+    @controller.session[:"user_return_to"] = "/foo.bar"
+    assert_equal "/foo.bar", @controller.pop_stored_location_for(:user)
+    assert_equal nil, @controller.session[:"user_return_to"]
+    assert_equal nil, @controller.stored_location_for(:user)
   end
 
   test 'store location for stores a location to redirect back to' do


### PR DESCRIPTION
First attempt :)

As described in issue #4939; I found the current behaviour unpredictable. This pull request introduces a new method `#pop_stored_location_for` that returns and deletes the location stored (on all cases, my idea was that by making this explicit it is no longer required to check `#is_navigational_format?`)