### PR TITLE
Fix to calling flash when the request object doesn't support it

### DIFF
--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -268,7 +268,7 @@ module Devise
       # Check if flash messages should be emitted. Default is to do it on
       # navigational formats
       def is_flashing_format?
-        is_navigational_format?
+        request.respond_to?(:flash) && is_navigational_format?
       end
 
       private

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -242,7 +242,7 @@ module Devise
     # Check if flash messages should be emitted. Default is to do it on
     # navigational formats
     def is_flashing_format?
-      is_navigational_format?
+      request.respond_to?(:flash) && is_navigational_format?
     end
 
     def request_format

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -312,6 +312,16 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
     end
   end
 
+  test 'is_flashing_format? depends on is_navigation_format?' do
+    @controller.expects(:is_navigational_format?).returns(true)
+    assert @controller.is_flashing_format?
+  end
+
+  test 'is_flashing_format? is guarded against flash (middleware) not being loaded' do
+    @controller.request.expects(:respond_to?).with(:flash).returns(false)
+    refute @controller.is_flashing_format?
+  end
+
   test 'is not a devise controller' do
     refute @controller.devise_controller?
   end


### PR DESCRIPTION
In cases, such as a rails api controller `ActionController::API`, the request object does _not_ have flash capabilities loaded.  The `is_flashing_format?` should gracefully return false in those cases.

Addresses #4947 