### PR TITLE
Ignore useless files into the gem file.

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   s.description = "Flexible authentication solution for Rails with Warden"
   s.authors     = ['José Valim', 'Carlos Antônio']
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- test/*`.split("\n")
+  s.files         = Dir["{app,config,lib}/**/*", "CHANGELOG.md", "MIT-LICENSE", "README.md"]
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 2.1.0'
 


### PR DESCRIPTION
RubyGem only needs the`lib, app, config`, special it for avoid the useless file packing into the gem file.

<img width="431" alt="2018-10-16 18 25 18" src="https://user-images.githubusercontent.com/5518/47010162-d717be80-d170-11e8-89f2-4c35b9be53da.png">
