### PR TITLE
add in a pretty_print method for better pry output

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -125,6 +125,27 @@ module Devise
         "#<#{self.class} #{inspection.join(", ")}>"
       end
 
+      def pretty_print(pp)
+        pp.object_address_group(self) do
+          if defined?(@attributes) && @attributes
+            columns = serializable_hash.select { |column_name, column_value| has_attribute?(column_name) || new_record? }
+            pp.seplist(columns, proc { pp.text ',' }) do |column_name, column_value|
+              column_value = read_attribute(column_name)
+              pp.breakable ' '
+              pp.group(1) do
+                pp.text column_name
+                pp.text ':'
+                pp.breakable
+                pp.pp column_value
+              end
+            end
+          else
+            pp.breakable ' '
+            pp.text 'not initialized'
+          end
+        end
+      end
+
       protected
 
       def devise_mailer


### PR DESCRIPTION
Currently the output for any devise model is awful in pry. This adds in a copy of activerecord's pretty print but modified to use the same logic as the overriding `inspect` in devise to make sure it doesn't print out sensitive data.

most of this method is taken from https://apidock.com/rails/ActiveRecord/Core/pretty_print.

https://github.com/rweng/pry-rails/issues/83