### PR TITLE
Add more tests

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -65,7 +65,6 @@ module Devise
 
       # Verifies whether a password (ie from sign in) is the user password.
       def valid_password?(password)
-        return false if password.blank?
         Devise::Encryptor.compare(self.class, encrypted_password, password)
       end
 

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -148,6 +148,16 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     refute user.valid_password?('654321')
   end
 
+  test 'should be invalid if the password is nil' do
+    user = new_user(password: nil)
+    refute user.valid_password?(nil)
+  end
+
+  test 'should be invalid if the password is blank' do
+    user = new_user(password: '')
+    refute user.valid_password?('')
+  end
+
   test 'should respond to current password' do
     assert new_user.respond_to?(:current_password)
   end


### PR DESCRIPTION
After merging #4261, I realized that we could add a couple more tests, to ensure the new behavior added to `#valid_password?` - which is that it should return `false` when the password is either `nil` or blank (`""`).
I've also removed [this condition](https://github.com/plataformatec/devise/blob/master/lib/devise/models/database_authenticatable.rb#L68) because it's already present at `Devise::Encryptor` module in the `.compare` [method](https://github.com/plataformatec/devise/blob/master/lib/devise/encryptor.rb#L15).