### PR TITLE
fixed description for Devise::Generators::ControllersGenerator

### DIFF
--- a/lib/generators/devise/controllers_generator.rb
+++ b/lib/generators/devise/controllers_generator.rb
@@ -18,7 +18,7 @@ module Devise
 
         This will create a controller class at app/controllers/users/sessions_controller.rb like this:
 
-          class Users::ConfirmationsController < Devise::ConfirmationsController
+          class Users::SessionsController < Devise::SessionsController
             content...
           end
       DESC


### PR DESCRIPTION
Hello. I found one little mistake in controllers generator's description. When I run command ```rails generate devise:controllers```  I see
```
For example:

  rails generate devise:controllers users -c=sessions

This will create a controller class at app/controllers/users/sessions_controller.rb like this:

  class Users::ConfirmationsController < Devise::ConfirmationsController
    content...
  end
```
You show how to overwrite sessions controller, but use the code of ConfirmationsController 😅