### PR TITLE
Do not keep the old email when replacing the email of an unconfirmed user

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -258,16 +258,20 @@ module Devise
         if Devise.activerecord51?
           def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
             @reconfirmation_required = true
-            self.unconfirmed_email = self.email
-            self.email = self.email_in_database
+            if confirmed?
+              self.unconfirmed_email = self.email
+              self.email = self.email_in_database
+            end
             self.confirmation_token = nil
             generate_confirmation_token
           end
         else
           def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
             @reconfirmation_required = true
-            self.unconfirmed_email = self.email
-            self.email = self.email_was
+            if confirmed?
+              self.unconfirmed_email = self.email
+              self.email = self.email_was
+            end
             self.confirmation_token = nil
             generate_confirmation_token
           end

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -527,6 +527,14 @@ class ReconfirmableTest < ActiveSupport::TestCase
     assert !admin.instance_variable_get(:@bypass_confirmation_postpone)
     admin.email = "new_test@email.com"
     admin.save
+    assert !admin.pending_reconfirmation?
+  end
+
+  test 'should require reconfirmation after creating a record and confirm it then updating the email' do
+    admin = create_admin
+    admin.confirm
+    admin.email = "new_test@email.com"
+    admin.save
     assert admin.pending_reconfirmation?
   end
 


### PR DESCRIPTION
If the user hasn't  confirmed yet, it's not useful to keep both the previous email and the new email. The previously unconfirmed email will not be confirmed any way since the token is already changed. Leaving it there will only cause accidental troubles. The change allows the following: If the user is not confirmed yet, just replace the email. New token will still be generated and reconfirmation email will still be sent.

This change won't break existing data, where both email and unconfirmed email exist for an unconfirmed user. When confirmed, the unconfirmed email will still replace the email. So no worries.