### PR TITLE
Skipping location storing if request xhr

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -232,7 +232,7 @@ module Devise
     # authenticated yet, but we still need to store the URI based on scope, so
     # different scopes would never use the same URI to redirect.
     def store_location!
-      store_location_for(scope, attempted_path) if request.get? && !http_auth?
+      store_location_for(scope, attempted_path) if request.get? && !request.xhr? && !http_auth?
     end
 
     def is_navigational_format?


### PR DESCRIPTION
Hi guys!
I'm pretty sure that many of devise users use frontend frameworks, like vue or react with their own routers on frontend.
I've got the problem:
User is opening two tabs in same browser while logged in, and logs out in one of them (or session expires - will be same result). Then he forgets about this tab and tries to click on any link in other tab. Since there is no requests to backend needed to open other URL via frontend router, page is being opened and tries to get some data from backend (via json xhr request). After getting infinite loading because xhr request gets 302 redirect, user refreshes the page and being redirected to login page, where after successful login he sees page retrieved by xhr request, because it was saved by devise.
I think that the right solution for such requests is do not store location.