### PR TITLE
Fix unclosed html tag and add deprecation warn

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -4,6 +4,13 @@ module DeviseHelper
   # Retain this method for backwards compatibility, deprecated in favour of modifying the
   # devise/shared/error_messages partial
   def devise_error_messages!
+    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+      [Devise] `DeviseHelper.devise_error_messages!`
+      is deprecated and it will be removed in the next major version.
+      To customize the errors styles please run `rails g devise:views` and modify the
+      `devise/shared/error_messages` partial.
+    DEPRECATION
+
     return "" if resource.errors.empty?
 
     render "devise/shared/error_messages", resource: resource

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %>
+        <li><%= message %></li>
       <% end %>
     </ul>
   </div>


### PR DESCRIPTION
- Add a deprecation warn for `DeviseHelper.devise_error_messages!`
- Fix unclosed `li` tag in `error_messages` partial