### PR TITLE
Fixed broken README link in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,7 @@ configured (by @joshpencheon)
     end
     ```
 
-    You can check more examples and explanations on the [README section](/plataformatec/devise#strong-parameters)
+    You can check more examples and explanations on the [README section](README.md#strong-parameters)
     and on the [ParameterSanitizer docs](lib/devise/parameter_sanitizer.rb).
 
 Please check [3-stable](https://github.com/plataformatec/devise/blob/3-stable/CHANGELOG.md)


### PR DESCRIPTION
The current link to the README file in the CHANGELOG.md file is broken.

<img width="989" alt="screen shot 2019-01-10 at 1 42 21 pm" src="https://user-images.githubusercontent.com/6728265/50969105-944e5400-14dd-11e9-805d-38c25f72f709.png">
