### PR TITLE
Apply Test Helper fix to Rails 6.0 as well as 5.x

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -139,7 +139,7 @@ module Devise
 
           status, headers, response = Devise.warden_config[:failure_app].call(env).to_a
           @controller.response.headers.merge!(headers)
-          @controller.response.content_type = headers["Content-Type"] unless Rails.version.start_with?('5', '6.0')
+          @controller.response.content_type = headers["Content-Type"] unless Rails::VERSION::MAJOR >= 5
           @controller.status = status
           @controller.response.body = response.body
           nil # causes process return @response

--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -139,7 +139,7 @@ module Devise
 
           status, headers, response = Devise.warden_config[:failure_app].call(env).to_a
           @controller.response.headers.merge!(headers)
-          @controller.response.content_type = headers["Content-Type"] unless Rails.version.start_with?('5')
+          @controller.response.content_type = headers["Content-Type"] unless Rails.version.start_with?('5', '6.0')
           @controller.status = status
           @controller.response.body = response.body
           nil # causes process return @response


### PR DESCRIPTION
This fixes an issue that raises an `ActionDispatch::IllegalStateError` in tests

```
 1) Users::SessionsController request/response duration #create bad password behaves like ideal duration is close to ideal standardised duration
     Failure/Error: post :create, params: { user: { email: email, password: password } }

     ActionDispatch::IllegalStateError:
       header already sent
     Shared Example Group: "ideal duration" called from ./spec/controllers/users/sessions_controller_spec.rb:36
     # [redacted]/gems/devise-4.5.0/lib/devise/test/controller_helpers.rb:142:in `_process_unauthenticated'
     # [redacted]/gems/devise-4.5.0/lib/devise/test/controller_helpers.rb:118:in `_catch_warden'
     # [redacted]/gems/devise-4.5.0/lib/devise/test/controller_helpers.rb:35:in `process'
     #[redacted]/gems/rails-controller-testing-1.0.4/lib/rails/controller/testing/integration.rb:13:in `block (2 levels) in <module:Integration>'
     # ./spec/controllers/users/sessions_controller_spec.rb:19:in `block (4 levels) in <top (required)>'
     # ./app/services/timer.rb:6:in `seconds'
     # ./spec/controllers/users/sessions_controller_spec.rb:18:in `block (3 levels) in <top (required)>'
```