### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,10 @@ env:
     - DEVISE_ORM=active_record
     - DEVISE_ORM=mongoid
 
-before_install: "rm ${BUNDLE_GEMFILE}.lock"
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+  - "rm ${BUNDLE_GEMFILE}.lock"
 
 before_script: "bundle update"
 


### PR DESCRIPTION
Now Travis uses bundler 2.0+ and it causes some build fails since we still support Rails 4.

This commit set Travis to not use a bundler version higher than 2.0.

More info: https://docs.travis-ci.com/user/languages/ruby/#bundler-20