### PR TITLE
Fix bin/test using Rails::TestUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ bin/test
 
 * Running tests for an specific file:
 ```bash
-ruby -Itest test/models/trackable_test.rb
+bin/test test/models/trackable_test.rb
 ```
 
 * Running a specific test given a regex:
 ```bash
-ruby -Itest test/models/trackable_test.rb --name /authentication/
+bin/test test/models/trackable_test.rb:16
 ```
 
 ## Starting with Rails?

--- a/bin/test
+++ b/bin/test
@@ -1,13 +1,17 @@
 #!/usr/bin/env ruby
 $: << File.expand_path(File.expand_path('../../test', __FILE__))
 
-require 'bundler/setup'
+# Remove this begin/rescue once Rails 4 support is removed.
 begin
-  require 'rails/test_unit/minitest_plugin'
+  require 'bundler/setup'
+  require 'rails/test_unit/runner'
+  require 'rails/test_unit/reporter'
+  require 'rails/test_unit/line_filtering'
+
+  Rails::TestUnitReporter.executable = 'bin/test'
+
+  Rails::TestUnit::Runner.parse_options(ARGV)
+  Rails::TestUnit::Runner.run(ARGV)
 rescue LoadError
   exec 'rake'
 end
-
-Rails::TestUnitReporter.executable = 'bin/test'
-
-exit Minitest.run(ARGV)


### PR DESCRIPTION
The command bin/test stop running single tests once Devise started to support Rails 5.2. The problem is because we used `rails/test_unit/minitest_plugin` and this file was moved to another place.

See: https://github.com/rails/rails/pull/29572

I'm not sure if we should require the `minitest-plugin` directly from Rails like we were doing, I tried it and it didn't work. So I'm changing this `bin/test` completely based on how Rails does that [here](https://github.com/rails/rails/blob/master/tools/test.rb)