### PR TITLE
Fix webrat warnings

### DIFF
--- a/test/support/webrat/integrations/rails.rb
+++ b/test/support/webrat/integrations/rails.rb
@@ -18,6 +18,12 @@ module Webrat
   end
 
   class RailsAdapter
+    # This method is private within webrat gem and after Ruby 2.4 we get a lot of warnings because
+    # Webrat::Session#response is delegated to this method.
+    def response
+      integration_session.response
+    end
+
     protected
 
     def do_request(http_method, url, data, headers)


### PR DESCRIPTION
Forwarding methods to private methods is deprecated and produces a warning after Ruby 2.4.

see: https://bugs.ruby-lang.org/issues/12782

To fix this issue I'm mocking patching webrat making RailsAdatper#response method public since Webrat::Session is delegating functions to it.