### PR TITLE
Check if `root_path` is defined with `#respond_to?` instead of `#present`

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -275,7 +275,7 @@ module Devise
     private
 
     def root_path_defined?(context)
-      defined?(context.routes) && context.routes.url_helpers.root_path.present?
+      defined?(context.routes) && context.routes.url_helpers.respond_to?(:root_path)
     end
 
     def rails_5_and_down?

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -44,7 +44,7 @@ class FailureTest < ActiveSupport::TestCase
       end
     end
 
-    def fake_app
+    def main_app
       FakeAppWithoutRootPath.new
     end
   end
@@ -125,12 +125,10 @@ class FailureTest < ActiveSupport::TestCase
     end
 
     test 'returns to the root path even when it\'s not defined' do
-      swap Devise, router_name: :fake_app do
-        call_failure app: FailureWithoutRootPath
-        assert_equal 302, @response.first
-        assert_equal 'You need to sign in or sign up before continuing.', @request.flash[:alert]
-        assert_equal 'http://test.host/', @response.second['Location']
-      end
+      call_failure app: FailureWithoutRootPath
+      assert_equal 302, @response.first
+      assert_equal 'You need to sign in or sign up before continuing.', @request.flash[:alert]
+      assert_equal 'http://test.host/', @response.second['Location']
     end
 
     test 'returns to the root path considering subdomain if no session path is available' do


### PR DESCRIPTION
When an application does not define a [`root`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-root), the method will be undefined instead of returning a falsey value. This used to work before version 4.6.0, but after 1aab449 it throws an error.

This pull request also includes a new test with fake objects that mimic this behavior.

Fixes #5021.