### PR TITLE
Do not set encrypted_password to nil if password is blank

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -60,7 +60,7 @@ module Devise
       # the hashed password.
       def password=(new_password)
         @password = new_password
-        self.encrypted_password = password_digest(@password) 
+        self.encrypted_password = password_digest(@password) if @password.present?
       end
 
       # Verifies whether a password (ie from sign in) is the user password.

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -122,6 +122,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_nil new_user(password: '').encrypted_password
   end
 
+  test 'should not set encrypted password to nil if updating with blank password' do
+    user = create_user
+    user.password = ''
+    refute_nil user.encrypted_password
+  end
+
   test 'should hash password again if password has changed' do
     user = create_user
     encrypted_password = user.encrypted_password
@@ -323,11 +329,5 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user.password = nil
     refute user.valid_password?('12345678')
     refute user.valid_password?(nil)
-  end
-
-  test 'should not set encrypted_password to nil if password was blank' do
-    user = User.create(email: "HEllO@example.com", password: "12345678")
-    user.password = ''
-    assert user.encrypted_password
   end
 end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -324,4 +324,10 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     refute user.valid_password?('12345678')
     refute user.valid_password?(nil)
   end
+
+  test 'should not set encrypted_password to nil if password was blank' do
+    user = User.create(email: "HEllO@example.com", password: "12345678")
+    user.password = ''
+    assert user.encrypted_password
+  end
 end


### PR DESCRIPTION
If the password attribute was set to a blank or `nil`, this was also setting the `encrypted_password` to `nil` (password_digest returns `nil` for a blank)

This means that calling `update` on a model with a blank password always sets `encrypted_password` to `nil`, which usually errors as a database constraint issue.

Introduced by https://github.com/plataformatec/devise/pull/4261/files#diff-19b4dd928714c72f1338874351e8ff2dR40

Related to https://github.com/plataformatec/devise/issues/5033 and https://github.com/plataformatec/devise/issues/5038