### PR TITLE
Remove Valid Password Constraints from DatabaseAuthenticatable Concern

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -198,7 +198,6 @@ module Devise
       # See https://github.com/plataformatec/devise-encryptable for examples
       # of other hashing engines.
       def password_digest(password)
-        return if password.blank?
         Devise::Encryptor.digest(self.class, password)
       end
 

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -38,7 +38,7 @@ module Devise
       def initialize(*args, &block)
         @skip_email_changed_notification = false
         @skip_password_change_notification = false
-        super 
+        super
       end
 
       # Skips sending the email changed notification after_update
@@ -60,7 +60,7 @@ module Devise
       # the hashed password.
       def password=(new_password)
         @password = new_password
-        self.encrypted_password = password_digest(@password) 
+        self.encrypted_password = password_digest(@password) || ''
       end
 
       # Verifies whether a password (ie from sign in) is the user password.
@@ -198,6 +198,7 @@ module Devise
       # See https://github.com/plataformatec/devise-encryptable for examples
       # of other hashing engines.
       def password_digest(password)
+        return if password.blank?
         Devise::Encryptor.digest(self.class, password)
       end
 

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -117,11 +117,6 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert_nil user.authenticatable_salt
   end
 
-  test 'should set encrypted password to nil if password is nil' do
-    assert_nil new_user(password: nil).encrypted_password
-    assert_nil new_user(password: '').encrypted_password
-  end
-
   test 'should hash password again if password has changed' do
     user = create_user
     encrypted_password = user.encrypted_password
@@ -146,16 +141,6 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = create_user
     user.encrypted_password = ''
     refute user.valid_password?('654321')
-  end
-
-  test 'should be invalid if the password is nil' do
-    user = new_user(password: nil)
-    refute user.valid_password?(nil)
-  end
-
-  test 'should be invalid if the password is blank' do
-    user = new_user(password: '')
-    refute user.valid_password?('')
   end
 
   test 'should respond to current password' do
@@ -316,12 +301,5 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
         :login
       ]
     end
-  end
-
-  test 'nil password should be invalid if password is set to nil' do
-    user = User.create(email: "HEllO@example.com", password: "12345678")
-    user.password = nil
-    refute user.valid_password?('12345678')
-    refute user.valid_password?(nil)
   end
 end

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -302,4 +302,12 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
       ]
     end
   end
+
+  test 'sets encrypted_password to blank string if nil or blank is passed' do
+    user = User.new(password: 'abc123')
+    assert_not user.encrypted_password.blank?
+    user.password = nil
+    assert_not user.valid_password?('abc123')
+    assert_equal '', user.encrypted_password
+  end
 end


### PR DESCRIPTION
# Overview
PR #4261 and subsequently #4970 were added to address issue #4245.  In doing so, a hard requirement for having a non-nil, non-blank password was injected into `DatabaseAuthenticatable`.  As many of us are upgrading from version < 4.6 to 4.6.1 to address https://github.com/plataformatec/devise/issues/4981 we are unable to do so because we have a pre-existing implementation that allows the creation of a Devise model with no password.  A common use case of this is pre-creating an account when a user submits an email for marketing purposes.

However, in my opinion, a valid use case is irrelevant to what this change did.  It broke the nice separation of concerns that existed in Devise prior to version 4.6.0.  `DatabaseAuthenticatable` should not be deciding what constitutes validity for a password, that is what the `Validatable` concern is for.  Given that `Validatable#password_required?` exists, which allows implementations to override default behavior and explicitly not require a password, is further evidence why this change was a mistake.

~Furthermore, the original issue that sparked this change, #4245, was either inaccurate to begin with, or had been properly fixed in 2+ years since being reported and the change being merged.  I have run the same "test" on an implementation using this branch:~

UPDATE: A colleague of mine pointed out that my change was different than the pre-4.6 behavior and that is why the test case from #4245 was passing.  I updated my change to set `encrypted_password` to a blank string if the passed password argument is blank as well.  This should mimic the pre-4.6 behavior as well as keeping the "default" `encrypted_password` value the same as defined in the schema. 

# Changelog
## Changes
- removed returning `nil` from `DatabaseAuthenticatable#password_digest` if the passed password argument is `nil` or `blank`
- returns `''` if a blank password argument is passed
- adds a simple unit test to match the test case from the original issue (#4245)
## Removed
- unit tests referencing the prior behavior