### PR TITLE
Regenerate confirmation token

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -130,6 +130,15 @@ module Devise
       end
 
       # Resend confirmation token.
+      # Regenerates the token.
+      def regenerate_confirmation_instructions
+        pending_any_confirmation do
+          self.confirmation_token = nil
+          send_confirmation_instructions
+        end
+      end
+
+      # Resend confirmation token.
       # Regenerates the token if the period is expired.
       def resend_confirmation_instructions
         pending_any_confirmation do

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -343,6 +343,14 @@ class ConfirmableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'generate a new token on regenerate' do
+    user = create_user
+    old  = user.confirmation_token
+    user = User.find(user.id)
+    user.regenerate_confirmation_instructions
+    assert_not_equal user.confirmation_token, old
+  end
+
   test 'should call after_confirmation if confirmed' do
     user = create_user
     user.define_singleton_method :after_confirmation do


### PR DESCRIPTION
Very simple functionality. I want to resend the confirmation instruction with a new token. Same code as resend but it put the `confirmation_token = nil` so i force the `send_confirmation_token` to generate a new one. The reason why i propose this new feature is because i need to deactivate the old confirmation token for security.