### PR TITLE
Fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ are executed in your tests.
 
 You can read more about testing your Rails 3 - Rails 4 controllers with RSpec in the wiki:
 
-* https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-3-and-4-%28and-RSpec%29
+* https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-(and-RSpec)
 
 ### OmniAuth
 


### PR DESCRIPTION
The link that's in there goes to a non-existent page. I'm guessing it was moved. I put the link in that I think it was moved to.