### PR TITLE
Update password confirmation autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* enhancements
+  * Add `autocomplete="new-password"` to `password_confirmation` fields (by @ferrl)
+
 ### 4.6.2 - 2019-03-26
 
 * bug fixes

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -14,7 +14,7 @@
 
   <div class="field">
     <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">

--- a/lib/generators/templates/simple_form_for/passwords/edit.html.erb
+++ b/lib/generators/templates/simple_form_for/passwords/edit.html.erb
@@ -13,7 +13,10 @@
                 autofocus: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation, label: "Confirm your new password", required: true %>
+    <%= f.input :password_confirmation,
+                label: "Confirm your new password",
+                required: true,
+                input_html: { autocomplete: "new-password" } %>
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
Update `password_confirmation` fields to include the correct `autocomplete` parameter, based on the discussions [here](https://github.com/plataformatec/devise/pull/4851#discussion_r271034695) and [here](https://github.com/plataformatec/devise/commit/6260c29a867b9a656f1e1557abe347a523178fab#r31284249).