### PR TITLE
Fix rails 6.0.rc1 email uniqueness validation deprecation error

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -30,7 +30,7 @@ module Devise
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
           if Devise.activerecord51?
-            validates_uniqueness_of :email, allow_blank: true, if: :will_save_change_to_email?
+            validates_uniqueness_of :email, allow_blank: true, case_sensitive: true, if: :will_save_change_to_email?
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
           else
             validates_uniqueness_of :email, allow_blank: true, if: :email_changed?


### PR DESCRIPTION
Rails 6 rc1 introduced a deprecation in uniqueness-validation:

> Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the case insensitive column, pass case_sensitive: true option explicitly to the uniqueness validator.

this PR fixes produced error.

Fixes #5064 