### PR TITLE
Using scoped errors for scoped views. Fixes #5066

### DIFF
--- a/lib/generators/devise/views_generator.rb
+++ b/lib/generators/devise/views_generator.rb
@@ -42,7 +42,7 @@ module Devise
       def view_directory(name, _target_path = nil)
         directory name.to_s, _target_path || "#{target_path}/#{name}" do |content|
           if scope
-            content.gsub "devise/shared/links", "#{plural_scope}/shared/links"
+            content.gsub("devise/shared/links", "#{plural_scope}/shared/links").gsub("devise/shared/error_messages", "#{plural_scope}/shared/error_messages")
           else
             content
           end

--- a/test/generators/views_generator_test.rb
+++ b/test/generators/views_generator_test.rb
@@ -11,16 +11,19 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_files
     assert_shared_links
+    assert_error_messages
   end
 
   test "Assert all views are properly created with scope param" do
     run_generator %w(users)
     assert_files "users"
     assert_shared_links "users"
+    assert_error_messages "users"
 
     run_generator %w(admins)
     assert_files "admins"
     assert_shared_links "admins"
+    assert_error_messages "admins"
   end
 
   test "Assert views with simple form" do
@@ -88,6 +91,7 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/#{scope}/registrations/edit.html.erb"
     assert_file "app/views/#{scope}/sessions/new.html.erb"
     assert_file "app/views/#{scope}/shared/_links.html.erb"
+    assert_file "app/views/#{scope}/shared/_error_messages.html.erb"
     assert_file "app/views/#{scope}/unlocks/new.html.erb"
   end
 
@@ -100,6 +104,18 @@ class ViewsGeneratorTest < Rails::Generators::TestCase
     assert_file "app/views/#{scope}/confirmations/new.html.erb", link
     assert_file "app/views/#{scope}/registrations/new.html.erb", link
     assert_file "app/views/#{scope}/sessions/new.html.erb", link
+    assert_file "app/views/#{scope}/unlocks/new.html.erb", link
+  end
+
+  def assert_error_messages(scope = nil)
+    scope = "devise" if scope.nil?
+    link = /<%= render \"#{scope}\/shared\/error_messages\", resource: resource %>/
+
+    assert_file "app/views/#{scope}/passwords/edit.html.erb", link
+    assert_file "app/views/#{scope}/passwords/new.html.erb", link
+    assert_file "app/views/#{scope}/confirmations/new.html.erb", link
+    assert_file "app/views/#{scope}/registrations/new.html.erb", link
+    assert_file "app/views/#{scope}/registrations/edit.html.erb", link
     assert_file "app/views/#{scope}/unlocks/new.html.erb", link
   end
 end


### PR DESCRIPTION
Added tests for `error_messages` file and content to be present in generated views, and the generated views to use scoped errors in place of default devise errors.

Fixes #5066