### PR TITLE
Increase default stretches to 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * refactor method name to be more consistent (by @saiqulhaq)
   * Fix rails 6.0.rc1 email uniqueness validation deprecation error (by @Vasfed)
   * Fix rails_51_and_up? method for Rails 6.rc1 (by @igorkasyanchuk)
+  * Increase default stretches to 12 (by @sergey-alekseev)
 
 ### 4.6.2 - 2019-03-26
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ member_session
 The Devise method in your models also accepts some options to configure its modules. For example, you can choose the cost of the hashing algorithm with:
 
 ```ruby
-devise :database_authenticatable, :registerable, :confirmable, :recoverable, stretches: 12
+devise :database_authenticatable, :registerable, :confirmable, :recoverable, stretches: 13
 ```
 
 Besides `:stretches`, you can define `:pepper`, `:encryptor`, `:confirm_within`, `:remember_for`, `:timeout_in`, `:unlock_in` among other options. For more details, see the initializer file that was created when you invoked the "devise:install" generator described above. This file is usually located at `/config/initializers/devise.rb`.

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -71,7 +71,7 @@ module Devise
 
   # The number of times to hash the password.
   mattr_accessor :stretches
-  @@stretches = 11
+  @@stretches = 12
 
   # The default key used when authenticating over http auth.
   mattr_accessor :http_authentication_key

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -103,7 +103,7 @@ Devise.setup do |config|
   # config.reload_routes = true
 
   # ==> Configuration for :database_authenticatable
-  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
   # using other algorithms, it sets how many times you want the password to be hashed.
   #
   # Limiting the stretches to just one in testing will increase the performance of
@@ -111,7 +111,7 @@ Devise.setup do |config|
   # a value less than 10 in other environments. Note that, for bcrypt (the default
   # algorithm), the cost increases exponentially with the number of stretches (e.g.
   # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
-  config.stretches = Rails.env.test? ? 1 : 11
+  config.stretches = Rails.env.test? ? 1 : 12
 
   # Set up a pepper to generate the hashed password.
   # config.pepper = '<%= SecureRandom.hex(64) %>'


### PR DESCRIPTION
Test script
---

```ruby
require 'bcrypt'
require 'benchmark'
Benchmark.measure { BCrypt::Password.create('password', cost: 12) }
```

Test results
---

- [Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz](https://ark.intel.com/content/www/us/en/ark/products/97535/intel-core-i5-7360u-processor-4m-cache-up-to-3-60-ghz.html): `#<Benchmark::Tms:0x00007fdd00a4eb30 @label="", @real=0.21730700000080105, @cstime=0.0, @cutime=0.0, @stime=0.00020399999999999585, @utime=0.21685199999999996, @total=0.21705599999999997>`
- [Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz](https://ark.intel.com/content/www/us/en/ark/products/137979/intel-core-i7-8559u-processor-8m-cache-up-to-4-50-ghz.html): `#<Benchmark::Tms:0x00007fe91094fd30 @label="", @real=0.17964200000278652, @cstime=0.0, @cutime=0.0, @stime=7.399999999996298e-05, @utime=0.17950799999999845, @total=0.1795819999999984>`

Other gems
---

- bcrypt-ruby which is used by devise [updated](https://github.com/codahale/bcrypt-ruby/pull/181) their default cost to 12 (not released a gem version yet).
- rails has [a PR](https://github.com/rails/rails/pull/35321) from the Rails core team member to update their `ActiveModel::SecurePassword` which powers `has_secure_password` default cost to 13 (not merged yet).

Previous changes
---

[Previous PR](https://github.com/plataformatec/devise/pull/3549) to increase the default stretches to 12 was created more than 4 years ago. That time the default stretches value [was increased](https://github.com/plataformatec/devise/commit/9efc601c73c147c207de15f1caea75de12ebef70) from 10 to 11.