### PR TITLE
Add dependency on activemodel

### DIFF
--- a/devise.gemspec
+++ b/devise.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency("bcrypt", "~> 3.0")
   s.add_dependency("railties", ">= 4.1.0", "< 6.0")
   s.add_dependency("responders")
+  s.add_dependency("activemodel")
 end


### PR DESCRIPTION
Because of https://github.com/plataformatec/devise/blob/354df3bc65fb211f0704208f52bf2213758585cf/lib/devise/models/authenticatable.rb#L3 this gem needs `activemodel` installed. Otherwise this is the error:

```
/Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require': cannot load such file -- active_model/version (LoadError)
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/devise-4.6.2/lib/devise/models/authenticatable.rb:3:in `<top (required)>'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/devise-4.6.2/lib/devise/models.rb:121:in `<top (required)>'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `block in require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:257:in `load_dependency'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require'
	from /Users/pt/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/devise-4.6.2/lib/devise.rb:516:in `<top (required)>'
```