### PR TITLE
Add dedicated reconfirmation mail subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * refactor method name to be more consistent (by @saiqulhaq)
   * Fix rails 6.0.rc1 email uniqueness validation deprecation error (by @Vasfed)
   * Fix rails_51_and_up? method for Rails 6.rc1 (by @igorkasyanchuk)
+  * Add `:subject_key` to devise_mail options for reconfirmation mail subject (by @sakuraineed)
 
 ### 4.6.2 - 2019-03-26
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
+      reconfirmation_instructions:
+        subject: "Reconfirmation instructions"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:

--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -30,7 +30,7 @@ module Devise
 
       def headers_for(action, opts)
         headers = {
-          subject: subject_for(action),
+          subject: subject_for(opts.delete(:subject_key) || action),
           to: resource.email,
           from: mailer_sender(devise_mapping),
           reply_to: mailer_reply_to(devise_mapping),

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -117,7 +117,7 @@ module Devise
           generate_confirmation_token!
         end
 
-        opts = pending_reconfirmation? ? { to: unconfirmed_email } : { }
+        opts = pending_reconfirmation? ? { subject_key: :reconfirmation_instructions, to: unconfirmed_email } : {}
         send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
       end
 

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -42,6 +42,12 @@ class ActiveSupport::TestCase
     User.create!(valid_attributes(attributes))
   end
 
+  def new_admin(attributes={})
+    valid_attributes = valid_attributes(attributes)
+    valid_attributes.delete(:username)
+    Admin.new(valid_attributes)
+  end
+
   def create_admin(attributes={})
     valid_attributes = valid_attributes(attributes)
     valid_attributes.delete(:username)


### PR DESCRIPTION
This PR adds `:subject_key` to devise_mail options for reconfirmation mail subject.