### PR TITLE
Updated Codeacademy's Rails Auth link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you are building your first Rails application, we recommend you *do not* use 
 
 * Michael Hartl's online book: https://www.railstutorial.org/book/modeling_users
 * Ryan Bates' Railscast: http://railscasts.com/episodes/250-authentication-from-scratch
-* Codecademy's Ruby on Rails: Authentication and Authorization: http://www.codecademy.com/en/learn/rails-auth
+* Codecademy's Ruby on Rails: Authentication and Authorization: https://www.codecademy.com/learn/rails-auth
 
 Once you have solidified your understanding of Rails and authentication mechanisms, we assure you Devise will be very pleasant to work with. :smiley:
 


### PR DESCRIPTION
The previous link gave 404 error.
Update with newer working link.