### PR TITLE
Fix sign_out_via default method(s) documentation

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -135,7 +135,7 @@ module ActionDispatch::Routing
     #  * failure_app: a rack app which is invoked whenever there is a failure. Strings representing a given
     #    are also allowed as parameter.
     #
-    #  * sign_out_via: the HTTP method(s) accepted for the :sign_out action (default: :get),
+    #  * sign_out_via: the HTTP method(s) accepted for the :sign_out action (default: :delete),
     #    if you wish to restrict this to accept only :post or :delete requests you should do:
     #
     #      devise_for :users, sign_out_via: [:post, :delete]


### PR DESCRIPTION
👋 

The default for `Devise.sign_out_via` configuration has been [changed from `:get` to `:delete`](https://github.com/plataformatec/devise/pull/4061) but the documentation has not been updated accordingly. 

Here's where the default is set in the codebase:

- https://github.com/plataformatec/devise/blob/81cb5b00f46cc24e6f41d6f1841ecaf442013898/lib/devise.rb#L226-L228
- https://github.com/plataformatec/devise/blob/81cb5b00f46cc24e6f41d6f1841ecaf442013898/lib/generators/templates/devise.rb#L256-L257

