### PR TITLE
add email_scope option for email uniqueness validator

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -115,6 +115,10 @@ module Devise
   mattr_accessor :email_regexp
   @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
+   # Option to scope the email uniqueness validator
+   mattr_accessor :email_scope
+   @@email_scope = nil
+
   # Range validation for password length
   mattr_accessor :password_length
   @@password_length = 6..128

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -12,6 +12,7 @@ module Devise
     # Validatable adds the following options to devise_for:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
+    #   * +email_scope+: option to scope the email uniqueness validator;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
     #
     module Validatable
@@ -30,10 +31,10 @@ module Devise
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
           if Devise.activerecord51?
-            validates_uniqueness_of :email, allow_blank: true, case_sensitive: true, if: :will_save_change_to_email?
+            validates_uniqueness_of :email, allow_blank: true, case_sensitive: true, if: :will_save_change_to_email?, scope: email_scope
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
           else
-            validates_uniqueness_of :email, allow_blank: true, if: :email_changed?
+            validates_uniqueness_of :email, allow_blank: true, if: :email_changed?, scope: email_scope
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :email_changed?
           end
 
@@ -66,7 +67,7 @@ module Devise
       end
 
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(self, :email_regexp, :password_length, :email_scope)
       end
     end
   end

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -173,6 +173,9 @@ Devise.setup do |config|
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
+  # Option to scope the email uniqueness validator. Default is nil;
+  # config.email_scope = [:username]
+
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -124,7 +124,9 @@ class RegistrationTest < Devise::IntegrationTest
     #    https://github.com/mongoid/mongoid/issues/756
     (pending "Fails on Mongoid < 2.1"; break) if defined?(Mongoid) && Mongoid::VERSION.to_f < 2.1
 
-    create_user
+    user = create_user
+    user.update_attribute(:username, nil)
+
     get new_user_registration_path
 
     fill_in 'email', with: 'user@test.com'
@@ -254,7 +256,7 @@ class RegistrationTest < Devise::IntegrationTest
     assert_contain "Password confirmation doesn't match Password"
     refute User.to_adapter.find_first.valid_password?('pas123')
   end
-  
+
   test 'a signed in user should see a warning about minimum password length' do
     sign_in_as_user
     get edit_user_registration_path

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -26,22 +26,13 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
-  test 'should require uniqueness of email when email_scope is used' do
+  test 'should allow duplicate email when email_scope attribute does not match' do
     existing_user = create_user
 
-    user = new_user(email: '')
-    assert user.invalid?
-    assert_no_match(/taken/, user.errors[:email].join)
-
-    user.email = existing_user.email
+    user = new_user(email: existing_user.email)
     user.username = nil
     assert user.valid?
     assert_no_match(/taken/, user.errors[:email].join)
-
-    user.email = existing_user.email
-    user.username = existing_user.username
-    assert user.invalid?
-    assert_match(/taken/, user.errors[:email].join)
 
     user.save(validate: false)
     assert user.valid?

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -26,6 +26,27 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.valid?
   end
 
+  test 'should require uniqueness of email when email_scope is used' do
+    existing_user = create_user
+
+    user = new_user(email: '')
+    assert user.invalid?
+    assert_no_match(/taken/, user.errors[:email].join)
+
+    user.email = existing_user.email
+    user.username = nil
+    assert user.valid?
+    assert_no_match(/taken/, user.errors[:email].join)
+
+    user.email = existing_user.email
+    user.username = existing_user.username
+    assert user.invalid?
+    assert_match(/taken/, user.errors[:email].join)
+
+    user.save(validate: false)
+    assert user.valid?
+  end
+
   test 'should require correct email format if email has changed, allowing blank' do
     user = new_user(email: '')
     assert user.invalid?

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -95,6 +95,9 @@ Devise.setup do |config|
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
 
+  # Option to scope the email uniqueness validator. Default is nil;
+  # config.email_scope = [:subdomain]
+
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.

--- a/test/rails_app/lib/shared_user.rb
+++ b/test/rails_app/lib/shared_user.rb
@@ -7,7 +7,7 @@ module SharedUser
     devise :database_authenticatable, :confirmable, :lockable, :recoverable,
            :registerable, :rememberable, :timeoutable,
            :trackable, :validatable, :omniauthable, password_length: 7..72,
-           reconfirmable: false
+           reconfirmable: false, email_scope: [:username]
 
     attr_accessor :other_key
 


### PR DESCRIPTION
This is a reboot of the closed PR #4793 with some tests. Issue #4767 has a lot of information about why this would be useful. 

Description from #4793 

- per subdomain auth;
- soft deletion and paranoid like support;
- example from https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address.

