### PR TITLE
Allow remember_for option to be dynamic

### DIFF
--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -63,7 +63,7 @@ module Devise
       end
 
       def remember_expires_at
-        self.class.remember_for.from_now
+        remember_for.from_now
       end
 
       def extend_remember_period
@@ -114,9 +114,13 @@ module Devise
         # 4. the token date is bigger than the remember_created_at
         # 5. the token matches
         generated_at.is_a?(Time) &&
-         (self.class.remember_for.ago < generated_at) &&
+         (remember_for.ago < generated_at) &&
          (generated_at > (remember_created_at || Time.now).utc) &&
          Devise.secure_compare(rememberable_value, token)
+      end
+
+      def remember_for
+        self.class.remember_for
       end
 
       private

--- a/test/models/rememberable_test.rb
+++ b/test/models/rememberable_test.rb
@@ -176,6 +176,12 @@ class RememberableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'remember_for can be set dynamically' do
+    resource = create_resource
+    resource.instance_eval { def remember_for; 3.days end }
+    assert_equal 3.days.from_now.to_date, resource.remember_expires_at.to_date
+  end
+
   test 'should have the required_fields array' do
     assert_equal Devise::Models::Rememberable.required_fields(User), [
       :remember_created_at


### PR DESCRIPTION
This will allow the `remember_for` option to be dynamic, by defining a `remember_for` method on the resource model in the same way as the `timeout_in` option supports.
https://github.com/plataformatec/devise/wiki/How-To:-Add-timeout_in-value-dynamically