### PR TITLE
Fix specs on Rails 6 RC2

### DIFF
--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -5,7 +5,9 @@ ActiveRecord::Base.logger = Logger.new(nil)
 ActiveRecord::Base.include_root_in_json = true
 
 migrate_path = File.expand_path("../../rails_app/db/migrate/", __FILE__)
-if Devise::Test.rails52_and_up?
+if Devise::Test.rails6?
+  ActiveRecord::MigrationContext.new(migrate_path, ActiveRecord::SchemaMigration).migrate
+elsif Devise::Test.rails52_and_up?
   ActiveRecord::MigrationContext.new(migrate_path).migrate
 else
   ActiveRecord::Migrator.migrate(migrate_path)

--- a/test/rails_app/app/views/admins/sessions/new.html.erb
+++ b/test/rails_app/app/views/admins/sessions/new.html.erb
@@ -1,2 +1,2 @@
 Welcome to "sessions/new" view!
-<%= render file: "devise/sessions/new" %>
+<%= render template: "devise/sessions/new" %>

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -45,7 +45,7 @@ module RailsApp
       Devise::SessionsController.layout "application"
     end
 
-    # Remove this check once Rails 5.0 support is removed.
+    # Remove the first check once Rails 5.0 support is removed.
     if Devise::Test.rails52_and_up? && !Devise::Test.rails6?
       Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
     end

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -46,7 +46,7 @@ module RailsApp
     end
 
     # Remove this check once Rails 5.0 support is removed.
-    if Devise::Test.rails52_and_up?
+    if Devise::Test.rails52_and_up? && !Devise::Test.rails6?
       Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
     end
   end

--- a/test/rails_app/config/boot.rb
+++ b/test/rails_app/config/boot.rb
@@ -6,7 +6,7 @@ end
 
 module Devise
   module Test
-    # Detection for minor differences between Rails 4 and 5, 5.1, and 5.2 in tests.
+    # Detection for minor differences between Rails versions in tests.
     
     def self.rails6?
       Rails.version.start_with? '6'

--- a/test/rails_app/config/boot.rb
+++ b/test/rails_app/config/boot.rb
@@ -8,6 +8,10 @@ module Devise
   module Test
     # Detection for minor differences between Rails 4 and 5, 5.1, and 5.2 in tests.
     
+    def self.rails6?
+      Rails.version.start_with? '6'
+    end
+
     def self.rails52_and_up?
       Rails::VERSION::MAJOR > 5 || rails52?
     end

--- a/test/test/controller_helpers_test.rb
+++ b/test/test/controller_helpers_test.rb
@@ -102,7 +102,12 @@ class TestControllerHelpersTest < Devise::ControllerTestCase
 
   test "returns the content type of a failure app" do
     get :index, params: { format: :xml }
-    assert response.content_type.include?('application/xml')
+
+    if Devise::Test.rails6?
+      assert response.media_type.include?('application/xml')
+    else
+      assert response.content_type.include?('application/xml')
+    end
   end
 
   test "defined Warden after_authentication callback should not be called when sign_in is called" do


### PR DESCRIPTION
The `ActiveRecord::MigrationContext` class now has a `schema_migration` attribute.
Reference: https://github.com/rails/rails/pull/36439/files#diff-8d3c44120f7b67ff79e2fbe6a40d0ad6R1018

This pull request also includes some changes to avoid deprecation warnings: https://github.com/plataformatec/devise/commit/3273f9e08943deb1b413268392bb640512aee799, https://github.com/plataformatec/devise/commit/77cb3941ec3c198435309370c9e538ab1339a378 and https://github.com/plataformatec/devise/commit/69534c666c66a30c4e1c814c0c15846059f35dcc