### PR TITLE
Fixed problem with Ruby 2.4+ on function prepend_before_filter

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,7 +1,7 @@
 class Devise::SessionsController < DeviseController
   prepend_before_filter :require_no_authentication, only: [ :new, :create ]
   prepend_before_filter :allow_params_authentication!, only: :create
-  prepend_before_filter only: [ :create, :destroy ] { request.env["devise.skip_timeout"] = true }
+  prepend_before_filter(only: [ :create, :destroy ]) { request.env["devise.skip_timeout"] = true }
 
   # GET /resource/sign_in
   def new


### PR DESCRIPTION
Fixed a problem with grammatical update of Ruby 2.4+ on function prepend_before_filter.