### PR TITLE
Always return an error when `confirmation_token` is blank

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -349,6 +349,12 @@ module Devise
         # Options must have the confirmation_token
         def confirm_by_token(confirmation_token)
           confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
+
+          if confirmable && confirmation_token.blank?
+            confirmable.errors.add(:confirmation_token, :blank)
+            return confirmable
+          end
+
           unless confirmable
             confirmation_digest = Devise.token_generator.digest(self, :confirmation_token, confirmation_token)
             confirmable = find_or_initialize_with_error_by(:confirmation_token, confirmation_digest)

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -348,17 +348,18 @@ module Devise
         # If the user is already confirmed, create an error for the user
         # Options must have the confirmation_token
         def confirm_by_token(confirmation_token)
-          confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
-
           # When the `confirmation_token` parameter is blank, if there are any users with a blank
           # `confirmation_token` in the database, the first one would be confirmed here.
           # The error is being manually added here to ensure no users are confirmed by mistake.
           # This was done in the model for convenience, since validation errors are automatically
           # displayed in the view.
-          if confirmable && confirmation_token.blank?
+          if confirmation_token.blank?
+            confirmable = new
             confirmable.errors.add(:confirmation_token, :blank)
             return confirmable
           end
+
+          confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
 
           unless confirmable
             confirmation_digest = Devise.token_generator.digest(self, :confirmation_token, confirmation_token)

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -350,6 +350,11 @@ module Devise
         def confirm_by_token(confirmation_token)
           confirmable = find_first_by_auth_conditions(confirmation_token: confirmation_token)
 
+          # When the `confirmation_token` parameter is blank, if there are any users with a blank
+          # `confirmation_token` in the database, the first one would be confirmed here.
+          # The error is being manually added here to ensure no users are confirmed by mistake.
+          # This was done in the model for convenience, since validation errors are automatically
+          # displayed in the view.
           if confirmable && confirmation_token.blank?
             confirmable.errors.add(:confirmation_token, :blank)
             return confirmable

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -175,6 +175,38 @@ class ConfirmationTest < Devise::IntegrationTest
     assert_current_url '/users/sign_in'
   end
 
+  test "should not be able to confirm an email with a blank confirmation token" do
+    visit_user_confirmation_with_token("")
+
+    assert_contain "Confirmation token can't be blank"
+  end
+
+  test "should not be able to confirm an email with a nil confirmation token" do
+    visit_user_confirmation_with_token(nil)
+
+    assert_contain "Confirmation token can't be blank"
+  end
+
+  test "should not confirm user with blank confirmation token" do
+    user = create_user(confirm: false)
+    user.update_attribute(:confirmation_token, "")
+
+    visit_user_confirmation_with_token("")
+
+    assert_contain "Confirmation token can't be blank"
+    refute user.reload.confirmed?
+  end
+
+  test "should not confirm user with nil confirmation token" do
+    user = create_user(confirm: false)
+    user.update_attribute(:confirmation_token, nil)
+
+    visit_user_confirmation_with_token(nil)
+
+    assert_contain "Confirmation token can't be blank"
+    refute user.reload.confirmed?
+  end
+
   test 'error message is configurable by resource name' do
     store_translations :en, devise: {
       failure: { user: { unconfirmed: "Not confirmed user" } }

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -187,24 +187,22 @@ class ConfirmationTest < Devise::IntegrationTest
     assert_contain "Confirmation token can't be blank"
   end
 
-  test "should not confirm user with blank confirmation token" do
+  test "should not be able to confirm user with blank confirmation token" do
     user = create_user(confirm: false)
     user.update_attribute(:confirmation_token, "")
 
     visit_user_confirmation_with_token("")
 
     assert_contain "Confirmation token can't be blank"
-    refute user.reload.confirmed?
   end
 
-  test "should not confirm user with nil confirmation token" do
+  test "should not be able to confirm user with nil confirmation token" do
     user = create_user(confirm: false)
     user.update_attribute(:confirmation_token, nil)
 
     visit_user_confirmation_with_token(nil)
 
     assert_contain "Confirmation token can't be blank"
-    refute user.reload.confirmed?
   end
 
   test 'error message is configurable by resource name' do

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -77,6 +77,24 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
   end
 
+  test 'should return a new record with errors when a blank token is given and a record exists on the database' do
+    user = create_user(confirmation_token: '')
+
+    confirmed_user = User.confirm_by_token('')
+
+    refute user.reload.confirmed?
+    assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
+  end
+
+  test 'should return a new record with errors when a nil token is given and a record exists on the database' do
+    user = create_user(confirmation_token: nil)
+
+    confirmed_user = User.confirm_by_token(nil)
+
+    refute user.reload.confirmed?
+    assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
+  end
+
   test 'should generate errors for a user email if user is already confirmed' do
     user = create_user
     user.confirmed_at = Time.now


### PR DESCRIPTION
As reported in #5071, if for some reason, a user in the database had the `confirmation_token`
column as a blank string, Devise would confirm that user after receiving a request with a blank `confirmation_token` parameter.

After this commit, a request sending a blank `confirmation_token` parameter will always receive a validation error, even if there are users with a blank `confirmation_token` in the database.

For applications that have users with a blank `confirmation_token` in the database, it's recommended to manually regenerate or to nullify them.

Closes #5071