### PR TITLE
`changed?` behaviour has been updated

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -152,6 +152,7 @@ module Devise
       #         # If the record is new or changed then delay the
       #         # delivery until the after_commit callback otherwise
       #         # send now because after_commit will not be called.
+      #         # For Rails < 6 is `changed?` instead of `saved_changes?`.
       #         if new_record? || saved_changes?
       #           pending_devise_notifications << [notification, args]
       #         else

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -152,7 +152,7 @@ module Devise
       #         # If the record is new or changed then delay the
       #         # delivery until the after_commit callback otherwise
       #         # send now because after_commit will not be called.
-      #         if new_record? || changed?
+      #         if new_record? || saved_changes?
       #           pending_devise_notifications << [notification, args]
       #         else
       #           render_and_send_devise_message(notification, *args)


### PR DESCRIPTION
When using the example async code, the first notification sent (:email_changed), it says "your email is being changed to <existing_email>", which is a bug.

This is due to https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81 `changed?` has been updated to check for dirtiness after save. Because it checks for dirtiness after save, it does not wait until after_commit before sending the notification.

The new method that behaves like the old `changed` is `saved_changes?`.
