### PR TITLE
Call set_flash_message helper instead of flash accessor

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -112,7 +112,7 @@ MESSAGE
     end
 
     if authenticated && resource = warden.user(resource_name)
-      set_flash_message(:alert, "already_authenticated", scope: "devise.failure")
+      set_flash_message(:alert, 'already_authenticated', scope: 'devise.failure')
       redirect_to after_sign_in_path_for(resource)
     end
   end

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -112,7 +112,7 @@ MESSAGE
     end
 
     if authenticated && resource = warden.user(resource_name)
-      flash[:alert] = I18n.t("devise.failure.already_authenticated")
+      set_flash_message(:alert, "already_authenticated", scope: "devise.failure")
       redirect_to after_sign_in_path_for(resource)
     end
   end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -323,6 +323,14 @@ class AuthenticationRedirectTest < Devise::IntegrationTest
     visit new_user_session_path
     assert_equal flash[:alert], I18n.t("devise.failure.already_authenticated")
   end
+
+  test 'require_no_authentication should set the already_authenticated flash message as admin' do
+    store_translations :en, devise: { failure: { admin: { already_authenticated: 'You are already signed in as admin.' } } } do
+      sign_in_as_admin
+      visit new_admin_session_path
+      assert_equal flash[:alert], "You are already signed in as admin."
+    end
+  end
 end
 
 class AuthenticationSessionTest < Devise::IntegrationTest


### PR DESCRIPTION
The flash accessor is being called directly instead of the #set_flash_message helper. The PR change this behavior calling `set_flash_message` helper.

fixes #5080 