### PR TITLE
Documentation: Details/Notes regarding Rails API-only applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,10 +697,10 @@ Devise supports ActiveRecord (default) and Mongoid. To select another ORM, simpl
 
 ### Rails API Mode
 
-Rails 5+ has a built-in [API Mode](https://edgeguides.rubyonrails.org/api_app.html) which optimizes Rails for use as an API (only). This comes with a set of side effects for what devise is able to support without additional modifications and some issues you may face during development/testing.
+Rails 5+ has a built-in [API Mode](https://edgeguides.rubyonrails.org/api_app.html) which optimizes Rails for use as an API (only). Devise is _somewhat_ able to handle applications that are built in this mode without additional modifications in the sense that it should not raise exceptions and the like. But some issues may still arise during `development`/`testing`, as we still don't know the full extent of this compatibility. (For more information, see #4947)
 
 #### Supported Authentication Strategies
-The only default configured strategy supported by devise for API-only applications is database via HTTP Auth, meaning the user is effectively authenicated on each request (a byproduct of API-only applications not supporting browser-based sessions via cookies).
+API-only applications don't support browser-based authentication via cookies, which is devise's default. Yet, devise can still provide authentication out of the box in those cases with the `http_authenticatable` strategy, which uses HTTP Basic Auth and authenticates the user on each request. (For more info, see this wiki article for [How To: Use HTTP Basic Authentication](https://github.com/plataformatec/devise/wiki/How-To:-Use-HTTP-Basic-Authentication))
 
 The devise default for HTTP Auth is disabled, so it will need to be enabled in the devise initializer for the database strategy:
 
@@ -708,8 +708,8 @@ The devise default for HTTP Auth is disabled, so it will need to be enabled in t
 config.http_authenticatable = [:database]
 ```
 
-This restriction does not limit you from implementing custom strategies, either in your application or via gem-based extensions for devise.
-A common authentication strategy for APIs is token-based authenication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/plataformatec/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives).
+This restriction does not limit you from implementing custom warden strategies, either in your application or via gem-based extensions for devise.
+A common authentication strategy for APIs is token-based authentication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/plataformatec/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives) or the this blog post on [Custom authentication methods with Devise](http://blog.plataformatec.com.br/2019/01/custom-authentication-methods-with-devise/).
 
 #### Testing
 API Mode changes the order of the middleware stack, and this can cause problems for `Devise::Test::IntegrationHelpers`. This problem usually surfaces as an ```undefined method `[]=' for nil:NilClass``` error when using integration test helpers, such as `#sign_in`. The solution is simply to reorder the middlewares by adding the following to test.rb:

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ Devise supports ActiveRecord (default) and Mongoid. To select another ORM, simpl
 
 ### Rails API Mode
 
-Rails 5+ has a built-in [API Mode](https://edgeguides.rubyonrails.org/api_app.html) which optimizes Rails for use as an API (only). Devise is _somewhat_ able to handle applications that are built in this mode without additional modifications in the sense that it should not raise exceptions and the like. But some issues may still arise during `development`/`testing`, as we still don't know the full extent of this compatibility. (For more information, see #4947)
+Rails 5+ has a built-in [API Mode](https://edgeguides.rubyonrails.org/api_app.html) which optimizes Rails for use as an API (only). Devise is _somewhat_ able to handle applications that are built in this mode without additional modifications in the sense that it should not raise exceptions and the like. But some issues may still arise during `development`/`testing`, as we still don't know the full extent of this compatibility. (For more information, see [issue #4947](https://github.com/plataformatec/devise/issues/4947/))
 
 #### Supported Authentication Strategies
 API-only applications don't support browser-based authentication via cookies, which is devise's default. Yet, devise can still provide authentication out of the box in those cases with the `http_authenticatable` strategy, which uses HTTP Basic Auth and authenticates the user on each request. (For more info, see this wiki article for [How To: Use HTTP Basic Authentication](https://github.com/plataformatec/devise/wiki/How-To:-Use-HTTP-Basic-Authentication))
@@ -709,7 +709,7 @@ config.http_authenticatable = [:database]
 ```
 
 This restriction does not limit you from implementing custom warden strategies, either in your application or via gem-based extensions for devise.
-A common authentication strategy for APIs is token-based authentication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/plataformatec/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives) or the this blog post on [Custom authentication methods with Devise](http://blog.plataformatec.com.br/2019/01/custom-authentication-methods-with-devise/).
+A common authentication strategy for APIs is token-based authentication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/plataformatec/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives) or this blog post on [Custom authentication methods with Devise](http://blog.plataformatec.com.br/2019/01/custom-authentication-methods-with-devise/).
 
 #### Testing
 API Mode changes the order of the middleware stack, and this can cause problems for `Devise::Test::IntegrationHelpers`. This problem usually surfaces as an ```undefined method `[]=' for nil:NilClass``` error when using integration test helpers, such as `#sign_in`. The solution is simply to reorder the middlewares by adding the following to test.rb:

--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -1,6 +1,6 @@
 ===============================================================================
 
-Some setup is required manually if you haven't yet, depending on your application's configuration:
+Depending on your application's configuration some manual setup may be required:
 
   1. Ensure you have defined default url options in your environments files. Here
      is an example of default_url_options appropriate for a development environment

--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -1,6 +1,6 @@
 ===============================================================================
 
-Some setup you must do manually if you haven't yet:
+Some setup is required manually if you haven't yet, depending on your application's configuration:
 
   1. Ensure you have defined default url options in your environments files. Here
      is an example of default_url_options appropriate for a development environment
@@ -10,10 +10,14 @@ Some setup you must do manually if you haven't yet:
 
      In production, :host should be set to the actual host of your application.
 
+     * Required for all applications. *
+
   2. Ensure you have defined root_url to *something* in your config/routes.rb.
      For example:
 
        root to: "home#index"
+     
+     * Not required for API-only Applications *
 
   3. Ensure you have flash messages in app/views/layouts/application.html.erb.
      For example:
@@ -21,8 +25,12 @@ Some setup you must do manually if you haven't yet:
        <p class="notice"><%= notice %></p>
        <p class="alert"><%= alert %></p>
 
+     * Not required for API-only Applications *
+
   4. You can copy Devise views (for customization) to your app by running:
 
        rails g devise:views
+       
+     * Not required *
 
 ===============================================================================

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -74,7 +74,10 @@ Devise.setup do |config|
   # Tell if authentication through HTTP Auth is enabled. False by default.
   # It can be set to an array that will enable http authentication only for the
   # given strategies, for example, `config.http_authenticatable = [:database]` will
-  # enable it only for database authentication. The supported strategies are:
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
   # :database      = Support basic authentication with authentication key + password
   # config.http_authenticatable = false
 


### PR DESCRIPTION
This is a bit of a knock on PR related to #4947 specifically addressing documentation.

I have been experimenting more and more with rails api-only application leveraging devise this PR attempts to make a solid attempt to stem the documentation issues (or really lack thereof) from creating unnecessary noise as bugs or feature requests.