### PR TITLE
Remove unnecessary braces at token_generator

### DIFF
--- a/lib/devise/token_generator.rb
+++ b/lib/devise/token_generator.rb
@@ -4,7 +4,7 @@ require 'openssl'
 
 module Devise
   class TokenGenerator
-    def initialize(key_generator, digest = "SHA256")
+    def initialize(key_generator, digest = 'SHA256')
       @key_generator = key_generator
       @digest = digest
     end
@@ -19,7 +19,8 @@ module Devise
       loop do
         raw = Devise.friendly_token
         enc = OpenSSL::HMAC.hexdigest(@digest, key, raw)
-        break [raw, enc] unless klass.to_adapter.find_first({ column => enc })
+
+        break [raw, enc] unless klass.to_adapter.find_first(column => enc)
       end
     end
 


### PR DESCRIPTION
And include a new blank line to "separate" logic contexts when reading code.

Thanks for the awesome gem! 