### PR TITLE
Add assert to Lockable integration test and Replace mathcer `assert_not` to `refute`

### DIFF
--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -44,7 +44,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     assert_equal "127.0.0.1", user.last_sign_in_ip
   end
 
-  test "current remote ip returns original ip behind a non transparent proxy" do
+  test "current and last sign in remote ip returns original ip behind a non transparent proxy" do
     user = create_user
 
     arbitrary_ip = '200.121.1.69'
@@ -53,6 +53,7 @@ class TrackableHooksTest < Devise::IntegrationTest
     end
     user.reload
     assert_equal arbitrary_ip, user.current_sign_in_ip
+    assert_equal arbitrary_ip, user.last_sign_in_ip
   end
 
   test "increase sign in count" do


### PR DESCRIPTION
This PR changed the below.
 - Add assert case to integration test of Lockable
 - Replace mathcer **assert_not** to **refute** in model test of Trackable
 
### Integration test of Lockable
 I added a below test case to `test/integration/trackable_test.rb#47`.
 Add line for check last_sign_in_ip value.
```ruby
assert_equal arbitrary_ip, user.last_sign_in_ip
```
This is because `assert_equal arbitrary_ip, user.current_sign_in_ip` 's test is exist but the above case I added was not in this test file. 
 
### Model test of Trackable
Replace mathcer **assert_not** to **refute**.
**assert_not** matcher is only used in `test/models/trackable_test.rb#49-50` and `test/models/trackable_test.rb#60` . However other testcases use **refute** so I replaced it.