### PR TITLE
Fix two deprecated usages of keyword arguments.

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -184,7 +184,7 @@ MESSAGE
     options[:default] = Array(options[:default]).unshift(kind.to_sym)
     options[:resource_name] = resource_name
     options = devise_i18n_options(options)
-    I18n.t("#{options[:resource_name]}.#{kind}", options)
+    I18n.t("#{options[:resource_name]}.#{kind}", **options)
   end
 
   # Controllers inheriting DeviseController are advised to override this

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -107,7 +107,7 @@ module Devise
         options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
         options = i18n_options(options)
 
-        I18n.t(:"#{scope}.#{message}", options)
+        I18n.t(:"#{scope}.#{message}", **options)
       else
         message.to_s
       end


### PR DESCRIPTION
This prevents us from using behavior that was deprecated in Ruby 2.7.

I was getting these lines in my test suite with Ruby 2.7, this change fixes them:
```
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/devise-4.7.1/lib/devise/failure_app.rb:110: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `t' is defined here
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/devise-4.7.1/app/controllers/devise_controller.rb:187: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/connorshea/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/i18n-1.7.0/lib/i18n.rb:179: warning: The called method `t' is defined here
```

See also:
- https://github.com/ruby-i18n/i18n/pull/501
- https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Thanks :)