### PR TITLE
add support for multiple omniauthable models

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -441,7 +441,9 @@ ERROR
         end
         path_prefix = Devise.omniauth_path_prefix || "/#{mapping.fullpath}/auth".squeeze("/")
 
-        set_omniauth_path_prefix!(path_prefix)
+        unless mapping.to.omniauth_providers.all? { |provider| Devise.omniauth_configs[provider].options[:path_prefix].present? }
+          set_omniauth_path_prefix!(path_prefix)
+        end
 
         mapping.to.omniauth_providers.each do |provider|
           match "#{path_prefix}/#{provider}",
@@ -489,7 +491,8 @@ ERROR
         if ::OmniAuth.config.path_prefix && ::OmniAuth.config.path_prefix != path_prefix
           raise "Wrong OmniAuth configuration. If you are getting this exception, it means that either:\n\n" \
             "1) You are manually setting OmniAuth.config.path_prefix and it doesn't match the Devise one\n" \
-            "2) You are setting :omniauthable in more than one model\n" \
+            "2) You are setting :omniauthable in more than one model, but you did not specify custom path_prefix " \
+            "when you registered provider for this model in config/initializers/devise.rb\n" \
             "3) You changed your Devise routes/OmniAuth setting and haven't restarted your server"
         else
           ::OmniAuth.config.path_prefix = path_prefix


### PR DESCRIPTION
AFAIK `devise` doesn't support omniauthable for multiple models because long time ago `omniauth` did not support custom path_prefix for each strategy. But according to [this comment from @josevalim](https://github.com/plataformatec/devise/issues/1047#issuecomment-1101655) omniauth solved that issue at least 9 years ago.

I implemented a sample rails application that shows how omniauthable can be used for multiple devise models. 
main commit of that app: https://github.com/john-denisov/showcase-multiple-omniauthable-models/commit/7b1f2371fabbc6cc8b78215739c6309f7d7f788f
installation instructions: https://github.com/john-denisov/showcase-multiple-omniauthable-models/blob/master/README.md
I followed [this guide](https://github.com/plataformatec/devise/wiki/OmniAuth:-Overview) to implement omniauth sign in for users and managers in my demo app

I will also update https://github.com/plataformatec/devise/wiki/OmniAuth-with-multiple-models if this PR gets approved 

Will appreciate any ideas how to improve this feature. Theoretically we can automatically duplicate all registered providers and set correct `path_prefix` for them if `devise :omniauthable` is specified in more than 1 model. That will reduce amount of configuration required but it won't allow to have separate sets of providers for different models 🤔 