### PR TITLE
Passkeys support: Rename Devise::Strategies::Authenticatable => PasswordAuthenticatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pkg
 log
 test/tmp/*
 gemfiles/*.lock
+.DS_Store

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -40,6 +40,7 @@ module Devise
   module Strategies
     autoload :Base,            'devise/strategies/base'
     autoload :PasswordAuthenticatable, 'devise/strategies/password_authenticatable'
+    autoload :Authenticatable, 'devise/strategies/authenticatable'
   end
 
   module Test

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -39,7 +39,7 @@ module Devise
 
   module Strategies
     autoload :Base,            'devise/strategies/base'
-    autoload :Authenticatable, 'devise/strategies/authenticatable'
+    autoload :PasswordAuthenticatable, 'devise/strategies/password_authenticatable'
   end
 
   module Test

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'devise/strategies/database_authenticatable'
+require 'devise/strategies/database_password_authenticatable'
 
 module Devise
   module Models

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'devise/strategies/rememberable'
+require 'devise/strategies/password_rememberable'
 require 'devise/hooks/rememberable'
 require 'devise/hooks/forgetable'
 

--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/password_authenticatable'
+
+module Devise
+  module Strategies
+    class Authenticatable < PasswordAuthenticatable
+      ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+      [Devise] `Devise::Strategies::Authenticatable` is deprecated and will be
+      removed in the next major version.
+      Use `Devise::Strategies::PasswordAuthenticatable` instead.
+      DEPRECATION
+    end
+  end
+end

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'devise/strategies/authenticatable'
+require 'devise/strategies/password_authenticatable'
 
 module Devise
   module Strategies
     # Default strategy for signing in a user, based on their email and password in the database.
-    class DatabaseAuthenticatable < Authenticatable
+    class DatabaseAuthenticatable < PasswordAuthenticatable
       def authenticate!
         resource  = password.present? && mapping.to.find_for_database_authentication(authentication_hash)
         hashed = false

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/database_password_authenticatable'
+
+module Devise
+  module Strategies
+    class DatabaseAuthenticatable < DatabasePasswordAuthenticatable
+      ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+      [Devise] `Devise::Strategies::DatabaseAuthenticatable` is deprecated and will be
+      removed in the next major version.
+      Use `Devise::Strategies::DatabasePasswordAuthenticatable` instead.
+      DEPRECATION
+    end
+  end
+end

--- a/lib/devise/strategies/database_password_authenticatable.rb
+++ b/lib/devise/strategies/database_password_authenticatable.rb
@@ -5,7 +5,7 @@ require 'devise/strategies/password_authenticatable'
 module Devise
   module Strategies
     # Default strategy for signing in a user, based on their email and password in the database.
-    class DatabaseAuthenticatable < PasswordAuthenticatable
+    class DatabasePasswordAuthenticatable < PasswordAuthenticatable
       def authenticate!
         resource  = password.present? && mapping.to.find_for_database_authentication(authentication_hash)
         hashed = false
@@ -28,4 +28,4 @@ module Devise
   end
 end
 
-Warden::Strategies.add(:database_authenticatable, Devise::Strategies::DatabaseAuthenticatable)
+Warden::Strategies.add(:database_authenticatable, Devise::Strategies::DatabasePasswordAuthenticatable)

--- a/lib/devise/strategies/password_authenticatable.rb
+++ b/lib/devise/strategies/password_authenticatable.rb
@@ -7,7 +7,7 @@ module Devise
     # This strategy should be used as basis for authentication strategies. It retrieves
     # parameters both from params or from http authorization headers. See database_authenticatable
     # for an example.
-    class Authenticatable < Base
+    class PasswordAuthenticatable < Base
       attr_accessor :authentication_hash, :authentication_type, :password
 
       def store?

--- a/lib/devise/strategies/password_rememberable.rb
+++ b/lib/devise/strategies/password_rememberable.rb
@@ -8,7 +8,7 @@ module Devise
     # to verify whether there is a cookie with the remember token, and to
     # recreate the user from this cookie if it exists. Must be called *before*
     # authenticatable.
-    class Rememberable < PasswordAuthenticatable
+    class PasswordRememberable < PasswordAuthenticatable
       # A valid strategy for rememberable needs a remember token in the cookies.
       def valid?
         @remember_cookie = nil
@@ -64,4 +64,4 @@ module Devise
   end
 end
 
-Warden::Strategies.add(:rememberable, Devise::Strategies::Rememberable)
+Warden::Strategies.add(:rememberable, Devise::Strategies::PasswordRememberable)

--- a/lib/devise/strategies/rememberable.rb
+++ b/lib/devise/strategies/rememberable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'devise/strategies/authenticatable'
+require 'devise/strategies/password_authenticatable'
 
 module Devise
   module Strategies
@@ -8,7 +8,7 @@ module Devise
     # to verify whether there is a cookie with the remember token, and to
     # recreate the user from this cookie if it exists. Must be called *before*
     # authenticatable.
-    class Rememberable < Authenticatable
+    class Rememberable < PasswordAuthenticatable
       # A valid strategy for rememberable needs a remember token in the cookies.
       def valid?
         @remember_cookie = nil

--- a/lib/devise/strategies/rememberable.rb
+++ b/lib/devise/strategies/rememberable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/password_rememberable'
+
+module Devise
+  module Strategies
+    class Rememberable < PasswordRememberable
+      ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+      [Devise] `Devise::Strategies::Rememberable` is deprecated and will be
+      removed in the next major version.
+      Use `Devise::Strategies::PasswordRememberable` instead.
+      DEPRECATION
+    end
+  end
+end


### PR DESCRIPTION
Rename Devise::Strategies::Authenticatable => PasswordAuthenticatable
* To begin the process of refactoring Devise to support passkeys (https://github.com/heartcombo/devise/issues/5527), we need to decouple authentication from being specifically tied to passwords.
	* The first step is explicitly prefixing generically-named components like `Authenticatable` with `Password`, since they concern password authentication

Add Devise::Strategies::Authenticatable shim w/ deprecation warning
* To maintain compatability with exisiting installations, we need the `Devise::Strategies::Authenticatable` class.
	* This re-adds the class in, subclassing from `PasswordAuthenticable` and printing a deprecation warning