### PR TITLE
Edited the email regex in config/initializers to remove a multiline a…

### DIFF
--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -99,7 +99,7 @@ Devise.setup do |config|
   # config.password_length = 8..72
 
   # Regex to use to validate the email address
-  # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+  # config.email_regexp = /\A([\w.%+-]+)@([\w-]+.)+([\w]{2,})\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
Environment
Ruby 3.1.2
Rails 7.0.7
Devise 4.9.4
Current behaviour
I ran into a failing test with Rspec on the valid email check

The original regex here;

config.email_regexp =/^([\w.%+-]+)@([\w-]+.)+([\w]{2,})$/i

was failing on a new line error

Solution
I corrected to

/\A([\w.%+-]+)@([\w-]+.)+([\w]{2,})\z/i

Basically the same but changing the start and end removed the multiline anchors error for me.
OLD uses ^ and $: Matches start/end of any line
NEW uses \A and \z: Matches start/end of entire string