### PR TITLE
Lock Nokogiri version for Webrat monkey-patch

### DIFF
--- a/gemfiles/Gemfile-rails-6-0
+++ b/gemfiles/Gemfile-rails-6-0
@@ -16,6 +16,7 @@ group :test do
   gem "omniauth-openid"
   gem "rexml"
   gem "timecop"
+  gem "nokogiri", "< 1.17.0", require: false
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 2.1", require: false
 end

--- a/gemfiles/Gemfile-rails-6-1
+++ b/gemfiles/Gemfile-rails-6-1
@@ -22,6 +22,7 @@ group :test do
   gem "omniauth-openid"
   gem "rexml"
   gem "timecop"
+  gem "nokogiri", "< 1.17.0", require: false
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 2.1", require: false
 end

--- a/gemfiles/Gemfile-rails-7-0
+++ b/gemfiles/Gemfile-rails-7-0
@@ -18,6 +18,7 @@ group :test do
   gem "omniauth-openid"
   gem "rexml"
   gem "timecop"
+  gem "nokogiri", "< 1.17.0", require: false
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 2.1", require: false
 end

--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -16,6 +16,7 @@ group :test do
   gem "omniauth-openid"
   gem "rexml"
   gem "timecop"
+  gem "nokogiri", "< 1.17.0", require: false
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 2.1", require: false
 end


### PR DESCRIPTION
The monkey-patch ~#2469~ in [test/support/webrat/matchers.rb](https://github.com/heartcombo/devise/blob/main/test/support/webrat/matchers.rb) is not compatible with Nokogiri ≥ 1.17, so many tests are currently failing.

Nokogiri [dropped support for Ruby 2.7 in 1.16](https://github.com/sparklemotion/nokogiri/pull/3040) which is still supported by Devise, so locking Nokogiri to < 1.17 seems like the easiest fix.