### PR TITLE
Allows multiple messages

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,86 @@
+VERSION 0.7
+
+# This allows one to change the running Ruby version with:
+#
+# `earthly --allow-privileged +test --EARTHLY_RUBY_VERSION=2.7`
+ARG --global EARTHLY_RUBY_VERSION=3.3
+ARG --global BUNDLER_VERSION=2.4.5
+
+FROM ruby:$EARTHLY_RUBY_VERSION
+WORKDIR /gem
+
+deps:
+    # No need to keep a single `RUN` here since this target uses `SAVE ARTIFACT`
+    # which means there's no Docker image created here.
+    RUN apt update \
+        && apt install --yes \
+                       --no-install-recommends \
+                       build-essential \
+                       git \
+        && mkdir /gems \
+        && git clone https://github.com/Pharmony/warden.git /gems/warden \
+        && cd /gems/warden \
+        && git checkout features/support-multiple-messages \
+        && gem install bundler:${BUNDLER_VERSION}
+
+    COPY Gemfile /gem/Gemfile
+    COPY Gemfile.lock /gem/Gemfile.lock
+    COPY *.gemspec /gem
+    COPY lib/devise/version.rb /gem/lib/devise/version.rb
+
+    RUN bundle install --jobs $(nproc)
+
+    SAVE ARTIFACT /gems git-gems
+    SAVE ARTIFACT /usr/local/bundle bundler
+    SAVE ARTIFACT /gem/Gemfile Gemfile
+    SAVE ARTIFACT /gem/Gemfile.lock Gemfile.lock
+
+dev:
+    RUN apt update \
+        && apt install --yes \
+                       --no-install-recommends \
+                       git \
+        && gem install bundler:${BUNDLER_VERSION}
+
+    # Import cached gems
+    COPY +deps/git-gems /gems
+    COPY +deps/bundler /usr/local/bundle
+    COPY +deps/Gemfile /gem/Gemfile
+    COPY +deps/Gemfile.lock /gem/Gemfile.lock
+
+    # Import gem files
+    FOR gem_folder IN app config lib test *.gemspec Rakefile
+        COPY $gem_folder /gem/$gem_folder
+    END
+
+    ENTRYPOINT ["bundle", "exec"]
+    CMD ["rake"]
+
+    # Run `earthly +dev` in order to get the Docker image exported to your
+    # Docker images.
+    SAVE IMAGE heartcombo/devise:latest
+
+#
+# This target runs the test suite.
+#
+# On you local machine you would likely use `docker compose run --rm gem`
+# instead, avoiding to refresh the Docker image which takes some seconds.
+#
+# Use the following command in order to run the tests suite:
+# earthly --allow-privileged +test [--TEST_COMMAND="rake test TEST=test/test_foobar.rb"]
+#
+# See the above `EARTHLY_RUBY_VERSION` variable.
+test:
+    FROM earthly/dind:alpine
+
+    COPY docker-compose-earthly.yml ./docker-compose.yml
+
+    # Optionnal argument in the case you'd like to run something else than
+    # `rake test`
+    ARG TEST_COMMAND
+
+    # Creates a temporary Docker image using the output from the +dev target,
+    # that will be used within the `WITH DOCKER ... END` block only.
+    WITH DOCKER --load heartcombo/devise:latest=+dev
+        RUN docker-compose run --rm gem $TEST_COMMAND
+    END

--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,6 @@ end
 # group :mongoid do
 #   gem "mongoid", "~> 4.0.0"
 # end
+
+gem "warden", "~> 1.2.9", github: 'Pharmony/warden',
+                          branch: 'features/support-multiple-messages'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/Pharmony/warden.git
+  revision: baf7b149b5322ac2b2f81cdc94d4e5331ff7ef1c
+  branch: features/support-multiple-messages
+  specs:
+    warden (1.2.9)
+      rack (>= 2.2.3)
+
+GIT
   remote: https://github.com/rails/rails-controller-testing.git
   revision: c203673f8011a7cdc2a8edf995ae6b3eec3417ca
   specs:
@@ -236,8 +244,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     version_gem (1.1.3)
-    warden (1.2.9)
-      rack (>= 2.0.9)
     webrat (0.7.3)
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
@@ -265,6 +271,7 @@ DEPENDENCIES
   rexml
   sqlite3 (~> 1.4)
   timecop
+  warden (~> 1.2.9)!
   webrat (= 0.7.3)
 
 BUNDLED WITH

--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -1,0 +1,7 @@
+# This file is only used by Earthly
+
+name: devise
+
+services:
+  gem:
+    image: heartcombo/devise:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+# This file allows you to use the `docker compose` command in order to run Ruby
+# commands or tests.
+
+name: devise
+
+services:
+  # docker compose run --rm gem [rspec [path to spec file]]
+  gem:
+    image: heartcombo/devise:latest
+    volumes:
+      - $PWD:/gem/

--- a/lib/devise/hooks/activatable.rb
+++ b/lib/devise/hooks/activatable.rb
@@ -7,6 +7,6 @@ Warden::Manager.after_set_user do |record, warden, options|
   if record && record.respond_to?(:active_for_authentication?) && !record.active_for_authentication?
     scope = options[:scope]
     warden.logout(scope)
-    throw :warden, scope: scope, message: record.inactive_message
+    throw :warden, scope: scope, messages: record.inactive_message
   end
 end

--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -25,7 +25,7 @@ Warden::Manager.after_set_user do |record, warden, options|
         record.timedout?(last_request_at) &&
         !proxy.remember_me_is_active?(record)
       Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
-      throw :warden, scope: scope, message: :timeout
+      throw :warden, scope: scope, messages: [:timeout]
     end
 
     unless env['devise.skip_trackable']

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -64,6 +64,9 @@ module Devise
         class_attribute :devise_modules, instance_writer: false
         self.devise_modules ||= []
 
+        class_attribute :devise_messages
+        self.devise_messages = []
+
         before_validation :downcase_keys
         before_validation :strip_whitespace
       end
@@ -80,10 +83,6 @@ module Devise
       # and inactive_message instead.
       def valid_for_authentication?
         block_given? ? yield : true
-      end
-
-      def unauthenticated_message
-        :invalid
       end
 
       def active_for_authentication?
@@ -122,6 +121,10 @@ module Devise
           "#{k}: #{respond_to?(:attribute_for_inspect) ? attribute_for_inspect(k) : v.inspect}"
         end
         "#<#{self.class} #{inspection.join(", ")}>"
+      end
+
+      def reset_devise_messages!
+        self.devise_messages = []
       end
 
       protected

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -142,10 +142,15 @@ module Devise
       # is already confirmed, it should never be blocked. Otherwise we need to
       # calculate if the confirm time has not expired for this user.
       def active_for_authentication?
-        super && (!confirmation_required? || confirmed? || confirmation_period_valid?)
+        valid = super && (!confirmation_required? || confirmed? || confirmation_period_valid?)
+
+        devise_messages << :unconfirmed unless valid
+
+        valid
       end
 
-      # The message to be shown if the account is inactive.
+      # Devise::RegistrationsController uses this method to determine the flash
+      # message to be shown to the user with `signed_up_but_#{inactive_message}`
       def inactive_message
         !confirmed? ? :unconfirmed : super
       end

--- a/lib/devise/strategies/authenticatable.rb
+++ b/lib/devise/strategies/authenticatable.rb
@@ -32,19 +32,18 @@ module Devise
       # given as parameter. Check Devise::Models::Authenticatable.valid_for_authentication?
       # for more information.
       #
-      # In case the resource can't be validated, it will fail with the given
-      # unauthenticated_message.
+      # In case the resource can't be validated, it will fail with collected
+      # devise_messages.
       def validate(resource, &block)
-        result = resource && resource.valid_for_authentication?(&block)
+        result = resource && resource.reset_devise_messages! && resource.valid_for_authentication?(&block)
 
-        if result
-          true
-        else
-          if resource
-            fail!(resource.unauthenticated_message)
-          end
-          false
+        return true if result
+
+        if resource
+          fail!(resource.devise_messages)
         end
+
+        false
       end
 
       # Get values from params and set in the resource.

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -7,7 +7,7 @@ module Devise
     # Default strategy for signing in a user, based on their email and password in the database.
     class DatabaseAuthenticatable < Authenticatable
       def authenticate!
-        resource  = password.present? && mapping.to.find_for_database_authentication(authentication_hash)
+        resource = password.present? && mapping.to.find_for_database_authentication(authentication_hash)
         hashed = false
 
         if validate(resource){ hashed = true; resource.valid_password?(password) }

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -52,7 +52,7 @@ class HttpAuthenticationTest < Devise::IntegrationTest
     sign_in_as_new_user_with_http("unknown")
     assert_equal 401, status
     assert_equal "application/json; charset=utf-8", headers["Content-Type"]
-    assert_match '"error":"Invalid Email or password."', response.body
+    assert_match '"errors":["Invalid Email or password."]', response.body
   end
 
   test 'returns a custom response with www-authenticate and chosen realm' do

--- a/test/test/controller_helpers_test.rb
+++ b/test/test/controller_helpers_test.rb
@@ -9,7 +9,7 @@ class TestControllerHelpersTest < Devise::ControllerTestCase
   test "redirects if attempting to access a page unauthenticated" do
     get :index
     assert_redirected_to new_user_session_path
-    assert_equal "You need to sign in or sign up before continuing.", flash[:alert]
+    assert_equal ['You need to sign in or sign up before continuing.'], flash[:alert]
   end
 
   test "redirects if attempting to access a page with an unconfirmed account" do


### PR DESCRIPTION
So far Devise models are using method overloading, or monkey-patching in order to provide the right flash message to be shown to the user informing about the authentication failure reason.

While this work fine, it's hard to understand and to debug (like in which order are executed the functions?), plus it prevent one little case to work : when you're reaching the lockable `last_attempt`, before your account is locked, you only see one flash message while there _should_ be actually two.

All that was fine and nice until we added our own model (with a hook) to add exponential delay between login failures (quite common security request) showing a flash message with the delay to be waited before retrying a login attempt and being at the lockable `last_attempt` step : a flash message was missing.

This PR update Devise so that:
* it uses [the future feature of warden to manage multiple messages](https://github.com/wardencommunity/warden/pull/216)
* it adapts Models to push messages to the `Models.devise_messages` array
* it passes the `Models.devise_messages`  the warden `fail!` method
* it adapts test suite to expect messages instead of message
* it propose a `Earthfile` to easily run test suite on any platform

## To be done

- [ ] open discussion about this change (Devise team feedback about this change, earthly, would you like some deprecation warnings,..?)
- [ ] discuss [Earthly](https://earthly.dev/) usage locally and/or from Github actions
- [ ] adapt the `inactive_message` case in order to push message to `Models.devise_messages` instead
- [ ] review the lockable test which still assert on the `unauthenticated_message` method
- [x] increase Earthfile `VERSION`