### PR TITLE
Set `attempted_path` in `warden.options` before calling failure app in controller test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* bug fixes
+  * Set `attempted_path` in `warden.options` before calling failure app in controller test helpers. #5768
+
 ### 5.0.4 - 2026-05-08
 
 * security fixes

--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -125,6 +125,7 @@ module Devise
         when :custom
           proxy.custom_response
         else
+          options.merge!(:attempted_path => ::Rack::Request.new(env).fullpath)
           request.env["PATH_INFO"] = "/#{options[:action]}"
           request.env["warden.options"] = options
           Warden::Manager._run_callbacks(:before_failure, env, options)

--- a/test/test/controller_helpers_test.rb
+++ b/test/test/controller_helpers_test.rb
@@ -95,6 +95,19 @@ class TestControllerHelpersTest < Devise::ControllerTestCase
     end
   end
 
+  test "sets attempted_path in warden.options" do
+    custom_failure_app = Class.new(Devise::FailureApp) do
+      def redirect_url
+        attempted_path
+      end
+    end
+
+    swap Devise.warden_config, failure_app: custom_failure_app do
+      get :index
+      assert_redirected_to "/users"
+    end
+  end
+
   test "returns the body of a failure app" do
     get :index
 


### PR DESCRIPTION
In controller tests, the failure app seems to be called directly rather than going through Warden. As such, it duplicates some of the set up Warden does before calling the failure app, however didn't set `attempted_path`, like Warden does. Therefore, if your custom failure app relied on `attempted_path`, it wouldn't be set in your controller tests, leading to different behavior in tests versus production.

This now brings the test helper closer in-line with the Warden implementation.

https://github.com/wardencommunity/warden/blob/67f5ba6baaa7564ec79afef02cf3a4d0f7d312e5/lib/warden/manager.rb#L138-L143

This is similar in nature to #3968, but includes a test, though in my case, my issue wasn't related to `relative_url_root`, so I can't speak to that side of the original issue.