### PR TITLE
Fix validation issue with passwordless users

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -36,7 +36,7 @@ module Devise
 
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
-          validates_length_of       :password, minimum: proc { password_length.min }, maximum: proc { password_length.max }, allow_blank: true
+          validates_length_of       :password, minimum: proc { password_length.min }, maximum: proc { password_length.max }, allow_blank: true, if: -> (x) { x.respond_to?(:password) }
         end
       end
 
@@ -55,7 +55,7 @@ module Devise
       # Passwords are always required if it's a new record, or if the password
       # or confirmation are being set somewhere.
       def password_required?
-        !persisted? || !password.nil? || !password_confirmation.nil?
+        respond_to?(:password) && (!persisted? || !password.nil? || !password_confirmation.nil?)
       end
 
       def email_required?

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -121,4 +121,9 @@ class ValidatableTest < ActiveSupport::TestCase
   test 'required_fields should be an empty array' do
     assert_equal [], Devise::Models::Validatable.required_fields(User)
   end
+
+  test 'should not fail is user has no password' do
+    user = create_user_without_password.reload
+    assert user.valid?
+  end
 end

--- a/test/rails_app/app/active_record/user_without_password.rb
+++ b/test/rails_app/app/active_record/user_without_password.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "shared_user_without_password"
+
+class UserWithoutPassword < ActiveRecord::Base
+  self.table_name = 'users'
+  include Shim
+  include SharedUserWithoutPassword
+end

--- a/test/rails_app/app/mongoid/user_without_password.rb
+++ b/test/rails_app/app/mongoid/user_without_password.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "shared_user_without_email"
+
+class UserWithoutEmail
+  include Mongoid::Document
+  include Shim
+  include SharedUserWithoutEmail
+
+  field :username, type: String
+  field :facebook_token, type: String
+
+  ## Database authenticatable
+  field :email, type: String, default: ""
+  field :encrypted_password, type: String, default: ""
+
+  ## Recoverable
+  field :reset_password_token, type: String
+  field :reset_password_sent_at, type: Time
+
+  ## Rememberable
+  field :remember_created_at, type: Time
+
+  ## Trackable
+  field :sign_in_count, type: Integer, default: 0
+  field :current_sign_in_at, type: Time
+  field :last_sign_in_at, type: Time
+  field :current_sign_in_ip, type: String
+  field :last_sign_in_ip, type: String
+
+  ## Lockable
+  field :failed_attempts, type: Integer, default: 0 # Only if lock strategy is :failed_attempts
+  field :unlock_token, type: String # Only if unlock strategy is :email or :both
+  field :locked_at, type: Time
+end

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -37,6 +37,11 @@ Rails.application.routes.draw do
     router_name: :main_app,
     module: :devise
 
+  devise_for :user_without_password,
+    class_name: 'UserWithoutPassword',
+    router_name: :main_app,
+    module: :devise
+
   as :user do
     get "/as/sign_in", to: "devise/sessions#new"
   end

--- a/test/rails_app/lib/shared_user_without_password.rb
+++ b/test/rails_app/lib/shared_user_without_password.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SharedUserWithoutPassword
+  extend ActiveSupport::Concern
+
+  included do
+    # NOTE: This is missing :database_authenticatable to avoid defining a `password` method.
+    # It is also missing :omniauthable because that adds unnecessary complexity to the setup
+    devise :confirmable, :lockable, :recoverable,
+           :registerable, :rememberable, :timeoutable,
+           :trackable, :validatable,
+           reconfirmable: false
+
+  end
+end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -50,6 +50,10 @@ class ActiveSupport::TestCase
     UserWithoutEmail.create!(valid_attributes(attributes))
   end
 
+  def create_user_without_password(attributes = {})
+    UserWithoutPassword.create!(valid_attributes(attributes).except(:password, :password_confirmation))
+  end
+
   def create_user_with_validations(attributes = {})
     UserWithValidations.create!(valid_attributes(attributes))
   end


### PR DESCRIPTION
Fix validation issue with passwordless users.

This implements the fix suggested by @abevoelker in this comment: https://github.com/heartcombo/devise/issues/5346#issuecomment-822022834.

This fix will help close a longstanding issue in devise-passwordless: https://github.com/devise-passwordless/devise-passwordless/issues/13#issuecomment-2059429976