### PR TITLE
Tell the recipient software when a password link expires.

### DIFF
--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -80,6 +80,16 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
     assert_match user.email, mail.body.encoded
   end
 
+  test 'headers should specify when the link expires' do
+    swap Devise, reset_password_within: 2.days do
+      expires = mail.header_fields.get_field("Expires")
+      assert_present expires
+      sent_at = DateTime.parse(mail.header_fields.get_field("Date").value)
+      validity = DateTime.parse(expires.value) - sent_at
+      assert_equal 2, validity
+    end
+  end
+
   test 'body should have link to confirm the account' do
     host, port = ActionMailer::Base.default_url_options.values_at :host, :port
 


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-mailmaint-expires/

That draft documents the (rare) existing usage of the Expires field, specifies a tighter syntax, and clarifies that "expires" doesn't mean having to delete anything. "Automatically moving the message from inbox to archive" is sensible.

The [IETF mailmaint WG](https://datatracker.ietf.org/wg/mailmaint/about/) requires two implementations before issuing an RFC. I did this one today, to see how hard it would be.

(Or maybe the true reason is: I searched my mail today for a particular domain and and saw several old password reset messages among the top search results. That's junk, those links are expired, let's tell the mailbox indexer when those messages become poor search results.)

It seems reasonable to extend it to cover confirmation messages too.