### PR TITLE
Fix example default value of config.parent_controller in Devise initializer template

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
-  # config.parent_controller = 'DeviseController'
+  # config.parent_controller = 'ApplicationController'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
This PR fixes the commented example default value for `config.parent_controller` in
the Devise initializer template (`config/initializers/devise.rb`).

The previous example set `config.parent_controller` to `DeviseController`, which is
incorrect. The actual default parent controller is `ApplicationController`.

The default value is set here:
https://github.com/heartcombo/devise/blob/cf93de390a29654620fdf7ac07b4794eb95171d0/lib/devise.rb#L240-L244

This setting is used in the code here:
https://github.com/heartcombo/devise/blob/cf93de390a29654620fdf7ac07b4794eb95171d0/app/controllers/devise_controller.rb#L4C1-L4C62