### PR TITLE
Fixed inconsistency between description and example in 'Running tests' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ bin/test test/models/trackable_test.rb
 * Running a specific test given a line number or a regex:
 ```bash
 bin/test test/models/trackable_test.rb:16
-bin/test test/models/trackable_test.rb -n /update.*record/ 
+bin/test test/models/trackable_test.rb -n '/update.*record/'
 ```
 
 ## Starting with Rails?


### PR DESCRIPTION
I corrected the “Running tests” section because there was an inconsistency between the description and the example.