### PR TITLE
Fix password_length for new generated templates and default due to bcrypt gem work

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,4 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      password_too_long_for_bcrypt: "too long (maximum is 72 bytes)"

--- a/devise.gemspec
+++ b/devise.gemspec
@@ -32,4 +32,11 @@ Gem::Specification.new do |s|
   s.add_dependency("bcrypt", "~> 3.0")
   s.add_dependency("railties", ">= 7.0")
   s.add_dependency("responders")
+
+  s.post_install_message = %q{
+[DEVISE] Devise now strictly enforces a 72-byte limit on passwords.
+This prevents a known BCrypt security issue where passwords exceeding 72 bytes are silently truncated, potentially causing hash collisions.
+
+This new validation runs automatically alongside your existing character length checks, specifically targeting passwords with heavy multi-byte characters (like emojis) that might look short but are large in memory.
+  }
 end

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -117,7 +117,7 @@ module Devise
 
   # Range validation for password length
   mattr_accessor :password_length
-  @@password_length = 6..128
+  @@password_length = 6..72 # max 72 bytes for bcrypt
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -180,8 +180,8 @@ Devise.setup do |config|
   # config.rememberable_options = {}
 
   # ==> Configuration for :validatable
-  # Range for password length.
-  config.password_length = 6..128
+  # Range for password length. 72 bytes max for bcrypt
+  config.password_length = 6..72
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -92,6 +92,14 @@ class ValidatableTest < ActiveSupport::TestCase
     assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
   end
 
+  test 'should validate that password cannot be bigger that 72 bytes for bcrypt' do
+    Devise.stubs(:password_length).returns(6..512)
+    password = '🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠🫠'
+    user = new_user(password: password, password_confirmation: password)
+    assert user.invalid?
+    assert_equal 'too long (maximum is 72 bytes)', user.errors[:password].join
+  end
+
   test 'should not require password length when it\'s not changed' do
     user = create_user.reload
     user.password = user.password_confirmation = nil


### PR DESCRIPTION
More info: https://github.com/bcrypt-ruby/bcrypt-ruby/issues/283

Reproduction:

```ruby
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2'
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222333'
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222333234234324'
```

All return true, so

Password 1: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1`
Password 2: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2`

These two users can login to each other's accounts because brcypt caps hashing to the first 72 bytes

not needed, if  https://github.com/heartcombo/devise/pull/5807 merged