### PR TITLE
sha256 password before passing to bcrypt to avoid issues with 72 bytes truncation for passwords

### DIFF
--- a/lib/devise/encryptor.rb
+++ b/lib/devise/encryptor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bcrypt'
+require 'digest'
 
 module Devise
   module Encryptor
@@ -8,17 +9,42 @@ module Devise
       if klass.pepper.present?
         password = "#{password}#{klass.pepper}"
       end
+      # This converts the password (of any length) into a fixed
+      # 64-character hex string, safely under the 72-char limit
+      password = Digest::SHA256.hexdigest(password)
+
+      # BCrypt the pre-hashed string
       ::BCrypt::Password.create(password, cost: klass.stretches).to_s
     end
 
+    # Compares a potential password with a stored hash.
+    #
+    # It attempts the new (SHA-256 -> BCrypt) method first.
+    # If that fails, it falls back to the old (direct BCrypt) method
+    # to support existing passwords that were not pre-hashed
     def self.compare(klass, hashed_password, password)
       return false if hashed_password.blank?
-      bcrypt   = ::BCrypt::Password.new(hashed_password)
+
+      begin
+        bcrypt = ::BCrypt::Password.new(hashed_password)
+      rescue ::BCrypt::Errors::InvalidHash
+        return false
+      end
+
       if klass.pepper.present?
         password = "#{password}#{klass.pepper}"
       end
-      password = ::BCrypt::Engine.hash_secret(password, bcrypt.salt)
-      Devise.secure_compare(password, hashed_password)
+
+      # This is for passwords created with the new `digest` method.
+      pre_hashed_password = Digest::SHA256.hexdigest(password)
+      new_style_hash = ::BCrypt::Engine.hash_secret(pre_hashed_password, bcrypt.salt)
+
+      return true if Devise.secure_compare(new_style_hash, hashed_password)
+
+      # This is for passwords created before this change
+      # We re-run the original logic
+      old_style_hash = ::BCrypt::Engine.hash_secret(password, bcrypt.salt)
+      Devise.secure_compare(old_style_hash, hashed_password)
     end
   end
 end

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'bcrypt'
+
+class EncryptorTest < ActiveSupport::TestCase
+  test 'digest/compare passwords' do
+    hashed_password = Devise::Encryptor.digest(Devise, 'example')
+    assert Devise::Encryptor.compare(Devise, hashed_password, 'example')
+    assert_not Devise::Encryptor.compare(Devise, hashed_password, 'example1')
+  end
+
+  test 'false for incorrect bcrypt string' do
+    assert_not Devise::Encryptor.compare(Devise, 'incorrect_bcrypt_string', 'example')
+  end
+
+  test 'digest/compare support passwords longer 72 bytes' do
+    hashed_password = Devise::Encryptor.digest(Devise, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa123')
+    assert Devise::Encryptor.compare(Devise, hashed_password, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa123')
+    assert_not Devise::Encryptor.compare(Devise, hashed_password, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa125')
+  end
+
+  test 'digest/compare support old bcrypt only passwords' do
+    password = 'example'
+    password_with_pepper = "#{password}#{Devise.pepper}"
+    old_hashed_password = ::BCrypt::Password.create(password_with_pepper, cost: Devise.stretches)
+
+    assert Devise::Encryptor.compare(Devise, old_hashed_password, password)
+    assert_not Devise::Encryptor.compare(Devise, old_hashed_password, 'examplo')
+  end
+end


### PR DESCRIPTION
More info: https://github.com/bcrypt-ruby/bcrypt-ruby/issues/283

Reproduction:

```ruby
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2'
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222333'
BCrypt::Password.new(BCrypt::Password.create('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')) == 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa222333234234324'
```

All return `true`, so

Password 1: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1`
Password 2: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2`

These two users can login to each other's accounts because brcypt caps hashing to the first 72 bytes. 

```ruby
> hash = Devise::Encryptor.digest(Devise, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')
=> "$2a$13$XxwZStO7/NHTDjJsnGQhIOSb8ZO12PTL1/.Lze6OIT.qOAfBrqBHS"
> Devise::Encryptor.compare(Devise, hash, 'password')
=> false
> Devise::Encryptor.compare(Devise, hash, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')
=> true
> Devise::Encryptor.compare(Devise, hash, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2')
=> true
```

As solution - hash password to sha256, so it always will be smaller, than 72 bytes. Added fallback for old passwords.

In this case we can reject https://github.com/heartcombo/devise/pull/5806