### PR TITLE
Drop obsolete Devise::Models::Authenticatable#inspect method

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -115,15 +115,6 @@ module Devise
         super(options)
       end
 
-      # Redefine inspect using serializable_hash, to ensure we don't accidentally
-      # leak passwords into exceptions.
-      def inspect
-        inspection = serializable_hash.collect do |k,v|
-          "#{k}: #{respond_to?(:attribute_for_inspect) ? attribute_for_inspect(k) : v.inspect}"
-        end
-        "#<#{self.class} #{inspection.join(", ")}>"
-      end
-
       protected
 
       def devise_mailer


### PR DESCRIPTION
Rails has handled [parameter filtering](https://api.rubyonrails.org/classes/ActiveSupport/ParameterFilter.html) for a number of years now.  So this PR just follows through on the suggestion made in [this comment](https://github.com/heartcombo/devise/pull/4957#issuecomment-450851530)

Fix #5274

Thank you!
