### PR TITLE
Fix minitest product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ BUNDLE_GEMFILE=gemfiles/Gemfile-rails-8-0 DEVISE_ORM=mongoid bin/test
 ```
 
 ### Running tests
-Devise uses [Mini Test](https://github.com/seattlerb/minitest) as test framework.
+Devise uses [minitest](https://github.com/seattlerb/minitest) as test framework.
 
 * Running all tests:
 ```bash


### PR DESCRIPTION
"Mini Test" was used in heartcombo/devise#5012 but "minitest" is the correct product name.
See also: https://github.com/minitest/minitest/blob/master/README.rdoc#description

> minitest provides a complete suite of testing facilities
> supporting TDD, BDD, and benchmarking.

In this description, "minitest" is used.