### PR TITLE
fix: update generator to use correct grammar for "send password reset" button

### DIFF
--- a/lib/generators/templates/simple_form_for/passwords/new.html.erb
+++ b/lib/generators/templates/simple_form_for/passwords/new.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
+    <%= f.button :submit, "Send me password reset instructions" %>
   </div>
 <% end %>
 


### PR DESCRIPTION
This mirrors #5515