### PR TITLE
Allow model config to override `sign_in_after_change_password`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* enhancements
+  * Allow resource class scopes to override the global configuration for `sign_in_after_change_password` behaviour. [#5824](https://github.com/heartcombo/devise/pull/5824)
+
 ### 5.0.1 - 2026-02-13
 
 * bug fixes

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -163,6 +163,6 @@ class Devise::RegistrationsController < DeviseController
   def sign_in_after_change_password?
     return true if account_update_params[:password].blank?
 
-    Devise.sign_in_after_change_password
+    resource_class.sign_in_after_change_password
   end
 end

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -187,6 +187,22 @@ class RegistrationTest < Devise::IntegrationTest
     end
   end
 
+  test 'a signed in user should not be able to use the website after changing their password if resource_class.sign_in_after_change_password is false' do
+    swap_model_config User, sign_in_after_change_password: false do
+      sign_in_as_user
+      get edit_user_registration_path
+
+      fill_in 'password', with: '1234567890'
+      fill_in 'password confirmation', with: '1234567890'
+      fill_in 'current password', with: '12345678'
+      click_button 'Update'
+
+      assert_contain 'Your account has been updated successfully, but since your password was changed, you need to sign in again.'
+      assert_equal new_user_session_path, @request.path
+      assert_not warden.authenticated?(:user)
+    end
+  end
+
   test 'a signed in user should be able to use the website after changing its email with config.sign_in_after_change_password is false' do
     swap Devise, sign_in_after_change_password: false do
       sign_in_as_user


### PR DESCRIPTION
The config exists at the model/resource class from the registerable module, but it was not being honored, instead we were directly relying on the main Devise config.

Now this can be configured and honored per-model/resource class, as expected.

This is similar to #5429 and `sign_in_after_reset_password` fix.