### PR TITLE
Disable Rails lazy routes with Devise

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -273,14 +273,8 @@ module Devise
   # PRIVATE CONFIGURATION
 
   # Store scopes mappings.
+  mattr_reader :mappings
   @@mappings = {}
-  def self.mappings
-    # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
-    # However, Devise's mappings are built during the routes loading phase.
-    # To ensure it works correctly, we need to load the routes first before accessing @@mappings.
-    Rails.application.try(:reload_routes_unless_loaded)
-    @@mappings
-  end
 
   # OmniAuth configurations.
   mattr_reader :omniauth_configs

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -53,5 +53,14 @@ module Devise
         Rails.autoloaders.main.ignore("#{root}/app/mailers/devise/mailer.rb")
       end
     end
+
+    # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+    # However, Devise's mappings are built during the routes loading phase, so we need to ensure
+    # routes are eagerly loaded by reverting the route set class back to the default.
+    initializer "devise.make_routes_eager_load", after: :make_routes_lazy, before: :add_routing_paths do |app|
+      if app.config.respond_to?(:route_set_class)
+        app.config.route_set_class = ActionDispatch::Routing::RouteSet
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an attempt at an alternative fix for the Rails 8 integration.

Ref.: https://github.com/heartcombo/devise/pull/5728 and https://github.com/rails/rails/commit/cdb283566c5d5251e2f7e663e655e57e8e10abbc

Possibly: closes #5844 and closes #5830