### PR TITLE
Remove dead link to Plataformatec blog from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ config.http_authenticatable = [:database]
 ```
 
 This restriction does not limit you from implementing custom warden strategies, either in your application or via gem-based extensions for devise.
-A common authentication strategy for APIs is token-based authentication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/heartcombo/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives) or this blog post on [Custom authentication methods with Devise](http://blog.plataformatec.com.br/2019/01/custom-authentication-methods-with-devise/).
+A common authentication strategy for APIs is token-based authentication. For more information on extending devise to support this type of authentication and others, see the wiki article for [Simple Token Authentication Examples and alternatives](https://github.com/heartcombo/devise/wiki/How-To:-Simple-Token-Authentication-Example#alternatives).
 
 #### Testing
 API Mode changes the order of the middleware stack, and this can cause problems for `Devise::Test::IntegrationHelpers`. This problem usually surfaces as an ```undefined method `[]=' for nil:NilClass``` error when using integration test helpers, such as `#sign_in`. The solution is simply to reorder the middlewares by adding the following to test.rb:


### PR DESCRIPTION
The link to the Plataformatec blog post "Custom authentication methods with Devise" in the API Mode section returns a 404. The blog has been offline since Plataformatec wound down operations.

This removes the dead link while keeping the wiki article link for Simple Token Authentication, which is still active.
