### PR TITLE
Fix auth key casing for multi-word translated labels

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -114,7 +114,7 @@ module Devise
         human_keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map { |key|
           # TODO: Remove the fallback and just use `downcase_first` once we drop support for Rails 7.0.
           human_key = scope_class.human_attribute_name(key)
-          human_key.respond_to?(:downcase_first) ? human_key.downcase_first : human_key[0].downcase + human_key[1..]
+          human_key.include?(" ") ? human_key.downcase : (human_key.respond_to?(:downcase_first) ? human_key.downcase_first : human_key[0].downcase + human_key[1..])
         }
         options[:authentication_keys] = human_keys.join(I18n.t(:"support.array.words_connector"))
         options = i18n_options(options)

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -201,7 +201,9 @@ class FailureTest < ActiveSupport::TestCase
     end
 
     test 'preserves translation capitalization after auth key replacement' do
-      store_translations :en, activerecord: { attributes: { user: { email: 'Email Address' } } } do
+      store_translations :en,
+        activerecord: { attributes: { user: { email: 'Email Address' } } },
+        mongoid: { attributes: { user: { email: 'Email Address' } } } do
         call_failure('warden' => OpenStruct.new(message: :invalid))
         assert_equal 'Invalid email address or password.', @request.flash[:alert]
       end

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -200,6 +200,13 @@ class FailureTest < ActiveSupport::TestCase
       assert_equal 'Invalid email or password.', @request.flash[:alert]
     end
 
+    test 'preserves translation capitalization after auth key replacement' do
+      store_translations :en, activerecord: { attributes: { user: { email: 'Email Address' } } } do
+        call_failure('warden' => OpenStruct.new(message: :invalid))
+        assert_equal 'Invalid email address or password.', @request.flash[:alert]
+      end
+    end
+
     test 'humanizes the flash message' do
       call_failure('warden' => OpenStruct.new(message: :invalid))
       assert_equal @request.flash[:alert], @request.flash[:alert].humanize


### PR DESCRIPTION
## Summary
Fixes the capitalization regression reported in #5835 when `human_attribute_name` returns a multi-word string (e.g. `"Email Address"`).

Previously this produced:
- `Invalid email Address or password.`

With this change it produces:
- `Invalid email address or password.`

## What changed
- In `Devise::FailureApp#i18n_message`, when building `authentication_keys`:
  - Keep existing behavior for single-word labels (`downcase_first` fallback)
  - Downcase the whole string for multi-word labels (`human_key.include?(" ") ? human_key.downcase : ...`)

This preserves behavior for values like `"E-Mail"` while fixing awkward capitalization for values like `"Email Address"`.

## Tests
Added coverage in `test/failure_app_test.rb`:
- `preserves translation capitalization after auth key replacement`

### Verification run (manual)
I ran the failure app test file locally in a clean Docker Ruby 3.4 environment:

```bash
docker run --rm -v "$PWD":/app -w /app ruby:3.4 bash -lc '
  apt-get update >/dev/null && \
  apt-get install -y --no-install-recommends build-essential git pkg-config libsqlite3-dev >/dev/null && \
  bundle install >/dev/null && \
  bin/test test/failure_app_test.rb
'
```

Result: **45 runs, 91 assertions, 0 failures, 0 errors, 0 skips**.
