### PR TITLE
Don't nilify non-string values in case_insensitive_keys / strip_whitespace_keys

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -205,15 +205,15 @@ module Devise
 
       def apply_to_attribute_or_variable(attr, method)
         if self[attr]
-          self[attr] = self[attr].try(method)
+          self[attr] = self[attr].send(method) if self[attr].respond_to?(method)
 
         # Use respond_to? here to avoid a regression where globally
         # configured strip_whitespace_keys or case_insensitive_keys were
         # attempting to strip or downcase when a model didn't have the
         # globally configured key.
         elsif respond_to?(attr) && respond_to?("#{attr}=")
-          new_value = send(attr).try(method)
-          send("#{attr}=", new_value)
+          value = send(attr)
+          send("#{attr}=", value.send(method)) if value.respond_to?(method)
         end
       end
 

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -70,6 +70,24 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not nilify case_insensitive_keys whose value does not respond to downcase" do
+    swap Devise, case_insensitive_keys: [:email, :sign_in_count] do
+      user = create_user
+      user.sign_in_count = 12
+      user.valid?
+      assert_equal 12, user.sign_in_count
+    end
+  end
+
+  test "does not nilify strip_whitespace_keys whose value does not respond to strip" do
+    swap Devise, strip_whitespace_keys: [:email, :sign_in_count] do
+      user = create_user
+      user.sign_in_count = 12
+      user.valid?
+      assert_equal 12, user.sign_in_count
+    end
+  end
+
   test "param filter should not convert booleans and integer to strings" do
     conditions = { "login" => "foo@bar.com", "bool1" => true, "bool2" => false, "fixnum" => 123, "will_be_converted" => (1..10) }
     conditions = Devise::ParameterFilter.new([], []).filter(conditions)


### PR DESCRIPTION
## What

When a non-string value (e.g. an integer column) is listed in `config.case_insensitive_keys` or `config.strip_whitespace_keys`, the value is silently overwritten with `nil` during `before_validation`.

## Why

`Authenticatable#apply_to_attribute_or_variable` applies `:downcase` / `:strip` via `.try(method)`. `Object#try` returns `nil` when the receiver doesn't respond to the method, and the result is then assigned back to the attribute. So an integer column listed in one of these keys gets nil-ified on every save attempt.

This was reported in #5780, where a typo in the config (`%i[email, site_id]`, which parses to `[:"email,", :site_id]`) caused `:site_id` — an integer column — to end up in the list and silently get reset to `nil`. The misconfiguration is on the user side, but the failure mode is silent data loss rather than a no-op or a clear error, which is what makes it hard to debug (the reporter spent an hour tracing it).

## Fix

Gate the assignment on `respond_to?` so a value that can't handle `:downcase` or `:strip` is left untouched:

```ruby
self[attr] = self[attr].send(method) if self[attr].respond_to?(method)
```

`Devise::ParameterFilter#filtered_hash_by_method_for_given_keys` already takes the same approach on the params side, so this aligns the two paths.

## Tests

Two tests in `test/models/database_authenticatable_test.rb` cover the case where an integer attribute (`sign_in_count`) is included in the keys list — they assert the value is preserved after `valid?` runs the `before_validation :downcase_keys` / `:strip_whitespace` callbacks. Both tests fail on `main` (the integer is replaced with `nil`) and pass with the fix.

Closes #5780.