### PR TITLE
Add 2FA interface for extension gems to hook into

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -37,6 +37,15 @@ class Devise::PasswordsController < DeviseController
     if resource.errors.empty?
       resource.unlock_access! if unlockable?(resource)
       if sign_in_after_reset_password?
+        if resource.respond_to?(:two_factor_enabled?) && resource.two_factor_enabled?
+          session["devise.two_factor.resource_id"] = resource.id
+          session["devise.two_factor.remember_me"] = false
+          default_method = resource.enabled_two_factors.first
+          set_flash_message!(:notice, :updated_two_factor_required)
+          respond_with resource, location: new_two_factor_challenge_path(resource_name, default_method)
+          return
+        end
+
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message!(:notice, flash_message)
         resource.after_database_authentication

--- a/app/controllers/devise/two_factor_controller.rb
+++ b/app/controllers/devise/two_factor_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Devise::TwoFactorController < DeviseController
+  prepend_before_action :require_no_authentication
+  prepend_before_action :set_authenticating_resource
+
+  # Extensions can inject custom actions or override defaults via on_load
+  ActiveSupport.run_load_hooks(:devise_two_factor_controller, self)
+
+  # Auto-generate default new_<method> actions for each registered 2FA module.
+  # Extensions that injected a custom action via on_load won't be overwritten.
+  Devise.two_factor_method_configs.each_key do |mod|
+    define_method(:"new_#{mod}") {} unless method_defined?(:"new_#{mod}")
+  end
+
+  # POST /users/two_factor
+  # All methods POST here. Warden picks the right strategy via valid?.
+  def create
+    self.resource = warden.authenticate!(auth_options)
+    set_flash_message!(:notice, :signed_in, scope: :"devise.sessions")
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    respond_with resource, location: after_sign_in_path_for(resource)
+  end
+
+  protected
+
+  def auth_options
+    default_method = @authenticating_resource.enabled_two_factors.first
+    { scope: resource_name, recall: "#{controller_path}#new_#{default_method}" }
+  end
+
+  def translation_scope
+    'devise.two_factor'
+  end
+
+  private
+
+  def set_authenticating_resource
+    resource_id = session["devise.two_factor.resource_id"]
+    @authenticating_resource = resource_class.where(id: resource_id).first if resource_id
+    return if @authenticating_resource
+
+    set_flash_message!(:alert, :sign_in_not_initiated, scope: :"devise.failure")
+    redirect_to new_session_path(resource_name)
+  end
+end

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -6,6 +6,7 @@ class DeviseController < Devise.parent_controller.constantize
 
   if respond_to?(:helper)
     helper DeviseHelper
+    helper Devise::TwoFactorHelper
   end
 
   if respond_to?(:helper_method)

--- a/app/helpers/devise/two_factor_helper.rb
+++ b/app/helpers/devise/two_factor_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Devise
+  module TwoFactorHelper
+    # Renders the link partials provided by each registered 2FA extension,
+    # excluding the method currently being challenged. Each extension is
+    # expected to ship a `devise/two_factor/<method>_link` partial.
+    def two_factor_method_links(resource, current_method)
+      methods = resource.enabled_two_factors - [current_method]
+      safe_join(methods.map { |method| render "devise/two_factor/#{method}_link" })
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
+      updated_two_factor_required: "Your password has been changed successfully. Please complete two-factor authentication."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       two_factor_session_expired: "Your two-factor authentication session has expired. Please sign in again."
+      sign_in_not_initiated: "Please sign in first."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      two_factor_session_expired: "Your two-factor authentication session has expired. Please sign in again."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -18,6 +18,7 @@ module Devise
   autoload :ParameterSanitizer, 'devise/parameter_sanitizer'
   autoload :TimeInflector,      'devise/time_inflector'
   autoload :TokenGenerator,     'devise/token_generator'
+  autoload :TwoFactor,          'devise/two_factor'
 
   module Controllers
     autoload :Helpers,        'devise/controllers/helpers'
@@ -40,6 +41,7 @@ module Devise
   module Strategies
     autoload :Base,            'devise/strategies/base'
     autoload :Authenticatable, 'devise/strategies/authenticatable'
+    autoload :TwoFactor,       'devise/strategies/two_factor'
   end
 
   module Test
@@ -312,6 +314,14 @@ module Devise
   mattr_accessor :sign_in_after_change_password
   @@sign_in_after_change_password = true
 
+  # Global default for two_factor_methods per-model config.
+  mattr_accessor :two_factor_methods
+  @@two_factor_methods = []
+
+  # Registry of two-factor method configs set via register_two_factor_method.
+  mattr_reader :two_factor_method_configs
+  @@two_factor_method_configs = {}
+
   # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup
@@ -437,6 +447,59 @@ module Devise
     end
 
     Devise::Mapping.add_module module_name
+  end
+
+
+  # Register available devise two factor methods.
+  # Third-party modules that intend to add a 2FA method need to be added explicitly using this method.
+  #
+  # Note that adding a module using this method does not cause it to be used in the authentication
+  # process. That requires the `:two_factor_authenticatable` module to be listed in the arguments passed
+  # to the 'devise' method in the model class definition along with the two factor method name listed under
+  # the `:two_factor_methods` argument passed to the 'devise' method.
+  #
+  # == Options:
+  #
+  #   +name+       - String representing the name of the 2FA method. This will be used to identify it.
+  #   +model+      - String representing the load path to a custom *model* for this 2FA method (to autoload.)
+  #   +strategy+   - Symbol representing if this module got a custom *strategy*.
+  #   +route+      - Generates extension-specific routes and URL helpers (e.g., credential management
+  #                  endpoints). This is separate from the core challenge/create routes that Devise
+  #                  generates automatically from +two_factor_methods+. Accepts true (defaults route
+  #                  name to the method name), a Symbol, or a Hash. Works the same as the +:route+
+  #                  option in +add_module+.
+  #
+  # == Examples:
+  #
+  #   Devise.register_two_factor_method(:my_two_factor_method)
+  #   Devise.register_two_factor_method(:my_two_factor_method, model: 'my_two_factor_method/model')
+  #   Devise.register_two_factor_method(:my_two_factor_method, model: 'my_two_factor_method/model', strategy: :my_two_factor_method, route: true)
+  #
+  def self.register_two_factor_method(name, options = {})
+    options.assert_valid_keys(:model, :strategy, :route)
+
+    two_factor_method_configs[name.to_sym] = options
+
+    STRATEGIES[name.to_sym] = options[:strategy] if options[:strategy]
+
+    if route = options[:route]
+      case route
+      when TrueClass
+        key, value = name, []
+      when Symbol
+        key, value = route, []
+      when Hash
+        key, value = route.keys.first, route.values.flatten
+      else
+        raise ArgumentError, ":route should be true, a Symbol or a Hash"
+      end
+
+      URL_HELPERS[key] ||= []
+      URL_HELPERS[key].concat(value)
+      URL_HELPERS[key].uniq!
+
+      ROUTES[name.to_sym] = key
+    end
   end
 
   # Sets warden configuration using a block that will be invoked on warden

--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -84,7 +84,13 @@ module Devise
     end
 
     def strategies
-      @strategies ||= STRATEGIES.values_at(*self.modules).compact.uniq.reverse
+      @strategies ||= begin
+        keys = self.modules
+        if to.respond_to?(:two_factor_methods) && to.two_factor_methods
+          keys = keys + Array(to.two_factor_methods)
+        end
+        STRATEGIES.values_at(*keys).compact.uniq.reverse
+      end
     end
 
     def no_input_strategies
@@ -92,7 +98,13 @@ module Devise
     end
 
     def routes
-      @routes ||= ROUTES.values_at(*self.modules).compact.uniq
+      @routes ||= begin
+        keys = self.modules
+        if to.respond_to?(:two_factor_methods) && to.two_factor_methods
+          keys = keys + Array(to.two_factor_methods)
+        end
+        ROUTES.values_at(*keys).compact.uniq
+      end
     end
 
     def authenticatable?

--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -120,3 +120,4 @@ module Devise
 end
 
 require 'devise/models/authenticatable'
+require 'devise/models/two_factor_authenticatable'

--- a/lib/devise/models/two_factor_authenticatable.rb
+++ b/lib/devise/models/two_factor_authenticatable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Devise
+  module Models
+    module TwoFactorAuthenticatable
+      extend ActiveSupport::Concern
+
+      def self.required_fields(klass)
+        []
+      end
+
+      module ClassMethods
+        Devise::Models.config(self, :two_factor_methods)
+
+        def two_factor_methods=(methods)
+          @two_factor_methods = methods
+          Array(methods).each do |method_name|
+            config = Devise.two_factor_method_configs[method_name]
+            raise "Unknown two-factor method: #{method_name}. " \
+              "Did you call Devise.register_two_factor_method?" unless config
+            begin
+              require config[:model]
+            rescue LoadError
+              raise unless config[:model].camelize.safe_constantize
+            end
+            mod = config[:model].camelize.constantize
+            include mod
+          end
+        end
+
+        def two_factor_modules
+          Array(two_factor_methods)
+        end
+      end
+
+      def enabled_two_factors
+        self.class.two_factor_modules.select do |method_name|
+          send(:"#{method_name}_two_factor_enabled?")
+        end
+      end
+
+      def two_factor_enabled?
+        enabled_two_factors.any?
+      end
+    end
+  end
+end

--- a/lib/devise/modules.rb
+++ b/lib/devise/modules.rb
@@ -13,6 +13,9 @@ Devise.with_options model: true do |d|
   # Other authentications
   d.add_module :omniauthable, controller: :omniauth_callbacks,  route: :omniauth_callback
 
+  # Two-factor authentication
+  d.add_module :two_factor_authenticatable, controller: :two_factor, route: :two_factor
+
   # Misc after
   routes = [nil, :new, :edit]
   d.add_module :recoverable,  controller: :passwords,     route: { password: routes }

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -37,6 +37,14 @@ module Devise
       end
     end
 
+    initializer "devise.two_factor" do
+      config.after_initialize do
+        if Devise.two_factor_method_configs.any?
+          Devise.include_helpers(Devise::TwoFactor)
+        end
+      end
+    end
+
     initializer "devise.secret_key" do |app|
       Devise.secret_key ||= app.secret_key_base
 

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -398,6 +398,25 @@ module ActionDispatch::Routing
         end
       end
 
+      def devise_two_factor(mapping, controllers) #:nodoc:
+        return unless mapping.to.respond_to?(:two_factor_methods) && mapping.to.two_factor_methods.present?
+
+        controller = controllers[:two_factor] || "devise/two_factor"
+        two_factor_path = mapping.path_names[:two_factor] || "two_factor"
+
+        # Central POST endpoint — all methods submit here
+        post two_factor_path,
+          to: "#{controller}#create",
+          as: "two_factor"
+
+        # Per-method challenge routes
+        Array(mapping.to.two_factor_methods).each do |method_name|
+          get "#{two_factor_path}/#{method_name}/new",
+            to: "#{controller}#new_#{method_name}",
+            as: "new_two_factor_#{method_name}"
+        end
+      end
+
       def devise_registration(mapping, controllers) #:nodoc:
         path_names = {
           new: mapping.path_names[:sign_up],

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -11,9 +11,13 @@ module Devise
         hashed = false
 
         if validate(resource){ hashed = true; resource.valid_password?(password) }
-          remember_me(resource)
-          resource.after_database_authentication
-          success!(resource)
+          if resource.respond_to?(:two_factor_enabled?) && resource.two_factor_enabled?
+            initiate_two_factor_authentication!(resource)
+          else
+            remember_me(resource)
+            resource.after_database_authentication
+            success!(resource)
+          end
         end
 
         # In paranoid mode, hash the password even when a resource doesn't exist for the given authentication key.
@@ -23,6 +27,20 @@ module Devise
         unless resource
           Devise.paranoid ? fail(:invalid) : fail(:not_found_in_database)
         end
+      end
+
+      private
+
+      def initiate_two_factor_authentication!(resource)
+        session["devise.two_factor.resource_id"] = resource.id
+        session["devise.two_factor.remember_me"] = remember_me?
+        default_method = resource.enabled_two_factors.first
+        redirect!(new_two_factor_challenge_path(scope, default_method))
+      end
+
+      def new_two_factor_challenge_path(scope, method)
+        Rails.application.routes.url_helpers
+          .send(:"#{scope}_new_two_factor_#{method}_path")
       end
     end
   end

--- a/lib/devise/strategies/two_factor.rb
+++ b/lib/devise/strategies/two_factor.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'devise/strategies/base'
+
+module Devise
+  module Strategies
+    class TwoFactor < Base
+      def valid?
+        session["devise.two_factor.resource_id"].present?
+      end
+
+      def authenticate!
+        resource = find_pending_resource
+        return fail!(:two_factor_session_expired) unless resource
+        return fail!(resource.unauthenticated_message) unless resource.valid_for_authentication? { true }
+
+        verify_two_factor!(resource)
+
+        unless halted?
+          restore_remember_me(resource)
+          resource.after_database_authentication
+          cleanup_two_factor_session!
+          success!(resource)
+        end
+      end
+
+      # Extensions must override. Should call fail! with a specific
+      # message on failure — this halts execution and triggers recall.
+      def verify_two_factor!(resource)
+        raise NotImplementedError, "#{self.class} must implement #verify_two_factor!"
+      end
+
+      private
+
+      def find_pending_resource
+        return unless session["devise.two_factor.resource_id"]
+        mapping.to.where(id: session["devise.two_factor.resource_id"]).first
+      end
+
+      def restore_remember_me(resource)
+        resource.remember_me = session["devise.two_factor.remember_me"] if resource.respond_to?(:remember_me=)
+      end
+
+      def cleanup_two_factor_session!
+        session.delete("devise.two_factor.resource_id")
+        session.delete("devise.two_factor.remember_me")
+      end
+    end
+  end
+end

--- a/lib/devise/two_factor.rb
+++ b/lib/devise/two_factor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Devise
+  module TwoFactor
+    autoload :UrlHelpers, "devise/two_factor/url_helpers"
+  end
+end

--- a/lib/devise/two_factor/url_helpers.rb
+++ b/lib/devise/two_factor/url_helpers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Devise
+  module TwoFactor
+    module UrlHelpers
+      def new_two_factor_challenge_path(resource_or_scope, method, *args)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        context = _route_context_for(resource_or_scope)
+        context.send(:"#{scope}_new_two_factor_#{method}_path", *args)
+      end
+
+      def new_two_factor_challenge_url(resource_or_scope, method, *args)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        context = _route_context_for(resource_or_scope)
+        context.send(:"#{scope}_new_two_factor_#{method}_url", *args)
+      end
+
+      def two_factor_path(resource_or_scope, *args)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        context = _route_context_for(resource_or_scope)
+        context.send(:"#{scope}_two_factor_path", *args)
+      end
+
+      def two_factor_url(resource_or_scope, *args)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        context = _route_context_for(resource_or_scope)
+        context.send(:"#{scope}_two_factor_url", *args)
+      end
+
+      private
+
+      def _route_context_for(resource_or_scope)
+        scope = Devise::Mapping.find_scope!(resource_or_scope)
+        router_name = Devise.mappings[scope].router_name
+        router_name ? send(router_name) : _devise_route_context
+      end
+    end
+  end
+end

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -86,6 +86,29 @@ class DeviseTest < ActiveSupport::TestCase
     Devise::CONTROLLERS.delete(:kivi)
   end
 
+  test 'register_two_factor_method stores config and populates STRATEGIES' do
+    Devise.register_two_factor_method(:fake_2fa, model: 'devise/models/fake_2fa', strategy: :fake_2fa_strategy)
+    assert_equal({ model: 'devise/models/fake_2fa', strategy: :fake_2fa_strategy }, Devise.two_factor_method_configs[:fake_2fa])
+    assert_equal :fake_2fa_strategy, Devise::STRATEGIES[:fake_2fa]
+    Devise.two_factor_method_configs.delete(:fake_2fa)
+    Devise::STRATEGIES.delete(:fake_2fa)
+  end
+
+  test 'register_two_factor_method with route populates ROUTES and URL_HELPERS' do
+    Devise.register_two_factor_method(:fake_rt, model: 'x', route: { fake_rt: [nil, :new] })
+    assert_equal :fake_rt, Devise::ROUTES[:fake_rt]
+    assert_equal [nil, :new], Devise::URL_HELPERS[:fake_rt]
+    Devise.two_factor_method_configs.delete(:fake_rt)
+    Devise::ROUTES.delete(:fake_rt)
+    Devise::URL_HELPERS.delete(:fake_rt)
+  end
+
+  test 'register_two_factor_method rejects unknown options' do
+    assert_raises(ArgumentError) do
+      Devise.register_two_factor_method(:bad, model: 'x', unknown: true)
+    end
+  end
+
   test 'Devise.secure_compare fails when comparing different strings or nil' do
     [nil, ""].each do |empty|
       assert_not Devise.secure_compare(empty, "something")

--- a/test/helpers/devise/two_factor_helper_test.rb
+++ b/test/helpers/devise/two_factor_helper_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Devise::TwoFactorHelperTest < Devise::IntegrationTest
+  test 'two_factor_method_links returns empty string when no other methods' do
+    resource = mock('resource')
+    resource.stubs(:enabled_two_factors).returns([:test_two_factor])
+
+    helper = Class.new(ActionView::Base) do
+      include Devise::TwoFactorHelper
+    end.new(ActionView::LookupContext.new([]), {}, nil)
+
+    result = helper.two_factor_method_links(resource, :test_two_factor)
+    assert_equal '', result
+  end
+
+  test 'two_factor_method_links renders link partials for other enabled methods' do
+    resource = mock('resource')
+    resource.stubs(:enabled_two_factors).returns([:webauthn, :totp, :backup_codes])
+
+    helper = Class.new(ActionView::Base) do
+      include Devise::TwoFactorHelper
+    end.new(ActionView::LookupContext.new([]), {}, nil)
+
+    helper.stubs(:render).with("devise/two_factor/totp_link").returns('<a href="/totp">Use TOTP</a>'.html_safe)
+    helper.stubs(:render).with("devise/two_factor/backup_codes_link").returns('<a href="/backup">Use backup codes</a>'.html_safe)
+
+    result = helper.two_factor_method_links(resource, :webauthn)
+    assert_includes result, "Use TOTP"
+    assert_includes result, "Use backup codes"
+    assert_not_includes result, "webauthn"
+  end
+end

--- a/test/integration/two_factor_test.rb
+++ b/test/integration/two_factor_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TwoFactorAuthenticationTest < Devise::IntegrationTest
+  test 'sign in redirects to two factor challenge when 2FA is enabled' do
+    user = create_user_with_two_factor(otp_secret: '123456')
+
+    visit new_user_with_two_factor_session_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: '12345678'
+    click_button 'Log In'
+
+    assert_not warden.authenticated?(:user_with_two_factor)
+    assert_equal user.id, session["devise.two_factor.resource_id"]
+  end
+
+  test 'sign in without 2FA enabled proceeds normally' do
+    user = create_user_with_two_factor(otp_secret: nil)
+
+    visit new_user_with_two_factor_session_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: '12345678'
+    click_button 'Log In'
+
+    assert warden.authenticated?(:user_with_two_factor)
+    assert_nil session["devise.two_factor.resource_id"]
+  end
+
+  test 'password reset with 2FA enabled redirects to two factor challenge' do
+    user = create_user_with_two_factor(otp_secret: '123456')
+    raw_token = user.send_reset_password_instructions
+
+    visit edit_user_with_two_factor_password_path(reset_password_token: raw_token)
+    fill_in 'New password', with: 'newpassword123'
+    fill_in 'Confirm new password', with: 'newpassword123'
+    click_button 'Change my password'
+
+    assert_not warden.authenticated?(:user_with_two_factor)
+    assert session["devise.two_factor.resource_id"]
+  end
+
+  test 'password reset without 2FA signs in directly' do
+    user = create_user_with_two_factor(otp_secret: nil)
+    raw_token = user.send_reset_password_instructions
+
+    visit edit_user_with_two_factor_password_path(reset_password_token: raw_token)
+    fill_in 'New password', with: 'newpassword123'
+    fill_in 'Confirm new password', with: 'newpassword123'
+    click_button 'Change my password'
+
+    assert warden.authenticated?(:user_with_two_factor)
+  end
+
+  test 'two-factor routes generate correct paths' do
+    assert_equal '/user_with_two_factors/two_factor/test_otp/new',
+      user_with_two_factor_new_two_factor_test_otp_path
+    assert_equal '/user_with_two_factors/two_factor',
+      user_with_two_factor_two_factor_path
+  end
+
+  test 'full two-factor sign-in: password -> challenge -> OTP -> authenticated' do
+    user = create_user_with_two_factor(otp_secret: '123456')
+
+    # Step 1: Submit password
+    post user_with_two_factor_session_path, params: {
+      user_with_two_factor: { email: user.email, password: '12345678' }
+    }
+
+    # Step 2: Redirected to the default 2FA method's challenge page
+    assert_redirected_to user_with_two_factor_new_two_factor_test_otp_path
+    follow_redirect!
+    assert_response :success
+
+    # Step 3: Submit correct OTP
+    post user_with_two_factor_two_factor_path, params: {
+      otp_attempt: user.otp_secret
+    }
+
+    # Step 4: Authenticated and redirected to after_sign_in_path
+    assert_response :redirect
+    assert warden.authenticated?(:user_with_two_factor)
+  end
+
+  test 'two-factor sign-in with wrong OTP recalls challenge page' do
+    user = create_user_with_two_factor(otp_secret: '123456')
+
+    post user_with_two_factor_session_path, params: {
+      user_with_two_factor: { email: user.email, password: '12345678' }
+    }
+    assert_redirected_to user_with_two_factor_new_two_factor_test_otp_path
+
+    # Submit wrong OTP
+    post user_with_two_factor_two_factor_path, params: {
+      otp_attempt: 'wrong'
+    }
+
+    # Should recall (re-render) the challenge page, not redirect
+    assert_response :success
+    assert_not warden.authenticated?(:user_with_two_factor)
+  end
+
+  test 'two-factor sign-in with expired session does not authenticate' do
+    user = create_user_with_two_factor(otp_secret: '123456')
+
+    post user_with_two_factor_session_path, params: {
+      user_with_two_factor: { email: user.email, password: '12345678' }
+    }
+    assert_redirected_to user_with_two_factor_new_two_factor_test_otp_path
+
+    # Simulate session expiration between password and OTP submission
+    reset!
+
+    post user_with_two_factor_two_factor_path, params: {
+      otp_attempt: user.otp_secret
+    }
+
+    assert_not warden.authenticated?(:user_with_two_factor)
+  end
+
+  test 'visiting two-factor challenge page without sign-in redirects to login' do
+    get user_with_two_factor_new_two_factor_test_otp_path
+
+    assert_redirected_to new_user_with_two_factor_session_path
+    assert_not warden.authenticated?(:user_with_two_factor)
+  end
+
+  private
+
+  def create_user_with_two_factor(attributes = {})
+    UserWithTwoFactor.create!(
+      username: 'usertest',
+      email: generate_unique_email,
+      password: '12345678',
+      password_confirmation: '12345678',
+      **attributes
+    )
+  end
+end

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -9,7 +9,7 @@ class SerializableTest < ActiveSupport::TestCase
 
   test 'should not include unsafe keys on JSON' do
     keys = from_json().keys.select{ |key| !key.include?("id") }
-    assert_equal %w(created_at email facebook_token updated_at username), keys.sort
+    assert_equal %w(created_at email facebook_token otp_secret updated_at username), keys.sort
   end
 
   test 'should not include unsafe keys on JSON even if a new except is provided' do

--- a/test/models/two_factor_authenticatable_test.rb
+++ b/test/models/two_factor_authenticatable_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TwoFactorAuthenticatableTest < ActiveSupport::TestCase
+  test '.two_factor_modules returns the configured two_factor_methods' do
+    assert_equal [:test_otp], UserWithTwoFactor.two_factor_modules
+  end
+
+  test '#two_factor_enabled? returns true when any method reports enabled' do
+    user = new_user_with_two_factor
+    user.stubs(:test_otp_two_factor_enabled?).returns(true)
+    assert user.two_factor_enabled?
+    assert_equal [:test_otp], user.enabled_two_factors
+  end
+
+  test '#two_factor_enabled? returns false when no method reports enabled' do
+    user = new_user_with_two_factor
+    user.stubs(:test_otp_two_factor_enabled?).returns(false)
+    assert_not user.two_factor_enabled?
+    assert_empty user.enabled_two_factors
+  end
+
+  test '.two_factor_methods= raises on unknown method' do
+    klass = Class.new do
+      extend Devise::Models::TwoFactorAuthenticatable::ClassMethods
+    end
+
+    assert_raises(RuntimeError, /Unknown two-factor method/) do
+      klass.two_factor_methods = [:nonexistent]
+    end
+  end
+
+  private
+
+  def new_user_with_two_factor(attributes = {})
+    UserWithTwoFactor.new(valid_attributes(attributes))
+  end
+end

--- a/test/rails_app/app/active_record/user_with_two_factor.rb
+++ b/test/rails_app/app/active_record/user_with_two_factor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'shared_user_with_two_factor'
+
+class UserWithTwoFactor < ActiveRecord::Base
+  self.table_name = 'users'
+  include Shim
+  include SharedUserWithTwoFactor
+end

--- a/test/rails_app/app/mongoid/user_with_two_factor.rb
+++ b/test/rails_app/app/mongoid/user_with_two_factor.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'shared_user_with_two_factor'
+
+class UserWithTwoFactor
+  include Mongoid::Document
+  include Shim
+  include SharedUserWithTwoFactor
+
+  field :username, type: String
+  field :email, type: String, default: ""
+  field :encrypted_password, type: String, default: ""
+  field :otp_secret, type: String
+end

--- a/test/rails_app/app/views/devise/two_factor/new_test_otp.html.erb
+++ b/test/rails_app/app/views/devise/two_factor/new_test_otp.html.erb
@@ -1,0 +1,6 @@
+<h2>Two-Factor Authentication</h2>
+
+<%= form_tag(two_factor_path(resource_name), method: :post) do %>
+  <%= text_field_tag :otp_attempt %>
+  <%= submit_tag "Verify" %>
+<% end %>

--- a/test/rails_app/config/initializers/test_two_factor.rb
+++ b/test/rails_app/config/initializers/test_two_factor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Test-only two-factor method for integration testing.
+# Simulates a real 2FA extension with a simple OTP check.
+
+require 'devise/models/two_factor_authenticatable'
+
+module Devise
+  module Models
+    module TestOtp
+      extend ActiveSupport::Concern
+
+      def test_otp_two_factor_enabled?
+        respond_to?(:otp_secret) && otp_secret.present?
+      end
+    end
+  end
+end
+
+module Devise
+  module Strategies
+    class TestOtp < Devise::Strategies::TwoFactor
+      def valid?
+        super && params[:otp_attempt].present?
+      end
+
+      def verify_two_factor!(resource)
+        unless resource.respond_to?(:otp_secret) && params[:otp_attempt] == resource.otp_secret
+          fail!(:invalid_otp)
+          return
+        end
+      end
+    end
+  end
+end
+
+Warden::Strategies.add(:test_otp, Devise::Strategies::TestOtp)
+
+Devise.register_two_factor_method :test_otp,
+  model: 'devise/models/test_otp',
+  strategy: :test_otp

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
   # Users scope
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
+  devise_for :user_with_two_factors
+
   devise_for :user_on_main_apps,
     class_name: 'UserOnMainApp',
     router_name: :main_app,

--- a/test/rails_app/db/migrate/20260303000000_add_otp_secret_to_users.rb
+++ b/test/rails_app/db/migrate/20260303000000_add_otp_secret_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOtpSecretToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :otp_secret, :string
+  end
+end

--- a/test/rails_app/db/schema.rb
+++ b/test/rails_app/db/schema.rb
@@ -13,7 +13,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20100401102949) do
+ActiveRecord::Schema.define(version: 20260303000000) do
 
   create_table "admins", force: true do |t|
     t.string   "email"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20100401102949) do
     t.integer  "failed_attempts",        default: 0
     t.string   "unlock_token"
     t.datetime "locked_at"
+    t.string   "otp_secret"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/test/rails_app/lib/shared_user_with_two_factor.rb
+++ b/test/rails_app/lib/shared_user_with_two_factor.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SharedUserWithTwoFactor
+  extend ActiveSupport::Concern
+
+  included do
+    devise :database_authenticatable, :registerable, :recoverable,
+           :two_factor_authenticatable, two_factor_methods: [:test_otp]
+
+    validates_uniqueness_of :email, allow_blank: true, if: :devise_will_save_change_to_email?
+  end
+end

--- a/test/strategies/two_factor_test.rb
+++ b/test/strategies/two_factor_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TwoFactorStrategyTest < ActiveSupport::TestCase
+  test 'TwoFactor strategy can be loaded' do
+    assert defined?(Devise::Strategies::TwoFactor)
+  end
+
+  test 'TwoFactor base strategy is not valid without a pending session' do
+    strategy = Devise::Strategies::TwoFactor.new(env_with_session)
+    assert_not strategy.valid?
+  end
+
+  test 'verify_two_factor! raises NotImplementedError by default' do
+    strategy = Devise::Strategies::TwoFactor.new(env_with_session)
+    assert_raises(NotImplementedError) do
+      strategy.verify_two_factor!(Object.new)
+    end
+  end
+
+  private
+
+  def env_with_session(session = {})
+    { 'rack.session' => session }
+  end
+end


### PR DESCRIPTION
### Motivation

Closes #5842.

### How it works

The application opts in by adding `:two_factor_authenticatable` to the model and listing the methods it wants to enable:

```ruby
class User < ApplicationRecord
  devise :database_authenticatable, :two_factor_authenticatable,
         two_factor_methods: [:webauthn]
end
```

Extension gems register themselves via a single API:

```ruby
# In an extension's engine
Warden::Strategies.add(:webauthn_two_factor, Devise::Strategies::WebauthnTwoFactor)

Devise.register_two_factor_method :webauthn,
  model: "devise/models/webauthn_two_factor",
  strategy: :webauthn_two_factor
```

`register_two_factor_method` adds the strategy to Devise's `STRATEGIES` map and stores the model concern path in a registry. When the user model is loaded, `two_factor_methods=` looks each method up in that registry and includes the corresponding model concern – so each extension brings its own model module without needing to be a full Devise module itself.

#### Sign in flow

1. User submits their password. `DatabaseAuthenticatable` validates it as before.
2. If validation succeeds *and* the resource has 2FA enabled (see the conventions below), the strategy stores the resource id and `remember_me` in the session and redirects to the default method's challenge action – instead of calling `success!`.
3. The challenge action lives on `Devise::TwoFactorController`. Devise auto-generates a `new_<method>` action per registered method, which renders the method's challenge view.
4. The user submits the challenge. All methods POST to a single `create` action, and Warden picks the right strategy via each strategy's `valid?`. The base `Devise::Strategies::TwoFactor` then restores `remember_me`, cleans up the session, and signs the user in.
5. If verification fails, the strategy calls `fail!` and Warden recalls back to the challenge action.

`PasswordsController#update` is also intercepted: when a user with 2FA enabled completes a password reset, they're redirected to the 2FA challenge instead of being signed in directly.

Generic URL helpers (`new_two_factor_challenge_path(scope, method)`, `two_factor_path(scope)`) and a `two_factor_method_links` view helper round out the public surface so extensions don't need to share a layout or hardcode route names – they just render their own challenge view and call the helper to render switch links to the user's other enabled methods.

### Conventions

For the pieces above to wire up automatically, extensions follow a small set of naming conventions keyed off the short name passed to `register_two_factor_method` (e.g. `:webauthn`):

- **`<method>_two_factor_enabled?`** – instance method on the model concern. Returns `true` when this user has the method configured (e.g. `webauthn_two_factor_enabled?` returns true when the user has at least one registered credential). Devise uses this to decide whether a user has 2FA on at all, and which methods are currently available for a given user.

  ```ruby
  module Devise::Models::WebauthnTwoFactor
    extend ActiveSupport::Concern

    included do
      has_many :webauthn_credentials
    end

    def webauthn_two_factor_enabled?
      webauthn_credentials.any?
    end
  end
  ```

- **`new_<method>`** – controller action. Auto-generated by Devise as an empty action that renders `new_<method>.html.erb`. Extensions can override it (see "Customizing the challenge action" below). A `set_authenticating_resource` `before_action` exposes the resource being challenged as `@authenticating_resource` for use in challenge views and custom actions.

- **`app/views/devise/two_factor/new_<method>.html.erb`** – challenge view, shipped by the extension gem and resolved through Rails engine view lookup (apps can override by placing a file at the same path).

- **`app/views/devise/two_factor/_<method>_link.html.erb`** – switch-link partial, rendered by the `two_factor_method_links` helper when a user has multiple methods enabled so they can jump to an alternate factor from any challenge page.

### Advanced: customizing the challenge action

Simple methods (e.g. OTP code entry) work out of the box with the auto-generated `new_<method>` action – no extra wiring needed. Methods that require setup logic on every render (e.g. WebAuthn generating a fresh challenge nonce and stashing it in the session) can inject a custom action via an `ActiveSupport.on_load` hook:

```ruby
# In the extension's engine
ActiveSupport.on_load(:devise_two_factor_controller) do
  include Devise::WebauthnTwoFactor::ChallengeAction
end
```

```ruby
module Devise::WebauthnTwoFactor::ChallengeAction
  extend ActiveSupport::Concern

  def new_webauthn
    @challenge_options = WebAuthn::Credential.options_for_get(
      allow: @authenticating_resource.webauthn_credentials.pluck(:external_id)
  )
    session[:webauthn_challenge] = @challenge_options.challenge
    render :new_webauthn
  end
end
```

The auto-generated action is only defined when the extension hasn't already provided one, so the injected method takes precedence.

### Validating the interface

In order to test this, I adapted two real 2FA gems on top of this PR — [`devise-webauthn`](https://github.com/cedarcode/devise-webauthn/compare/29f1d323b5917550779f1c4588969112aee13d73...5cfed8a716c02d) and [`devise-otp`](https://github.com/wmlele/devise-otp/compare/c2b96ed2602f0962b09b4e6a84605f7e4a35806f...618a04cf072846) — and wired them up together in our [demo app for `devise-webauthn`](https://github.com/cedarcode/devise-webauthn-demo-app/compare/2e7d6642a5a18233d...d6b21d7831504387df3705e99c121c90755bda62), so that a single application offers users a choice between WebAuthn and TOTP.

Both gems plug into the new interface via `Devise.register_two_factor_method` without needing to touch `Devise`'s password authentication logic, and the demo app shows them coexisting – the user can pick either factor at the challenge step using the links generated by the `two_factor_method_links` helper.

### What's intentionally out of scope

- Hooks for extension-specific cleanup (e.g. `after_two_factor_verification`)
- Failed-attempt tracking / lockout for 2FA – `Lockable` is untouched, and failed 2FA attempts don't increment `failed_attempts`. Rate limiting for 2FA is better handled at the application or middleware level.
- Re-authentication challenge for sensitive actions.

I hope this lands as a solid foundation that we can build these features on top of.

### A note on the scope of this PR

I'm aware this PR is on the ambitious side for a single change but fell into the "why does every 2FA gem reinvent this?" rabbit hole while building `devise-webauthn`, and had a lot of fun working through what a shared interface might look like – so here we are. Happy to split into smaller PRs if reviewers would prefer that!

### A note on AI tooling

Claude Code was used to generate parts of the implementation. I was deeply involved in the design throughout – every architectural decision is something I worked through and chose deliberately. I've also reviewed and edited the generated code before submitting this PR.