### PR TITLE
Update commented email_regexp example to match the current default

### DIFF
--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -99,7 +99,7 @@ Devise.setup do |config|
   # config.password_length = 8..72
 
   # Regex to use to validate the email address
-  # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
The commented `email_regexp` example in the test app initializer still showed the old `/^...$/i` regex with multiline anchors, which no longer matches the actual default in `lib/devise.rb` or the generator template. This updates the example to the current default `/\A[^@\s]+@[^@\s]+\z/`. Unlike #5723, it syncs the example with the real default rather than patching the old pattern.

Fixes #5721