### PR TITLE
Do not include the query string in PATH_INFO when recalling the original controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### unreleased
+
+* bug fixes
+  * Do not include the query string in `PATH_INFO` when the failure app recalls the original controller. [#5704](https://github.com/heartcombo/devise/issues/5704)
+
 ### 5.0.4 - 2026-05-08
 
 * security fixes

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -57,14 +57,18 @@ module Devise
     end
 
     def recall
+      # Rack does not allow the query string in PATH_INFO, and it is already
+      # available to the recalled action through QUERY_STRING.
+      path_info = attempted_path.to_s.split("?").first
+
       header_info = if relative_url_root?
         base_path = Pathname.new(relative_url_root)
-        full_path = Pathname.new(attempted_path)
+        full_path = Pathname.new(path_info)
 
         { "SCRIPT_NAME" => relative_url_root,
           "PATH_INFO" => '/' + full_path.relative_path_from(base_path).to_s }
       else
-        { "PATH_INFO" => attempted_path }
+        { "PATH_INFO" => path_info }
       end
 
       header_info.each do | var, value|

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -383,6 +383,17 @@ class FailureTest < ActiveSupport::TestCase
       assert_includes @response.third.body, 'Your account is not activated yet.'
     end
 
+    test 'calls the original controller without the query string in PATH_INFO' do
+      env = {
+        "warden.options" => { recall: "devise/sessions#new", attempted_path: "/users/sign_in?redirect_to=/dashboard" },
+        "devise.mapping" => Devise.mappings[:user],
+        "warden" => stub_everything
+      }
+      call_failure(env)
+      assert_includes @response.third.body, '<h2>Log in</h2>'
+      assert_equal '/users/sign_in', @request.env["PATH_INFO"]
+    end
+
     if Rails.application.config.respond_to?(:relative_url_root)
       test 'calls the original controller with the proper environment considering the relative url root' do
         swap Rails.application.config, relative_url_root: "/sample" do
@@ -394,6 +405,20 @@ class FailureTest < ActiveSupport::TestCase
           call_failure(env)
           assert_includes @response.third.body, '<h2>Log in</h2>'
           assert_includes @response.third.body, 'Invalid email or password.'
+          assert_equal '/sample', @request.env["SCRIPT_NAME"]
+          assert_equal '/users/sign_in', @request.env["PATH_INFO"]
+        end
+      end
+
+      test 'calls the original controller without the query string in PATH_INFO considering the relative url root' do
+        swap Rails.application.config, relative_url_root: "/sample" do
+          env = {
+            "warden.options" => { recall: "devise/sessions#new", attempted_path: "/sample/users/sign_in?redirect_to=/dashboard"},
+            "devise.mapping" => Devise.mappings[:user],
+            "warden" => stub_everything
+          }
+          call_failure(env)
+          assert_includes @response.third.body, '<h2>Log in</h2>'
           assert_equal '/sample', @request.env["SCRIPT_NAME"]
           assert_equal '/users/sign_in', @request.env["PATH_INFO"]
         end


### PR DESCRIPTION
Warden sets `attempted_path` to the request's fullpath, including the query string, and the failure app was writing that value verbatim into `PATH_INFO` when recalling the original controller. Per the Rack SPEC, `PATH_INFO` must not contain a query string, and this mismatch causes valid authenticity tokens to be rejected on recall, since Rails takes the path into account when validating them.

This strips the query string before mutating `PATH_INFO`; the query remains available to the recalled action through `QUERY_STRING`.

Fixes #5704